### PR TITLE
chore: web-client version bump

### DIFF
--- a/crates/web-client/package.json
+++ b/crates/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demox-labs/miden-sdk",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Polygon Miden Wasm SDK",
   "collaborators": [
     "Polygon Miden",


### PR DESCRIPTION
Bumping the npm version for the web-client for publishing 