### PR TITLE
refactor: lock account check

### DIFF
--- a/crates/rust-client/src/store/sqlite_store/account.rs
+++ b/crates/rust-client/src/store/sqlite_store/account.rs
@@ -12,7 +12,7 @@ use miden_objects::{
     asset::{Asset, AssetVault},
 };
 use miden_tx::utils::{Deserializable, Serializable};
-use rusqlite::{Connection, Transaction, params, types::Value};
+use rusqlite::{Connection, Transaction, named_params, params, types::Value};
 
 use super::{SqliteStore, column_value_as_u64, u64_to_value};
 use crate::store::{AccountRecord, AccountStatus, StoreError};
@@ -280,9 +280,24 @@ pub(super) fn insert_account_asset_vault(
     Ok(())
 }
 
-pub(super) fn lock_account(tx: &Transaction<'_>, account_id: AccountId) -> Result<(), StoreError> {
-    const QUERY: &str = "UPDATE accounts SET locked = true WHERE id = ?";
-    tx.execute(QUERY, params![account_id.to_hex()])?;
+/// Checks if the mismatched digest belongs to a previous account state (stale data), if not, it
+/// locks the account.
+pub(super) fn check_account_mismatch(
+    tx: &Transaction<'_>,
+    account_id: &AccountId,
+    mismatched_digest: &Digest,
+) -> Result<(), StoreError> {
+    // Mismatched digests may be due to stale network data. If the mismatched digest is
+    // tracked in the db and corresponds to the mismatched account, it means we
+    // got a past update and shouldn't lock the account.
+    const QUERY: &str = "UPDATE accounts SET locked = true WHERE id = :account_id AND NOT EXISTS (SELECT 1 FROM accounts WHERE id = :account_id AND account_commitment = :digest)";
+    tx.execute(
+        QUERY,
+        named_params! {
+            ":account_id": account_id.to_hex(),
+            ":digest": mismatched_digest.to_string()
+        },
+    )?;
     Ok(())
 }
 

--- a/crates/rust-client/src/store/sqlite_store/account.rs
+++ b/crates/rust-client/src/store/sqlite_store/account.rs
@@ -280,9 +280,9 @@ pub(super) fn insert_account_asset_vault(
     Ok(())
 }
 
-/// Checks if the mismatched digest belongs to a previous account state (stale data), if not, it
-/// locks the account.
-pub(super) fn check_account_mismatch(
+/// Locks the account if the mismatched digest doesn't belong to a previous account state (stale
+/// data).
+pub(super) fn lock_account_on_unexpected_commitment(
     tx: &Transaction<'_>,
     account_id: &AccountId,
     mismatched_digest: &Digest,

--- a/crates/rust-client/src/store/sqlite_store/sync.rs
+++ b/crates/rust-client/src/store/sqlite_store/sync.rs
@@ -11,7 +11,7 @@ use crate::{
     store::{
         StoreError, TransactionFilter,
         sqlite_store::{
-            account::{check_account_mismatch, update_account},
+            account::{lock_account_on_unexpected_commitment, update_account},
             note::apply_note_updates_tx,
         },
     },
@@ -188,7 +188,7 @@ impl SqliteStore {
         }
 
         for (account_id, digest) in account_updates.mismatched_private_accounts() {
-            check_account_mismatch(&tx, account_id, digest)?;
+            lock_account_on_unexpected_commitment(&tx, account_id, digest)?;
         }
 
         // Commit the updates

--- a/crates/rust-client/src/store/web_store/account/mod.rs
+++ b/crates/rust-client/src/store/web_store/account/mod.rs
@@ -326,9 +326,9 @@ impl WebStore {
         Ok(())
     }
 
-    /// Checks if the mismatched digest belongs to a previous account state (stale data), if not, it
-    /// locks the account.
-    pub(crate) async fn check_account_mismatch(
+    /// Locks the account if the mismatched digest doesn't belong to a previous account state (stale
+    /// data).
+    pub(crate) async fn lock_account_on_unexpected_commitment(
         &self,
         account_id: &AccountId,
         mismatched_digest: &Digest,

--- a/crates/rust-client/src/store/web_store/account/mod.rs
+++ b/crates/rust-client/src/store/web_store/account/mod.rs
@@ -11,7 +11,6 @@ use miden_objects::{
 };
 use miden_tx::utils::{Deserializable, Serializable};
 use serde_wasm_bindgen::from_value;
-use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::JsFuture;
 
 use super::WebStore;
@@ -326,12 +325,29 @@ impl WebStore {
 
         Ok(())
     }
-}
 
-pub async fn lock_account(account_id: &AccountId) -> Result<(), JsValue> {
-    let account_id_str = account_id.to_string();
-    let promise = idxdb_lock_account(account_id_str);
-    JsFuture::from(promise).await?;
+    /// Checks if the mismatched digest belongs to a previous account state (stale data), if not, it
+    /// locks the account.
+    pub(crate) async fn check_account_mismatch(
+        &self,
+        account_id: &AccountId,
+        mismatched_digest: &Digest,
+    ) -> Result<(), StoreError> {
+        // Mismatched digests may be due to stale network data. If the mismatched digest is
+        // tracked in the db and corresponds to the mismatched account, it means we
+        // got a past update and shouldn't lock the account.
+        if let Some(account) = self.get_account_header_by_commitment(*mismatched_digest).await? {
+            if account.id() == *account_id {
+                return Ok(());
+            }
+        }
 
-    Ok(())
+        let account_id_str = account_id.to_string();
+        let promise = idxdb_lock_account(account_id_str);
+        JsFuture::from(promise).await.map_err(|js_error| {
+            StoreError::DatabaseError(format!("failed to lock account: {js_error:?}",))
+        })?;
+
+        Ok(())
+    }
 }

--- a/crates/rust-client/src/store/web_store/sync/mod.rs
+++ b/crates/rust-client/src/store/web_store/sync/mod.rs
@@ -199,9 +199,11 @@ impl WebStore {
         }
 
         for (account_id, digest) in account_updates.mismatched_private_accounts() {
-            self.check_account_mismatch(account_id, digest).await.map_err(|err| {
-                StoreError::DatabaseError(format!("failed to check account mismatch: {err:?}"))
-            })?;
+            self.lock_account_on_unexpected_commitment(account_id, digest).await.map_err(
+                |err| {
+                    StoreError::DatabaseError(format!("failed to check account mismatch: {err:?}"))
+                },
+            )?;
         }
 
         let account_states_to_rollback = self


### PR DESCRIPTION
This PR addresses the final point in #663 by moving the account commitment missmatch check to the inside of the lock functions.