### PR TITLE
feat: Make the maximum block delta customizable from the client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Added account code to `miden account --show` command (#835).
 * Changed exec's input file format to TOML instead of JSON (#870).
 * [BREAKING] Client's methods renamed after `PartialMmr` change to `PartialBlockchain` (#894).
+* Made the maximum number of blocks the client can be behind the network customizable (#TBD).
 
 ## 0.8.2 (TBD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * Added account code to `miden account --show` command (#835).
 * Changed exec's input file format to TOML instead of JSON (#870).
 * [BREAKING] Client's methods renamed after `PartialMmr` change to `PartialBlockchain` (#894).
-* Made the maximum number of blocks the client can be behind the network customizable (#TBD).
+* Made the maximum number of blocks the client can be behind the network customizable (#895).
 
 ## 0.8.2 (TBD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * Added account code to `miden account --show` command (#835).
 * Changed exec's input file format to TOML instead of JSON (#870).
 * [BREAKING] Client's methods renamed after `PartialMmr` change to `PartialBlockchain` (#894).
-* Made the maximum number of blocks the client can be behind the network customizable (#895).
+* [BREAKING] Made the maximum number of blocks the client can be behind the network customizable (#895).
 
 ## 0.8.2 (TBD)
 

--- a/bin/miden-cli/src/commands/init.rs
+++ b/bin/miden-cli/src/commands/init.rs
@@ -48,6 +48,10 @@ pub struct InitCmd {
     /// If the proving RPC isn't set, the proving mode will be set to local.
     #[clap(long)]
     remote_prover_endpoint: Option<String>,
+
+    /// Maximum number of blocks the client can be behind the network.
+    #[clap(long)]
+    block_delta: Option<u32>,
 }
 
 impl InitCmd {
@@ -80,6 +84,8 @@ impl InitCmd {
             Some(rpc) => CliEndpoint::try_from(rpc.as_str()).ok(),
             None => None,
         };
+
+        cli_config.max_block_number_delta = self.block_delta;
 
         let config_as_toml_string = toml::to_string_pretty(&cli_config).map_err(|err| {
             CliError::Config("failed to serialize config".to_string().into(), err.to_string())

--- a/bin/miden-cli/src/config.rs
+++ b/bin/miden-cli/src/config.rs
@@ -34,6 +34,9 @@ pub struct CliConfig {
     pub remote_prover_endpoint: Option<CliEndpoint>,
     /// Path to the directory from where account component template files will be loaded.
     pub component_template_directory: PathBuf,
+    /// Maximum number of blocks the client can be behind the network for transactions and account
+    /// proofs to be considered valid.
+    pub max_block_number_delta: Option<u32>,
 }
 
 // Make `ClientConfig` a provider itself for composability.
@@ -68,6 +71,7 @@ impl Default for CliConfig {
             token_symbol_map_filepath: Path::new(TOKEN_SYMBOL_MAP_FILEPATH).to_path_buf(),
             remote_prover_endpoint: None,
             component_template_directory: Path::new(DEFAULT_COMPONENT_TEMPLATE_DIR).to_path_buf(),
+            max_block_number_delta: None,
         }
     }
 }

--- a/bin/miden-cli/src/lib.rs
+++ b/bin/miden-cli/src/lib.rs
@@ -123,6 +123,7 @@ impl Cli {
             store as Arc<dyn Store>,
             Arc::new(keystore.clone()),
             in_debug_mode,
+            cli_config.max_block_number_delta,
         );
 
         // Execute CLI command

--- a/bin/miden-cli/src/tests.rs
+++ b/bin/miden-cli/src/tests.rs
@@ -708,6 +708,7 @@ async fn create_rust_client_with_store_path(store_path: &Path) -> (TestClient, C
             store,
             std::sync::Arc::new(keystore.clone()),
             true,
+            None,
         ),
         keystore,
     )

--- a/crates/rust-client/src/builder.rs
+++ b/crates/rust-client/src/builder.rs
@@ -48,6 +48,9 @@ pub struct ClientBuilder {
     keystore: Option<AuthenticatorConfig>,
     /// A flag to enable debug mode.
     in_debug_mode: bool,
+    /// Maximum number of blocks the client can be behind the network for transactions and account
+    /// proofs to be considered valid.
+    max_block_number_delta: Option<u32>,
 }
 
 impl Default for ClientBuilder {
@@ -60,6 +63,7 @@ impl Default for ClientBuilder {
             store_path: "store.sqlite3".to_string(),
             keystore: None,
             in_debug_mode: false,
+            max_block_number_delta: None,
         }
     }
 }
@@ -119,6 +123,14 @@ impl ClientBuilder {
     #[must_use]
     pub fn with_authenticator(mut self, authenticator: Arc<dyn TransactionAuthenticator>) -> Self {
         self.keystore = Some(AuthenticatorConfig::Instance(authenticator));
+        self
+    }
+
+    /// Optionally set a maximum number of blocks that the client can be behind the network.
+    /// By default, there's no maximum.
+    #[must_use]
+    pub fn with_max_block_number_delta(mut self, delta: u32) -> Self {
+        self.max_block_number_delta = Some(delta);
         self
     }
 }
@@ -198,6 +210,13 @@ impl ClientBuilder {
             }
         };
 
-        Ok(Client::new(rpc_api, rng, arc_store, authenticator, self.in_debug_mode))
+        Ok(Client::new(
+            rpc_api,
+            rng,
+            arc_store,
+            authenticator,
+            self.in_debug_mode,
+            self.max_block_number_delta,
+        ))
     }
 }

--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -76,6 +76,10 @@
 //! let rng = RpoRandomCoin::new(coin_seed.map(Felt::new));
 //! let keystore = FilesystemKeyStore::new("path/to/keys/directory".try_into()?)?;
 //!
+//! // Determine the maximum number of blocks that the client can be behind from the network.
+//! // 256 is simply an example value.
+//! let max_block_number_delta = Some(256);
+//!
 //! // Instantiate the client using a Tonic RPC client
 //! let endpoint = Endpoint::new("https".into(), "localhost".into(), Some(57291));
 //! let client: Client = Client::new(
@@ -84,6 +88,7 @@
 //!     store,
 //!     Arc::new(keystore),
 //!     false, // Set to true for debug mode, if needed.
+//!     max_block_number_delta,
 //! );
 //!
 //! # Ok(())
@@ -226,6 +231,9 @@ pub struct Client {
     mast_store: Arc<TransactionMastStore>,
     /// Flag to enable the debug mode for scripts compilation and execution.
     in_debug_mode: bool,
+    /// Maximum number of blocks the client can be behind the network for transactions and account
+    /// proofs to be considered valid.
+    max_block_number_delta: Option<u32>,
 }
 
 /// Construction and access methods.
@@ -249,6 +257,8 @@ impl Client {
     /// - `in_debug_mode`: Instantiates the transaction executor (and in turn, its compiler) in
     ///   debug mode, which will enable debug logs for scripts compiled with this mode for easier
     ///   MASM debugging.
+    /// - `max_block_number_delta`: Determines the maximum number of blocks that the client can be
+    ///   behind the network for transactions and account proofs to be considered valid.
     ///
     /// # Errors
     ///
@@ -259,6 +269,7 @@ impl Client {
         store: Arc<dyn Store>,
         authenticator: Arc<dyn TransactionAuthenticator>,
         in_debug_mode: bool,
+        max_block_number_delta: Option<u32>,
     ) -> Self {
         let client_data_store = Arc::new(ClientDataStore::new(store.clone()));
         let mast_store = client_data_store.mast_store();
@@ -279,6 +290,7 @@ impl Client {
             tx_prover,
             tx_executor,
             in_debug_mode,
+            max_block_number_delta,
             mast_store,
         }
     }

--- a/crates/rust-client/src/mock.rs
+++ b/crates/rust-client/src/mock.rs
@@ -351,7 +351,7 @@ pub async fn create_test_client() -> (MockClient, MockRpcApi, FilesystemKeyStore
     let arc_rpc_api = Arc::new(rpc_api.clone());
 
     let client =
-        MockClient::new(arc_rpc_api, Box::new(rng), store, Arc::new(keystore.clone()), true);
+        MockClient::new(arc_rpc_api, Box::new(rng), store, Arc::new(keystore.clone()), true, None);
     (client, rpc_api, keystore)
 }
 

--- a/crates/rust-client/src/sync/block_header.rs
+++ b/crates/rust-client/src/sync/block_header.rs
@@ -15,10 +15,6 @@ use crate::{
     store::{NoteFilter, PartialBlockchainFilter, StoreError},
 };
 
-/// Maximum number of blocks the client can be behind the network for transactions and account
-/// proofs to be considered valid.
-pub(crate) const MAX_BLOCK_NUMBER_DELTA: u32 = 256;
-
 /// Network information management methods.
 impl Client {
     /// Updates committed notes with no MMR data. These could be notes that were

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -78,7 +78,6 @@ use crate::{
 };
 
 mod block_header;
-pub(crate) use block_header::MAX_BLOCK_NUMBER_DELTA;
 use block_header::apply_mmr_changes;
 
 mod tag;

--- a/crates/web-client/src/lib.rs
+++ b/crates/web-client/src/lib.rs
@@ -89,6 +89,7 @@ impl WebClient {
             web_store.clone(),
             Arc::new(keystore.clone()),
             false,
+            None,
         ));
         self.store = Some(web_store);
         self.keystore = Some(keystore);

--- a/docs/src/cli-config.md
+++ b/docs/src/cli-config.md
@@ -18,6 +18,7 @@ default_account_id = "0x012345678"
 token_symbol_map_filepath = "token_symbol_map.toml"
 remote_prover_endpoint = "http://localhost:8080"
 component_template_directory = "./templates"
+max_block_number_delta = 256
 
 [rpc]
 endpoint = { protocol = "http", host = "localhost", port = 57291 }
@@ -107,6 +108,15 @@ value = [
     { name = "ticker", type = "token_symbol", description = "Token symbol of the faucet's asset, limited to 4 characters." }, 
     { value = "0" },
 ]
+```
+
+### Block Delta
+The `max_block_number_delta` is an optional field that is used to configure the maximum number of blocks the client can be behind the network.
+
+If not set, the default behavior is to ignore the block difference between the client and the network. If set, the client will check this difference is within the specified maximum when validating a transaction.
+
+```sh
+miden init --block-delta 256
 ```
 
 ### Environment variables

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -47,6 +47,9 @@ miden init --network https://18.203.155.106:1234
 # You can use the --store_path flag to override the default store config
 miden init --store_path db/store.sqlite3
 
+# You can use the --block-delta flag to set maximum number of blocks the client can be behind
+miden init --block-delta 250
+
 # You can provide both flags
 miden init --network 18.203.155.106 --store_path db/store.sqlite3
 ```

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -74,6 +74,7 @@ pub async fn create_test_client() -> (TestClient, TestClientKeyStore) {
         store,
         Arc::new(keystore.clone()),
         true,
+        None,
     );
 
     client.sync_state().await.unwrap();


### PR DESCRIPTION
This PR makes it possible to customize the number of blocks the client is behind the network.
Before this PR, the maximum number of blocks the client could be behind was hard-coded to be 256 blocks. Now, that difference can be set to any u32 or be ignored entirely.

The following changes were introduced:
- The current default maximum block difference is ignored (that is to say, it is set to `None`)
- `Client` struct:
    - Received a new member `max_block_number_delta: Option<u32>`. This represents the number of blocks the client can be behind from the network in order for transactions and account proofs to be considered valid. If `None`, then the block difference is simply ignored.
    - Its `new()` method now receives one additional argument of type `Option<u32>` used to set `max_block_number_delta`.
- `ClientBuilder` struct:
    - Received a new member `max_block_number_delta: Option<u32>`. Same meaning as above. Used to fulfill `Client`'s constructor.
    - `max_block_number_delta` starts as `None` but can be modified to a different value using the `with_max_block_number_delta(mut self, delta: u32)` method.
- `CliConfig` struct:
    - Received a new member `max_block_number_delta: Option<u32>`. Same meaning as above. Used to fulfill `Client`'s constructor.
- `InitCmd` struct:
    - Now receives an optional flag `--block-delta <num>` that is used to specify the maximum number of blocks the client can be behind. If not passed, then the difference is ignored.
    - Consequently, it now holds an additional member variable `block_delta` to store the value passed via the CLI.

Closes: #795