### PR TITLE
fix: cargo machete action version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@main
       - name: machete
-        uses: bnjbvr/cargo-machete@main
+        uses: bnjbvr/cargo-machete@v0.7.1
 
   clippy:
     name: Clippy


### PR DESCRIPTION
This PR downgrades the Github action that ran `cargo machete`. The latest version uses Rust 2024 which wouldn't work on this project.