### PR TITLE
refactor: make `TonicRpcClient` `Send+Sync`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,23 @@
+# Runs docs related jobs.
+# CI job heavily inspired by: https://github.com/tarides/changelog-check-action
+
+name: docs
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+jobs:
+  documented:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 0
+      - name: Check for changes in the docs directory
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          NO_DOCS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'no docs') }}
+        run: ./scripts/check-docs.sh "${{ inputs.docs }}"
+        shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [BREAKING] Updated keystore to accept arbitrarily large public keys (#833).
 * Added Examples to Mdbook for Web Client (#850).
 * Added account code to `miden account --show` command (#835).
+* Make `TonicRpcClient` `Send+Sync` when buiding for `std` (#868).
 
 ## 0.8.2 (TBD)
 

--- a/crates/rust-client/src/mock.rs
+++ b/crates/rust-client/src/mock.rs
@@ -196,7 +196,7 @@ impl MockRpcApi {
     }
 }
 use alloc::boxed::Box;
-#[async_trait(?Send)]
+#[async_trait]
 impl NodeRpcClient for MockRpcApi {
     async fn sync_notes(
         &self,

--- a/crates/rust-client/src/rpc/mod.rs
+++ b/crates/rust-client/src/rpc/mod.rs
@@ -42,7 +42,6 @@
 use alloc::{boxed::Box, collections::BTreeSet, string::String, vec::Vec};
 use core::fmt;
 
-use async_trait::async_trait;
 use domain::{
     account::{AccountDetails, AccountProofs},
     note::{NetworkNote, NoteSyncInfo},
@@ -93,8 +92,9 @@ use crate::{
 /// The implementers are responsible for connecting to the Miden node, handling endpoint
 /// requests/responses, and translating responses into domain objects relevant for each of the
 /// endpoints.
-#[async_trait(?Send)]
-pub trait NodeRpcClient {
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+pub trait NodeRpcClient: Send + Sync {
     /// Given a Proven Transaction, send it to the node for it to be included in a future block
     /// using the `/SubmitProvenTransaction` RPC endpoint.
     async fn submit_proven_transaction(

--- a/crates/rust-client/src/store/sqlite_store/chain_data.rs
+++ b/crates/rust-client/src/store/sqlite_store/chain_data.rs
@@ -16,11 +16,27 @@ use rusqlite::{
 use super::SqliteStore;
 use crate::store::{ChainMmrNodeFilter, StoreError};
 
-type SerializedBlockHeaderData = (u32, Vec<u8>, Vec<u8>, bool);
-type SerializedBlockHeaderParts = (u64, Vec<u8>, Vec<u8>, bool);
+struct SerializedBlockHeaderData {
+    block_num: u32,
+    header: Vec<u8>,
+    chain_mmr_peaks: Vec<u8>,
+    has_client_notes: bool,
+}
+struct SerializedBlockHeaderParts {
+    _block_num: u64,
+    header: Vec<u8>,
+    _chain_mmr: Vec<u8>,
+    has_client_notes: bool,
+}
 
-type SerializedChainMmrNodeData = (i64, String);
-type SerializedChainMmrNodeParts = (u64, String);
+struct SerializedChainMmrNodeData {
+    id: i64,
+    node: String,
+}
+struct SerializedChainMmrNodeParts {
+    id: u64,
+    node: String,
+}
 
 // CHAIN MMR NODE FILTER
 // --------------------------------------------------------------------------------------------
@@ -65,7 +81,11 @@ impl SqliteStore {
 
         conn.prepare(QUERY)?
             .query_map(params![Rc::new(block_number_list)], parse_block_headers_columns)?
-            .map(|result| Ok(result?).and_then(parse_block_header))
+            .map(|result| {
+                Ok(result?).and_then(|serialized_block_header_parts: SerializedBlockHeaderParts| {
+                    parse_block_header(&serialized_block_header_parts)
+                })
+            })
             .collect()
     }
 
@@ -75,7 +95,13 @@ impl SqliteStore {
         const QUERY: &str = "SELECT block_num, header, chain_mmr_peaks, has_client_notes FROM block_headers WHERE has_client_notes=true";
         conn.prepare(QUERY)?
             .query_map(params![], parse_block_headers_columns)?
-            .map(|result| Ok(result?).and_then(parse_block_header).map(|(block, _)| block))
+            .map(|result| {
+                Ok(result?)
+                    .and_then(|serialized_block_header_parts: SerializedBlockHeaderParts| {
+                        parse_block_header(&serialized_block_header_parts)
+                    })
+                    .map(|(block, _)| block)
+            })
             .collect()
     }
 
@@ -96,7 +122,13 @@ impl SqliteStore {
 
         conn.prepare(&filter.to_query())?
             .query_map(params_from_iter(params), parse_chain_mmr_nodes_columns)?
-            .map(|result| Ok(result?).and_then(parse_chain_mmr_nodes))
+            .map(|result| {
+                Ok(result?).and_then(
+                    |serialized_chain_mmr_node_parts: SerializedChainMmrNodeParts| {
+                        parse_chain_mmr_nodes(&serialized_chain_mmr_node_parts)
+                    },
+                )
+            })
             .collect()
     }
 
@@ -154,13 +186,17 @@ impl SqliteStore {
         has_client_notes: bool,
     ) -> Result<(), StoreError> {
         let chain_mmr_peaks = chain_mmr_peaks.peaks().to_vec();
-        let (block_num, header, chain_mmr, has_client_notes) =
-            serialize_block_header(block_header, &chain_mmr_peaks, has_client_notes);
+        let SerializedBlockHeaderData {
+            block_num,
+            header,
+            chain_mmr_peaks,
+            has_client_notes,
+        } = serialize_block_header(block_header, &chain_mmr_peaks, has_client_notes);
         const QUERY: &str = "\
         INSERT OR IGNORE INTO block_headers
             (block_num, header, chain_mmr_peaks, has_client_notes)
         VALUES (?, ?, ?, ?)";
-        tx.execute(QUERY, params![block_num, header, chain_mmr, has_client_notes])?;
+        tx.execute(QUERY, params![block_num, header, chain_mmr_peaks, has_client_notes])?;
 
         set_block_header_has_client_notes(tx, u64::from(block_num), has_client_notes)?;
         Ok(())
@@ -176,7 +212,7 @@ fn insert_chain_mmr_node(
     id: InOrderIndex,
     node: Digest,
 ) -> Result<(), StoreError> {
-    let (id, node) = serialize_chain_mmr_node(id, node);
+    let SerializedChainMmrNodeData { id, node } = serialize_chain_mmr_node(id, node);
     const QUERY: &str = "INSERT OR IGNORE INTO chain_mmr_nodes (id, node) VALUES (?, ?)";
     tx.execute(QUERY, params![id, node])?;
     Ok(())
@@ -197,7 +233,12 @@ fn serialize_block_header(
     let header = block_header.to_bytes();
     let chain_mmr_peaks = chain_mmr_peaks.to_bytes();
 
-    (block_num.as_u32(), header, chain_mmr_peaks, has_client_notes)
+    SerializedBlockHeaderData {
+        block_num: block_num.as_u32(),
+        header,
+        chain_mmr_peaks,
+        has_client_notes,
+    }
 }
 
 fn parse_block_headers_columns(
@@ -208,21 +249,27 @@ fn parse_block_headers_columns(
     let chain_mmr: Vec<u8> = row.get(2)?;
     let has_client_notes: bool = row.get(3)?;
 
-    Ok((u64::from(block_num), header, chain_mmr, has_client_notes))
+    Ok(SerializedBlockHeaderParts {
+        _block_num: u64::from(block_num),
+        header,
+        _chain_mmr: chain_mmr,
+        has_client_notes,
+    })
 }
 
 fn parse_block_header(
-    serialized_block_header_parts: SerializedBlockHeaderParts,
+    serialized_block_header_parts: &SerializedBlockHeaderParts,
 ) -> Result<(BlockHeader, bool), StoreError> {
-    let (_, header, _, has_client_notes) = serialized_block_header_parts;
-
-    Ok((BlockHeader::read_from_bytes(&header)?, has_client_notes))
+    Ok((
+        BlockHeader::read_from_bytes(&serialized_block_header_parts.header)?,
+        serialized_block_header_parts.has_client_notes,
+    ))
 }
 
 fn serialize_chain_mmr_node(id: InOrderIndex, node: Digest) -> SerializedChainMmrNodeData {
     let id = i64::try_from(id.inner()).expect("id is a valid i64");
     let node = node.to_hex();
-    (id, node)
+    SerializedChainMmrNodeData { id, node }
 }
 
 fn parse_chain_mmr_nodes_columns(
@@ -230,18 +277,20 @@ fn parse_chain_mmr_nodes_columns(
 ) -> Result<SerializedChainMmrNodeParts, rusqlite::Error> {
     let id: u64 = row.get(0)?;
     let node = row.get(1)?;
-    Ok((id, node))
+    Ok(SerializedChainMmrNodeParts { id, node })
 }
 
 fn parse_chain_mmr_nodes(
-    serialized_chain_mmr_node_parts: SerializedChainMmrNodeParts,
+    serialized_chain_mmr_node_parts: &SerializedChainMmrNodeParts,
 ) -> Result<(InOrderIndex, Digest), StoreError> {
-    let (id, node) = serialized_chain_mmr_node_parts;
-
     let id = InOrderIndex::new(
-        NonZeroUsize::new(usize::try_from(id).expect("id is u64, should not fail")).unwrap(),
+        NonZeroUsize::new(
+            usize::try_from(serialized_chain_mmr_node_parts.id)
+                .expect("id is u64, should not fail"),
+        )
+        .unwrap(),
     );
-    let node: Digest = Digest::try_from(&node)?;
+    let node: Digest = Digest::try_from(&serialized_chain_mmr_node_parts.node)?;
     Ok((id, node))
 }
 

--- a/crates/rust-client/src/store/web_store/sync/mod.rs
+++ b/crates/rust-client/src/store/web_store/sync/mod.rs
@@ -16,7 +16,7 @@ use wasm_bindgen_futures::JsFuture;
 use super::{
     WebStore,
     account::{lock_account, utils::update_account},
-    chain_data::utils::serialize_chain_mmr_node,
+    chain_data::utils::{SerializedChainMmrNodeData, serialize_chain_mmr_node},
     note::utils::apply_note_updates_tx,
 };
 use crate::{
@@ -141,9 +141,9 @@ impl WebStore {
         let mut serialized_node_ids = Vec::new();
         let mut serialized_nodes = Vec::new();
         for (id, node) in &new_authentication_nodes {
-            let serialized_data = serialize_chain_mmr_node(*id, *node)?;
-            serialized_node_ids.push(serialized_data.id);
-            serialized_nodes.push(serialized_data.node);
+            let SerializedChainMmrNodeData { id, node } = serialize_chain_mmr_node(*id, *node)?;
+            serialized_node_ids.push(id);
+            serialized_nodes.push(node);
         }
 
         // TODO: LOP INTO idxdb_apply_state_sync call

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -uo pipefail
+
+DOCS_DIR="docs/"
+
+if [ "${NO_DOCS_LABEL}" = "true" ]; then
+    # 'no docs' label set, so finish successfully
+    echo "\"no docs\" label has been set"
+    exit 0
+else
+    # a docs check is required
+    # fail if the diff is empty (no changes in docs directory)
+    if git diff --quiet "origin/${BASE_REF}" -- "${DOCS_DIR}"; then
+        >&2 echo "Changes should be accompanied by documentation updates in the \"docs/\" directory.
+This behavior can be overridden by using the \"no docs\" label, which is used for changes
+that don't require documentation updates or are purely maintenance-related."
+        exit 1
+    fi
+
+    echo "The \"docs/\" directory has been updated."
+fi


### PR DESCRIPTION
addresses https://github.com/0xPolygonMiden/miden-client/issues/849#issuecomment-2821710119

The futures generated by the `TonicRpcClient`'s async functions were not Send. The cause was the way we used the `async_trait` crate. When you add `(?Send)` to the attribute, the generated futures [will not implement Send](https://docs.rs/async-trait/latest/async_trait/#non-threadsafe-futures). This meant that we had to remove the `(?Send)` from the `async_trait` definition of `NodeRpcClient`.

There is an additional problem that only appears when using `tonic-web-wasm-client`. The futures generated by the web tonic client code are not `Send`, this meant that the removal of `?Send` generated compilation errors. I couldn't find a way to fix this. The workaround was to add the `?Send` only when building for wasm, this was done with the following lines:

```rust
#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
```

This means that the wasm client's futures won't be Send but maybe this is not a big drawback and can be tackled in the future if needed.