### PR TITLE
Improve Web Client Publishing Flow on Next Branch

### DIFF
--- a/.github/workflows/enforce-web-client-version-bump.yml
+++ b/.github/workflows/enforce-web-client-version-bump.yml
@@ -1,0 +1,76 @@
+# This workflow checks if the version number in the `package.json` file of the `web-client` 
+# package has been bumped when there are changes in the `web-client` or `web_store` 
+# directories. If the version number has not been bumped, it fails the workflow with 
+# an error message.
+
+name: Enforce SDK Version Bump
+
+on:
+  pull_request:
+    branches: [ next ]
+    types: [ opened, reopened, synchronize, labeled, unlabeled ]
+
+jobs:
+  enforce-bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out code (full history)
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Gather changed files
+        id: detect
+        # pass the PR base branch into the script
+        run: bash ./scripts/detect-web-client-changes.sh "${{ github.event.pull_request.base.ref }}"
+      
+      # new step: detect a bypass label on the PR
+      - name: Check for bypass label
+        id: skip
+        uses: actions/github-script@v6
+        with:
+          script: |
+            // list all PR labels
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            const bypass = labels.includes('bypass-sdk-version-bump');
+            core.setOutput('bypass', bypass);
+
+      # Only if code changed do we compare versions
+      - name: Fetch base package.json version
+        if: steps.detect.outputs.code_changed == 'true'
+        id: base
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const resp = await github.rest.repos.getContent({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              path:  'crates/web-client/package.json',
+              ref:   context.payload.pull_request.base.ref
+            });
+            const content = Buffer.from(resp.data.content, 'base64').toString();
+            const { version } = JSON.parse(content);
+            core.setOutput('version', version);
+
+      - name: Read head package.json version
+        if: steps.detect.outputs.code_changed == 'true'
+        id: head
+        run: |
+          VER=$(node -p "require('./crates/web-client/package.json').version")
+          echo "version=$VER" >> $GITHUB_OUTPUT
+
+      - name: Fail if version not bumped
+        if: >
+          steps.detect.outputs.code_changed == 'true' &&
+          steps.base.outputs.version == steps.head.outputs.version &&
+          steps.skip.outputs.bypass != 'true'
+        run: |
+          echo "::error ::You modified code under web-client or web_store but did not bump the version in crates/web-client/package.json. Bump the version or add the 'bypass-sdk-version-bump' label to the PR."
+          echo "::error ::Base and head version are both '${{ steps.head.outputs.version }}'."
+          exit 1
+
+      - name: Success
+        run: echo "✅ OK - either no relevant code changes, version was bumped, or bypass label was applied."

--- a/.github/workflows/publish-web-client-next.yml
+++ b/.github/workflows/publish-web-client-next.yml
@@ -1,0 +1,68 @@
+# This workflow publishes the 'web-client' package to npm if the version number in the 
+# 'web-client' package.json file has changed.
+
+name: Publish Web Client SDK to NPM on Next
+
+on:
+  push:
+    branches:
+      - next
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Set up Rust and wasm target
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+          target: wasm32-unknown-unknown
+          components: rust-src 
+
+      - name: Install & build web-client
+        run: |
+          cd crates/web-client
+          yarn install --frozen-lockfile
+          yarn build
+
+      - name: Did version bump?
+        id: check_version
+        run: |
+          # Fetch two commits so we can diff
+          git fetch origin ${{ github.ref }} --depth=2
+
+          # Count if package.json changed
+          CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} \
+            | grep -c '^crates/web-client/package.json$' || true)
+
+          echo "version_changed=$([ "$CHANGED" -gt 0 ] && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - name: Publish to npm
+        if: steps.check_version.outputs.version_changed == 'true'
+        continue-on-error: true
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_WEBCLIENT_TOKEN }}
+        run: |
+          cd crates/web-client
+          npm publish --tag next
+
+      - name: Done
+        run: echo "✅ Build complete; publish only attempted if package.json changed."
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Changed exec's input file format to TOML instead of JSON (#870).
 * [BREAKING] Client's methods renamed after `PartialMmr` change to `PartialBlockchain` (#894).
 * [BREAKING] Made the maximum number of blocks the client can be behind the network customizable (#895).
+* Improve Web Client Publishing Flow on Next Branch (#906).
 
 ## 0.8.2 (TBD)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto-build"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#490903d6b9aa0623e47579160f12b046d5995558"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#9ad7bba92f2857dc213118576a2038fe88ba6800"
 dependencies = [
  "anyhow",
  "prost",

--- a/scripts/detect-web-client-changes.sh
+++ b/scripts/detect-web-client-changes.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# $1 = the base ref (e.g. "next")
+BASE_REF="$1"
+
+# Fetch the base branch so we can diff against it
+git fetch origin "${BASE_REF}" --depth=1
+
+# List changed files between the base SHA and our HEAD
+CHANGED_FILES=$(git diff --name-only origin/"${BASE_REF}"...HEAD)
+
+echo "Changed files:"
+echo "$CHANGED_FILES"
+echo
+
+# Detect our two target directories
+if echo "$CHANGED_FILES" \
+     | grep -E '^crates/web-client/|^crates/rust-client/src/store/web_store/' \
+  >/dev/null; then
+  echo "code_changed=true" >> "$GITHUB_OUTPUT"
+else
+  echo "code_changed=false" >> "$GITHUB_OUTPUT"
+fi


### PR DESCRIPTION
# Summary
This PR adds two github actions that aid in improving the process of publishing the unstable version of the web client SDK to the npm registry. 

- **enforce-web-client-version-bump.yml**: this action runs on opened PRs or commits to those PRs. It checks if there have been changes in the `crates/web-client` or `crates/rust-client/src/store/web_client` folders. If there have been changes, it checks whether the version number in the `crates/web-client/package.json` file has been bumped. If it has been properly bumped or if there are no relevant changes that would merit a bump, the action passes. The action fails when changes are detected in those folders, but the `package.json` version has not been bumped.

- **publish-web-client-next.yml**: this action runs on pushes to the `next` branch. It checks if the version number in `crates/web-client/package.json` has been changed. If it has, then it attempts to publish the package. If it hasn't, it does nothing. The action fails (but continues on error) if there is an error when publishing.

The combination of these two actions should ensure that the unstable version which is needed for tutorial creation, wallet development, etc. is always published when there are changes to the web client code thus always providing the latest relevant code. 

**TODO:** before merging, I need coordinate with someone with the proper permissions to add a `NPM_TOKEN` to the repo's secrets to allow the publish to happen from the action. 