### PR TITLE
feat: read serialized note details

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ WARNINGS=RUSTDOCFLAGS="-D warnings"
 
 NODE_DIR="miden-node"
 NODE_REPO="https://github.com/0xPolygonMiden/miden-node.git"
-NODE_BRANCH="next"
+NODE_BRANCH="tomasarrachea-optimize-note-storage"
 
 PROVER_DIR="miden-base"
 PROVER_REPO="https://github.com/0xPolygonMiden/miden-base.git"

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ WARNINGS=RUSTDOCFLAGS="-D warnings"
 
 NODE_DIR="miden-node"
 NODE_REPO="https://github.com/0xPolygonMiden/miden-node.git"
-NODE_BRANCH="tomasarrachea-optimize-note-storage"
+NODE_BRANCH="next"
 
 PROVER_DIR="miden-base"
 PROVER_REPO="https://github.com/0xPolygonMiden/miden-base.git"


### PR DESCRIPTION
This PR updates the client to the miden-node https://github.com/0xPolygonMiden/miden-node/pull/790 changes.

The `get_notes_by_id` endpoint was returning the serialized notes in the `details` field, instead of serializing only the details. This PR updates the client to deserialize the details and use that to build the notes.