### PR TITLE
bug: Prevent  from adding to the keystore when import fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Converted Web Client `NoteType` class to `enum` (#831)
 * Exported `import_account_by_id` function to Web Client (#858)
+* Fixed duplicate key bug in `import_account` (#899)
 
 ## 0.8.1 (2025-03-28)
 

--- a/crates/web-client/js/index.js
+++ b/crates/web-client/js/index.js
@@ -117,7 +117,7 @@ export class WebClient {
     this.seed = seed;
 
     // Check if Web Workers are available.
-    if (false) {
+    if (typeof Worker !== "undefined") {
       console.log("WebClient: Web Workers are available.");
       // Create the worker.
       this.worker = new Worker(

--- a/crates/web-client/js/index.js
+++ b/crates/web-client/js/index.js
@@ -117,7 +117,7 @@ export class WebClient {
     this.seed = seed;
 
     // Check if Web Workers are available.
-    if (typeof Worker !== "undefined") {
+    if (false) {
       console.log("WebClient: Web Workers are available.");
       // Create the worker.
       this.worker = new Worker(

--- a/crates/web-client/package.json
+++ b/crates/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demox-labs/miden-sdk",
-  "version": "0.8.2",
+  "version": "0.8.4",
   "description": "Polygon Miden Wasm SDK",
   "collaborators": [
     "Polygon Miden",

--- a/crates/web-client/src/import.rs
+++ b/crates/web-client/src/import.rs
@@ -29,13 +29,10 @@ impl WebClient {
                 .map_err(|err| err.to_string())?;
             let account_id = account_data.account.id().to_string();
 
-            let message = match client
+            client
                 .add_account(&account_data.account, account_data.account_seed, false)
                 .await
-            {
-                Ok(_) => format!("Imported account with ID: {account_id}"),
-                Err(err) => return Err(js_error_with_context(err, "failed to import account")),
-            };
+                .map_err(|err| js_error_with_context(err, "failed to import account"))?;
 
             keystore
                 .expect("KeyStore should be initialized")
@@ -43,7 +40,7 @@ impl WebClient {
                 .await
                 .map_err(|err| err.to_string())?;
 
-            Ok(JsValue::from_str(&message))
+            Ok(JsValue::from_str(&format!("Imported account with ID: {account_id}")))
         } else {
             Err(JsValue::from_str("Client not initialized"))
         }
@@ -63,10 +60,10 @@ impl WebClient {
                 .await?;
 
         let native_id = generated_acct.id();
-        match client.import_account_by_id(native_id).await {
-            Ok(_) => (),
-            Err(err) => return Err(js_error_with_context(err, "failed to import public account")),
-        }
+        client
+            .import_account_by_id(native_id)
+            .await
+            .map_err(|err| js_error_with_context(err, "failed to import public account"))?;
 
         keystore
             .expect("KeyStore should be initialized")

--- a/crates/web-client/src/import.rs
+++ b/crates/web-client/src/import.rs
@@ -29,22 +29,21 @@ impl WebClient {
                 .map_err(|err| err.to_string())?;
             let account_id = account_data.account.id().to_string();
 
+            let message = match client
+                .add_account(&account_data.account, account_data.account_seed, false)
+                .await
+            {
+                Ok(_) => format!("Imported account with ID: {account_id}"),
+                Err(err) => return Err(js_error_with_context(err, "failed to import account")),
+            };
+
             keystore
                 .expect("KeyStore should be initialized")
                 .add_key(&account_data.auth_secret_key)
                 .await
                 .map_err(|err| err.to_string())?;
 
-            match client
-                .add_account(&account_data.account, account_data.account_seed, false)
-                .await
-            {
-                Ok(_) => {
-                    let message = format!("Imported account with ID: {account_id}");
-                    Ok(JsValue::from_str(&message))
-                },
-                Err(err) => Err(js_error_with_context(err, "failed to import account")),
-            }
+            Ok(JsValue::from_str(&message))
         } else {
             Err(JsValue::from_str("Client not initialized"))
         }
@@ -63,17 +62,17 @@ impl WebClient {
             generate_wallet(client, &AccountStorageMode::public(), mutable, Some(init_seed))
                 .await?;
 
+        let native_id = generated_acct.id();
+        match client.import_account_by_id(native_id).await {
+            Ok(_) => (),
+            Err(err) => return Err(js_error_with_context(err, "failed to import public account")),
+        }
+
         keystore
             .expect("KeyStore should be initialized")
             .add_key(&AuthSecretKey::RpoFalcon512(key_pair))
             .await
             .map_err(|err| err.to_string())?;
-
-        let native_id = generated_acct.id();
-        client
-            .import_account_by_id(native_id)
-            .await
-            .map_err(|err| js_error_with_context(err, "failed to import account"))?;
 
         Ok(Account::from(generated_acct))
     }

--- a/crates/web-client/src/new_account.rs
+++ b/crates/web-client/src/new_account.rs
@@ -26,16 +26,18 @@ impl WebClient {
             let (new_account, account_seed, key_pair) =
                 generate_wallet(client, storage_mode, mutable, init_seed).await?;
 
+            match client.add_account(&new_account, Some(account_seed), false).await {
+                Ok(_) => (),
+                Err(err) => {
+                    return Err(js_error_with_context(err, "failed to insert new wallet"));
+                },
+            }
+
             keystore
                 .expect("KeyStore should be initialized")
                 .add_key(&AuthSecretKey::RpoFalcon512(key_pair))
                 .await
                 .map_err(|err| err.to_string())?;
-
-            client
-                .add_account(&new_account, Some(account_seed), false)
-                .await
-                .map_err(|err| js_error_with_context(err, "failed to insert new wallet"))?;
 
             Ok(new_account.into())
         } else {

--- a/crates/web-client/src/new_account.rs
+++ b/crates/web-client/src/new_account.rs
@@ -26,12 +26,10 @@ impl WebClient {
             let (new_account, account_seed, key_pair) =
                 generate_wallet(client, storage_mode, mutable, init_seed).await?;
 
-            match client.add_account(&new_account, Some(account_seed), false).await {
-                Ok(_) => (),
-                Err(err) => {
-                    return Err(js_error_with_context(err, "failed to insert new wallet"));
-                },
-            }
+            client
+                .add_account(&new_account, Some(account_seed), false)
+                .await
+                .map_err(|err| js_error_with_context(err, "failed to insert new wallet"))?;
 
             keystore
                 .expect("KeyStore should be initialized")

--- a/crates/web-client/test/new_account.test.ts
+++ b/crates/web-client/test/new_account.test.ts
@@ -86,7 +86,7 @@ describe("new_wallet tests", () => {
         clientSeed,
         isolatedClient: true,
       })
-    ).to.be.rejectedWith(/storage error: Failed to insert item/);
+    ).to.be.rejectedWith(/failed to insert new wallet/);
   });
 });
 


### PR DESCRIPTION
This PR fixes a bug where users were not able to create new public accounts after importing their account from seed/wallet file. 

When creating a new account for an imported wallet, we first attempt to import an account with the seed to see if one exists. If one does not, we create one. However, we were storing the Falcon keys in the keystore on this import attempt, and thus when we tried to create a new account, the keys were already present in the store. 