### PR TITLE
fix: update `miden-base` in client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,9 +357,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.22"
+version = "1.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
+checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
 dependencies = [
  "jobserver",
  "libc",
@@ -638,9 +638,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -1358,7 +1358,7 @@ dependencies = [
 [[package]]
 name = "miden-block-prover"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#a30142d0653ff833af501179fb3ccbc9e98767ae"
+source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#3d8c3b28048fffbb63592a971d0fcae5dc58bce9"
 dependencies = [
  "miden-lib",
  "miden-objects",
@@ -1509,7 +1509,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#a30142d0653ff833af501179fb3ccbc9e98767ae"
+source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#3d8c3b28048fffbb63592a971d0fcae5dc58bce9"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -1564,7 +1564,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto-build"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#ff6ce58768f84112aa776efb5cec87dc47de95f2"
+source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#490903d6b9aa0623e47579160f12b046d5995558"
 dependencies = [
  "anyhow",
  "prost",
@@ -1575,7 +1575,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#a30142d0653ff833af501179fb3ccbc9e98767ae"
+source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#3d8c3b28048fffbb63592a971d0fcae5dc58bce9"
 dependencies = [
  "bech32",
  "getrandom 0.3.3",
@@ -1622,7 +1622,7 @@ dependencies = [
 [[package]]
 name = "miden-proving-service-client"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#a30142d0653ff833af501179fb3ccbc9e98767ae"
+source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#3d8c3b28048fffbb63592a971d0fcae5dc58bce9"
 dependencies = [
  "async-trait",
  "getrandom 0.3.3",
@@ -1652,7 +1652,7 @@ dependencies = [
 [[package]]
 name = "miden-testing"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#a30142d0653ff833af501179fb3ccbc9e98767ae"
+source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#3d8c3b28048fffbb63592a971d0fcae5dc58bce9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1671,7 +1671,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#a30142d0653ff833af501179fb3ccbc9e98767ae"
+source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#3d8c3b28048fffbb63592a971d0fcae5dc58bce9"
 dependencies = [
  "async-trait",
  "miden-lib",
@@ -1905,9 +1905,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
+checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
 
 [[package]]
 name = "parking_lot"
@@ -3621,9 +3621,9 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "46ec44dc15085cea82cf9c78f85a9114c463a369786585ad2882d1ff0b0acf40"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -3634,12 +3634,13 @@ dependencies = [
 
 [[package]]
 name = "windows-future"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1d6bbefcb7b60acd19828e1bc965da6fcf18a7e39490c5f8be71e54a19ba32"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core",
  "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3682,18 +3683,18 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "4b895b5356fc36103d0f64dd1e94dfa7ac5633f1c9dd6e80fe9ec4adef69e09d"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "2a7ab927b2637c19b3dbe0965e75d8f2d30bdd697a1516191cad2ec4df8fb28a"
 dependencies = [
  "windows-link",
 ]
@@ -3754,6 +3755,15 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ WARNINGS=RUSTDOCFLAGS="-D warnings"
 
 NODE_DIR="miden-node"
 NODE_REPO="https://github.com/0xPolygonMiden/miden-node.git"
-NODE_BRANCH="next"
+NODE_BRANCH="tomyrd-update-base"
 
 PROVER_DIR="miden-base"
 PROVER_REPO="https://github.com/0xPolygonMiden/miden-base.git"

--- a/crates/rust-client/src/transaction/request/foreign.rs
+++ b/crates/rust-client/src/transaction/request/foreign.rs
@@ -1,12 +1,11 @@
 //! Contains structures and functions related to FPI (Foreign Procedure Invocation) transactions.
-use alloc::{string::ToString, vec::Vec};
+use alloc::string::ToString;
 use core::cmp::Ordering;
 
 use miden_objects::{
-    account::{Account, AccountCode, AccountHeader, AccountId, AccountStorageHeader, StorageSlot},
-    block::AccountWitness,
-    crypto::merkle::SmtProof,
-    transaction::ForeignAccountInputs,
+    account::{AccountId, PartialAccount, PartialStorage},
+    asset::PartialVault,
+    transaction::AccountInputs,
 };
 use miden_tx::utils::{Deserializable, DeserializationError, Serializable};
 
@@ -24,10 +23,10 @@ pub enum ForeignAccount {
     /// account ID. The second element of the tuple indicates which storage slot indices
     /// and map keys are desired to be retrieved.
     Public(AccountId, AccountStorageRequirements),
-    /// Private account data requires [`ForeignAccountInformation`] to be passed. An account witness
+    /// Private account data requires [`PartialAccount`] to be passed. An account witness
     /// will be retrieved from the network at execution time so that it can be used as inputs to
     /// the transaction kernel.
-    Private(ForeignAccountInformation),
+    Private(PartialAccount),
 }
 
 impl ForeignAccount {
@@ -47,17 +46,13 @@ impl ForeignAccount {
 
     /// Creates a new [`ForeignAccount::Private`]. A proof of the account's inclusion will be
     /// retrieved at execution time.
-    pub fn private(
-        account: impl Into<ForeignAccountInformation>,
-    ) -> Result<Self, TransactionRequestError> {
-        let foreign_account: ForeignAccountInformation = account.into();
-        if foreign_account.account_header().id().is_public() {
-            return Err(TransactionRequestError::InvalidForeignAccountId(
-                foreign_account.account_header().id(),
-            ));
+    pub fn private(account: impl Into<PartialAccount>) -> Result<Self, TransactionRequestError> {
+        let partial_account: PartialAccount = account.into();
+        if partial_account.id().is_public() {
+            return Err(TransactionRequestError::InvalidForeignAccountId(partial_account.id()));
         }
 
-        Ok(Self::Private(foreign_account))
+        Ok(Self::Private(partial_account))
     }
 
     pub fn storage_slot_requirements(&self) -> AccountStorageRequirements {
@@ -73,9 +68,7 @@ impl ForeignAccount {
     pub fn account_id(&self) -> AccountId {
         match self {
             ForeignAccount::Public(account_id, _) => *account_id,
-            ForeignAccount::Private(foreign_account_inputs) => {
-                foreign_account_inputs.account_header.id()
-            },
+            ForeignAccount::Private(partial_account) => partial_account.id(),
         }
     }
 }
@@ -100,9 +93,9 @@ impl Serializable for ForeignAccount {
                 account_id.write_into(target);
                 storage_requirements.write_into(target);
             },
-            ForeignAccount::Private(foreign_account_inputs) => {
+            ForeignAccount::Private(partial_account) => {
                 target.write(1u8);
-                foreign_account_inputs.write_into(target);
+                partial_account.write_into(target);
             },
         }
     }
@@ -120,7 +113,7 @@ impl Deserializable for ForeignAccount {
                 Ok(ForeignAccount::Public(account_id, storage_requirements))
             },
             1 => {
-                let foreign_inputs = ForeignAccountInformation::read_from(source)?;
+                let foreign_inputs = PartialAccount::read_from(source)?;
                 Ok(ForeignAccount::Private(foreign_inputs))
             },
             _ => Err(DeserializationError::InvalidValue("Invalid account type".to_string())),
@@ -128,179 +121,7 @@ impl Deserializable for ForeignAccount {
     }
 }
 
-// FOREIGN ACCOUNT INFORMATION
-// ================================================================================================
-
-/// Contains information about a foreign account, with everything required to execute its code from
-/// the context of the native account.
-///
-/// At the moment of transaction execution ([`crate::Client::new_transaction()`]), an account
-/// witness is fetched for the account and this struct can be converted into
-/// [`ForeignAccountInputs`], which is then used as inputs to the transaction kernel.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ForeignAccountInformation {
-    /// Account header of the foreign account.
-    account_header: AccountHeader,
-    /// Header information about the account's storage.
-    storage_header: AccountStorageHeader,
-    /// Code associated with the account.
-    account_code: AccountCode,
-    /// Storage SMT proof for storage map values that the transaction will access.
-    storage_map_proofs: Vec<SmtProof>,
-}
-
-impl ForeignAccountInformation {
-    /// Creates a new [`ForeignAccountInformation`]
-    pub fn new(
-        account_header: AccountHeader,
-        storage_header: AccountStorageHeader,
-        account_code: AccountCode,
-        storage_map_proofs: Vec<SmtProof>,
-    ) -> ForeignAccountInformation {
-        ForeignAccountInformation {
-            account_header,
-            storage_header,
-            account_code,
-            storage_map_proofs,
-        }
-    }
-
-    /// Creates a new [`ForeignAccountInputs`] from an [`Account`] and a list of storage keys.
-    ///
-    /// # Errors
-    ///
-    /// - If one of the specified slots in `storage_requirements` is not a map-type slot or it is
-    ///   not found.
-    pub fn from_account(
-        account: Account,
-        storage_requirements: &AccountStorageRequirements,
-    ) -> Result<ForeignAccountInformation, TransactionRequestError> {
-        // Get required proofs
-        let mut smt_proofs = vec![];
-        for (slot_index, keys) in storage_requirements.inner() {
-            for key in keys {
-                let slot = account.storage().slots().get(*slot_index as usize);
-                match slot {
-                    Some(StorageSlot::Map(map)) => {
-                        smt_proofs.push(map.open(key));
-                    },
-                    Some(StorageSlot::Value(_)) => {
-                        return Err(
-                            TransactionRequestError::ForeignAccountStorageSlotInvalidIndex(
-                                *slot_index,
-                            ),
-                        );
-                    },
-                    None => {
-                        return Err(TransactionRequestError::StorageSlotNotFound(
-                            *slot_index,
-                            account.id(),
-                        ));
-                    },
-                }
-            }
-        }
-
-        let account_code: AccountCode = account.code().clone();
-        let storage_header: AccountStorageHeader = account.storage().get_header();
-        let account_header: AccountHeader = account.into();
-
-        Ok(ForeignAccountInformation::new(
-            account_header,
-            storage_header,
-            account_code,
-            smt_proofs,
-        ))
-    }
-
-    /// Returns the account's [`AccountHeader`]
-    pub fn account_header(&self) -> &AccountHeader {
-        &self.account_header
-    }
-
-    /// Returns the account's [`AccountStorageHeader`].
-    pub fn storage_header(&self) -> &AccountStorageHeader {
-        &self.storage_header
-    }
-
-    /// Returns the account's storage maps.
-    pub fn storage_map_proofs(&self) -> &[SmtProof] {
-        &self.storage_map_proofs
-    }
-
-    /// Returns the account's [`AccountCode`].
-    pub fn account_code(&self) -> &AccountCode {
-        &self.account_code
-    }
-
-    /// Extends the storage proofs with the input `smt_proofs` and returns the new structure
-    #[must_use]
-    pub fn with_storage_map_proofs(
-        mut self,
-        smt_proofs: impl IntoIterator<Item = SmtProof>,
-    ) -> Self {
-        self.storage_map_proofs.extend(smt_proofs);
-        self
-    }
-
-    /// Consumes the [`ForeignAccountInformation`] and, with the `merkle_path`, instantiates a
-    /// [`ForeignAccountInputs`]. The merkle path should be a valid proof of inclusion of the
-    /// account at a specific block in the MMR.
-    ///
-    /// The [`ForeignAccountInputs`] can then be passed as transaction arguments for transaction
-    /// execution.
-    pub fn into_foreign_account_inputs(
-        self,
-        account_witness: AccountWitness,
-    ) -> ForeignAccountInputs {
-        let (header, storage_header, account_code, storage_map_proofs) = self.into_parts();
-        ForeignAccountInputs::new(
-            header,
-            storage_header,
-            account_code,
-            account_witness,
-            storage_map_proofs,
-        )
-    }
-
-    /// Consumes the [`ForeignAccountInputs`] and returns its parts.
-    pub fn into_parts(self) -> (AccountHeader, AccountStorageHeader, AccountCode, Vec<SmtProof>) {
-        (
-            self.account_header,
-            self.storage_header,
-            self.account_code,
-            self.storage_map_proofs,
-        )
-    }
-}
-
-impl Serializable for ForeignAccountInformation {
-    fn write_into<W: miden_tx::utils::ByteWriter>(&self, target: &mut W) {
-        self.account_header.write_into(target);
-        self.storage_header.write_into(target);
-        self.account_code.write_into(target);
-        self.storage_map_proofs.write_into(target);
-    }
-}
-
-impl Deserializable for ForeignAccountInformation {
-    fn read_from<R: miden_tx::utils::ByteReader>(
-        source: &mut R,
-    ) -> Result<Self, miden_tx::utils::DeserializationError> {
-        let account_header = AccountHeader::read_from(source)?;
-        let storage_header = AccountStorageHeader::read_from(source)?;
-        let account_code = AccountCode::read_from(source)?;
-        let storage_maps = Vec::<SmtProof>::read_from(source)?;
-        Ok(ForeignAccountInformation::new(
-            account_header,
-            storage_header,
-            account_code,
-            storage_maps,
-        ))
-    }
-}
-
-impl TryFrom<AccountProof> for ForeignAccountInputs {
+impl TryFrom<AccountProof> for AccountInputs {
     type Error = TransactionRequestError;
 
     fn try_from(value: AccountProof) -> Result<Self, Self::Error> {
@@ -317,12 +138,19 @@ impl TryFrom<AccountProof> for ForeignAccountInputs {
             let storage_map_proofs =
                 storage_slots.into_iter().flat_map(|(_, slots)| slots).collect();
 
-            return Ok(ForeignAccountInputs::new(
-                account_header,
-                storage_header,
-                code,
+            return Ok(AccountInputs::new(
+                PartialAccount::new(
+                    account_header.id(),
+                    account_header.nonce(),
+                    code,
+                    PartialStorage::new(storage_header, storage_map_proofs),
+                    PartialVault::new(account_header.vault_root(), vec![]), /* We don't use
+                                                                             * vault
+                                                                             * information so we
+                                                                             * leave it
+                                                                             * empty */
+                ),
                 witness,
-                storage_map_proofs,
             ));
         }
         Err(TransactionRequestError::ForeignAccountDataMissing)

--- a/crates/rust-client/src/transaction/request/mod.rs
+++ b/crates/rust-client/src/transaction/request/mod.rs
@@ -13,7 +13,7 @@ use miden_objects::{
     assembly::AssemblyError,
     crypto::merkle::MerkleStore,
     note::{Note, NoteDetails, NoteId, NoteTag, PartialNote},
-    transaction::{ForeignAccountInputs, TransactionArgs, TransactionScript},
+    transaction::{AccountInputs, TransactionArgs, TransactionScript},
     vm::AdviceMap,
 };
 use miden_tx::utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
@@ -23,7 +23,7 @@ mod builder;
 pub use builder::{PaymentTransactionData, SwapTransactionData, TransactionRequestBuilder};
 
 mod foreign;
-pub use foreign::{ForeignAccount, ForeignAccountInformation};
+pub use foreign::ForeignAccount;
 
 // TRANSACTION REQUEST
 // ================================================================================================
@@ -159,7 +159,7 @@ impl TransactionRequest {
     pub(super) fn into_transaction_args(
         self,
         tx_script: TransactionScript,
-        foreign_account_inputs: Vec<ForeignAccountInputs>,
+        foreign_account_inputs: Vec<AccountInputs>,
     ) -> TransactionArgs {
         let note_args = self.get_note_args();
         let TransactionRequest {
@@ -349,10 +349,7 @@ mod tests {
     use miden_tx::utils::{Deserializable, Serializable};
 
     use super::{TransactionRequest, TransactionRequestBuilder};
-    use crate::{
-        rpc::domain::account::AccountStorageRequirements,
-        transaction::{ForeignAccount, ForeignAccountInformation},
-    };
+    use crate::{rpc::domain::account::AccountStorageRequirements, transaction::ForeignAccount};
 
     #[test]
     fn transaction_request_serialization() {
@@ -407,14 +404,7 @@ mod tests {
                     AccountStorageRequirements::new([(5u8, &[Digest::default()])]),
                 )
                 .unwrap(),
-                ForeignAccount::private(
-                    ForeignAccountInformation::from_account(
-                        account,
-                        &AccountStorageRequirements::default(),
-                    )
-                    .unwrap(),
-                )
-                .unwrap(),
+                ForeignAccount::private(account).unwrap(),
             ])
             .with_own_output_notes(vec![
                 OutputNote::Full(notes.pop().unwrap()),

--- a/tests/integration/fpi_tests.rs
+++ b/tests/integration/fpi_tests.rs
@@ -4,9 +4,7 @@ use miden_client::{
     auth::AuthSecretKey,
     block::BlockHeader,
     rpc::domain::account::{AccountStorageRequirements, StorageMapKey},
-    transaction::{
-        ForeignAccount, ForeignAccountInformation, TransactionKernel, TransactionRequestBuilder,
-    },
+    transaction::{ForeignAccount, TransactionKernel, TransactionRequestBuilder},
 };
 use miden_lib::{account::auth::RpoFalcon512, utils::word_to_masm_push_string};
 use miden_objects::{
@@ -310,10 +308,7 @@ async fn test_standard_fpi(storage_mode: AccountStorageMode) {
         // Get current foreign account current state from the store (after 1st deployment tx)
         let foreign_account: Account =
             client.get_account(foreign_account_id).await.unwrap().unwrap().into();
-        ForeignAccount::private(
-            ForeignAccountInformation::from_account(foreign_account, &storage_requirements)
-                .unwrap(),
-        )
+        ForeignAccount::private(foreign_account)
     };
 
     let tx_request = builder.with_foreign_accounts([foreign_account.unwrap()]).build().unwrap();


### PR DESCRIPTION
This PR uses `tomyrd-update-base` as the node branch, we should update it to `next` once it's merged.