### PR TITLE
feat: Add support for HTTP ACCEPT header version matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Added support for `bech32` account IDs in the CLI (#840).
 * Added support for MASM account component libraries in Web Client (#900).
+* Added support for RPC client/server version matching through HTTP ACCEPT header (#912).
 
 ### Changes
 

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -21,22 +21,9 @@ workspace = true
 [features]
 concurrent = ["miden-tx/concurrent", "std"]
 default = ["std", "tonic/channel"]
-idxdb = [
-    "dep:base64",
-    "dep:serde-wasm-bindgen",
-    "dep:wasm-bindgen",
-    "dep:wasm-bindgen-futures",
-    "dep:serde",
-    "dep:getrandom",
-]
-sqlite = [
-    "dep:rusqlite",
-    "dep:deadpool",
-    "dep:deadpool-sync",
-    "dep:rusqlite_migration",
-    "std",
-]
-std = ["miden-objects/std", "miden-proving-service-client/std"]
+idxdb = ["dep:base64", "dep:serde-wasm-bindgen", "dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:serde", "dep:getrandom"]
+sqlite = ["dep:rusqlite", "dep:deadpool", "dep:deadpool-sync", "dep:rusqlite_migration", "std"]
+std = ["miden-objects/std","miden-proving-service-client/std"]
 testing = ["miden-objects/testing", "miden-lib/testing", "miden-tx/testing"]
 tonic = ["std", "tonic/transport", "tonic/tls-ring", "tonic/tls-native-roots"]
 web-tonic = ["dep:tonic-web-wasm-client", "dep:getrandom"]
@@ -45,37 +32,24 @@ web-tonic = ["dep:tonic-web-wasm-client", "dep:getrandom"]
 async-trait = { workspace = true }
 base64 = { version = "0.22", optional = true }
 chrono = { version = "0.4", optional = false }
-deadpool = { version = "0.12", features = [
-    "managed",
-    "rt_tokio_1",
-], default-features = false, optional = true }
+deadpool = { version = "0.12", features = ["managed", "rt_tokio_1"], default-features = false, optional = true }
 deadpool-sync = { version = "0.1", optional = true }
 hex = { version = "0.4" }
-miden-proving-service-client = { workspace = true, features = ["tx-prover"] }
+miden-proving-service-client = { workspace = true , features = ["tx-prover"]}
 miden-lib = { workspace = true }
 miden-objects = { workspace = true }
 miden-tx = { workspace = true, features = ["async"] }
 prost = { version = "0.13", default-features = false, features = ["derive"] }
 rand = { workspace = true }
-rusqlite = { version = "0.35", features = [
-    "vtab",
-    "array",
-    "bundled",
-], optional = true }
+rusqlite = { version = "0.35", features = ["vtab", "array", "bundled"], optional = true }
 rusqlite_migration = { version = "2.1", optional = true }
 serde = { workspace = true, optional = true }
 serde-wasm-bindgen = { version = "0.6", optional = true }
 thiserror = { workspace = true }
-tonic = { version = "0.13", default-features = false, features = [
-    "prost",
-    "codegen",
-    "tls-native-roots",
-] }
+tonic = { version = "0.13", default-features = false, features = ["prost", "codegen"] }
 tonic-web-wasm-client = { version = "0.7", optional = true, default-features = false }
 tracing = { workspace = true }
-wasm-bindgen = { version = "0.2", features = [
-    "serde-serialize",
-], optional = true }
+wasm-bindgen = { version = "0.2", features = ["serde-serialize"], optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 getrandom = { version = "0.3", optional = true, features = ["wasm_js"] }
 
@@ -86,22 +60,13 @@ ignored = ["getrandom"]
 web-sys = { version = "0.3", features = ["console", "Window", "Storage"] }
 
 [dev-dependencies]
-miden-client = { path = ".", features = [
-    "testing",
-    "concurrent",
-    "sqlite",
-    "tonic",
-] }
+miden-client = { path = ".", features = ["testing", "concurrent", "sqlite", "tonic"] }
 miden-lib = { workspace = true, features = ["testing"] }
-miden-objects = { workspace = true, default-features = false, features = [
-    "testing",
-] }
-miden-testing = { git = "https://github.com/0xMiden/miden-base", branch = "next", default-features = false, features = [
-    "async",
-] }
+miden-objects = { workspace = true, default-features = false, features = ["testing"] }
+miden-testing = { git = "https://github.com/0xMiden/miden-base", branch = "next", default-features = false, features = ["async"] }
 tokio = { workspace = true }
 uuid = { version = "1.10", features = ["serde", "v4"] }
-web-sys = { version = "0.3", features = ["console"] }
+web-sys = { version = "0.3", features = ["console"]}
 
 [build-dependencies]
 miden-node-proto-build = { git = "https://github.com/0xMiden/miden-node", branch = "next", default-features = false }

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -21,9 +21,22 @@ workspace = true
 [features]
 concurrent = ["miden-tx/concurrent", "std"]
 default = ["std", "tonic/channel"]
-idxdb = ["dep:base64", "dep:serde-wasm-bindgen", "dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:serde", "dep:getrandom"]
-sqlite = ["dep:rusqlite", "dep:deadpool", "dep:deadpool-sync", "dep:rusqlite_migration", "std"]
-std = ["miden-objects/std","miden-proving-service-client/std"]
+idxdb = [
+    "dep:base64",
+    "dep:serde-wasm-bindgen",
+    "dep:wasm-bindgen",
+    "dep:wasm-bindgen-futures",
+    "dep:serde",
+    "dep:getrandom",
+]
+sqlite = [
+    "dep:rusqlite",
+    "dep:deadpool",
+    "dep:deadpool-sync",
+    "dep:rusqlite_migration",
+    "std",
+]
+std = ["miden-objects/std", "miden-proving-service-client/std"]
 testing = ["miden-objects/testing", "miden-lib/testing", "miden-tx/testing"]
 tonic = ["std", "tonic/transport", "tonic/tls-ring", "tonic/tls-native-roots"]
 web-tonic = ["dep:tonic-web-wasm-client", "dep:getrandom"]
@@ -32,24 +45,36 @@ web-tonic = ["dep:tonic-web-wasm-client", "dep:getrandom"]
 async-trait = { workspace = true }
 base64 = { version = "0.22", optional = true }
 chrono = { version = "0.4", optional = false }
-deadpool = { version = "0.12", features = ["managed", "rt_tokio_1"], default-features = false, optional = true }
+deadpool = { version = "0.12", features = [
+    "managed",
+    "rt_tokio_1",
+], default-features = false, optional = true }
 deadpool-sync = { version = "0.1", optional = true }
 hex = { version = "0.4" }
-miden-proving-service-client = { workspace = true , features = ["tx-prover"]}
+miden-proving-service-client = { workspace = true, features = ["tx-prover"] }
 miden-lib = { workspace = true }
 miden-objects = { workspace = true }
 miden-tx = { workspace = true, features = ["async"] }
 prost = { version = "0.13", default-features = false, features = ["derive"] }
 rand = { workspace = true }
-rusqlite = { version = "0.35", features = ["vtab", "array", "bundled"], optional = true }
+rusqlite = { version = "0.35", features = [
+    "vtab",
+    "array",
+    "bundled",
+], optional = true }
 rusqlite_migration = { version = "2.1", optional = true }
 serde = { workspace = true, optional = true }
 serde-wasm-bindgen = { version = "0.6", optional = true }
 thiserror = { workspace = true }
-tonic = { version = "0.13", default-features = false, features = ["prost", "codegen"] }
+tonic = { version = "0.13", default-features = false, features = [
+    "prost",
+    "codegen",
+] }
 tonic-web-wasm-client = { version = "0.7", optional = true, default-features = false }
 tracing = { workspace = true }
-wasm-bindgen = { version = "0.2", features = ["serde-serialize"], optional = true }
+wasm-bindgen = { version = "0.2", features = [
+    "serde-serialize",
+], optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 getrandom = { version = "0.3", optional = true, features = ["wasm_js"] }
 
@@ -60,13 +85,22 @@ ignored = ["getrandom"]
 web-sys = { version = "0.3", features = ["console", "Window", "Storage"] }
 
 [dev-dependencies]
-miden-client = { path = ".", features = ["testing", "concurrent", "sqlite", "tonic"] }
+miden-client = { path = ".", features = [
+    "testing",
+    "concurrent",
+    "sqlite",
+    "tonic",
+] }
 miden-lib = { workspace = true, features = ["testing"] }
-miden-objects = { workspace = true, default-features = false, features = ["testing"] }
-miden-testing = { git = "https://github.com/0xMiden/miden-base", branch = "next", default-features = false, features = ["async"] }
+miden-objects = { workspace = true, default-features = false, features = [
+    "testing",
+] }
+miden-testing = { git = "https://github.com/0xMiden/miden-base", branch = "next", default-features = false, features = [
+    "async",
+] }
 tokio = { workspace = true }
 uuid = { version = "1.10", features = ["serde", "v4"] }
-web-sys = { version = "0.3", features = ["console"]}
+web-sys = { version = "0.3", features = ["console"] }
 
 [build-dependencies]
 miden-node-proto-build = { git = "https://github.com/0xMiden/miden-node", branch = "next", default-features = false }

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -69,6 +69,7 @@ thiserror = { workspace = true }
 tonic = { version = "0.13", default-features = false, features = [
     "prost",
     "codegen",
+    "tls-native-roots",
 ] }
 tonic-web-wasm-client = { version = "0.7", optional = true, default-features = false }
 tracing = { workspace = true }

--- a/crates/rust-client/src/rpc/tonic_client/api_client.rs
+++ b/crates/rust-client/src/rpc/tonic_client/api_client.rs
@@ -1,11 +1,4 @@
-use alloc::string::String;
-
-use tonic::{
-    metadata::{AsciiMetadataValue, errors::InvalidMetadataValue},
-    service::Interceptor,
-};
-
-// CLIENT
+// WEB CLIENT
 // ================================================================================================
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "web-tonic"))]
@@ -29,6 +22,9 @@ pub(crate) mod api_client_wrapper {
     }
 }
 
+// CLIENT
+// ================================================================================================
+
 #[cfg(feature = "tonic")]
 pub(crate) mod api_client_wrapper {
     use alloc::{boxed::Box, string::String};
@@ -37,9 +33,12 @@ pub(crate) mod api_client_wrapper {
         time::Duration,
     };
 
-    use tonic::{service::interceptor::InterceptedService, transport::Channel};
+    use tonic::{
+        metadata::{AsciiMetadataValue, errors::InvalidMetadataValue},
+        service::{Interceptor, interceptor::InterceptedService},
+        transport::Channel,
+    };
 
-    use super::{MetadataInterceptor, accept_header_interceptor};
     use crate::rpc::{RpcError, generated::rpc::api_client::ApiClient as ProtoClient};
 
     pub type InnerClient = ProtoClient<InterceptedService<Channel, MetadataInterceptor>>;
@@ -81,44 +80,47 @@ pub(crate) mod api_client_wrapper {
             &mut self.0
         }
     }
-}
 
-// INTERCEPTOR
-// ================================================================================================
+    // INTERCEPTOR
+    // ================================================================================================
 
-/// Interceptor designed to inject required metadata into all [`ApiClient`] requests.
-#[derive(Default, Clone)]
-pub struct MetadataInterceptor {
-    metadata: alloc::collections::BTreeMap<&'static str, AsciiMetadataValue>,
-}
-
-impl MetadataInterceptor {
-    /// Adds or overwrites metadata to the interceptor.
-    pub fn with_metadata(
-        mut self,
-        key: &'static str,
-        value: String,
-    ) -> Result<Self, InvalidMetadataValue> {
-        self.metadata.insert(key, AsciiMetadataValue::try_from(value)?);
-        Ok(self)
+    /// Interceptor designed to inject required metadata into all [`ApiClient`] requests.
+    #[derive(Default, Clone)]
+    pub struct MetadataInterceptor {
+        metadata: alloc::collections::BTreeMap<&'static str, AsciiMetadataValue>,
     }
-}
 
-impl Interceptor for MetadataInterceptor {
-    fn call(&mut self, request: tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status> {
-        let mut request = request;
-        for (key, value) in &self.metadata {
-            request.metadata_mut().insert(*key, value.clone());
+    impl MetadataInterceptor {
+        /// Adds or overwrites metadata to the interceptor.
+        pub fn with_metadata(
+            mut self,
+            key: &'static str,
+            value: String,
+        ) -> Result<Self, InvalidMetadataValue> {
+            self.metadata.insert(key, AsciiMetadataValue::try_from(value)?);
+            Ok(self)
         }
-        Ok(request)
     }
-}
 
-/// Returns the HTTP ACCEPT header [`MetadataInterceptor`] that is expected by Miden RPC.
-fn accept_header_interceptor() -> MetadataInterceptor {
-    let version = env!("CARGO_PKG_VERSION");
-    let accept_value = format!("application/vnd.miden.{version}+grpc");
-    MetadataInterceptor::default()
-        .with_metadata("accept", accept_value)
-        .expect("valid key/value metadata for interceptor")
+    impl Interceptor for MetadataInterceptor {
+        fn call(
+            &mut self,
+            request: tonic::Request<()>,
+        ) -> Result<tonic::Request<()>, tonic::Status> {
+            let mut request = request;
+            for (key, value) in &self.metadata {
+                request.metadata_mut().insert(*key, value.clone());
+            }
+            Ok(request)
+        }
+    }
+
+    /// Returns the HTTP ACCEPT header [`MetadataInterceptor`] that is expected by Miden RPC.
+    fn accept_header_interceptor() -> MetadataInterceptor {
+        let version = env!("CARGO_PKG_VERSION");
+        let accept_value = format!("application/vnd.miden.{version}+grpc");
+        MetadataInterceptor::default()
+            .with_metadata("accept", accept_value)
+            .expect("valid key/value metadata for interceptor")
+    }
 }

--- a/crates/rust-client/src/rpc/tonic_client/api_client.rs
+++ b/crates/rust-client/src/rpc/tonic_client/api_client.rs
@@ -68,6 +68,7 @@ pub(crate) mod api_client_wrapper {
             Ok(ApiClient(ProtoClient::with_interceptor(channel, interceptor)))
         }
     }
+
     impl Deref for ApiClient {
         type Target = InnerClient;
         fn deref(&self) -> &Self::Target {

--- a/crates/rust-client/src/rpc/tonic_client/api_client.rs
+++ b/crates/rust-client/src/rpc/tonic_client/api_client.rs
@@ -62,6 +62,8 @@ pub(crate) mod api_client_wrapper {
                 .map_err(|err| RpcError::ConnectionError(Box::new(err)))?
                 .timeout(Duration::from_millis(timeout_ms));
             let channel = endpoint
+                .tls_config(tonic::transport::ClientTlsConfig::new().with_native_roots())
+                .map_err(|err| RpcError::ConnectionError(Box::new(err)))?
                 .connect()
                 .await
                 .map_err(|err| RpcError::ConnectionError(Box::new(err)))?;

--- a/crates/rust-client/src/rpc/tonic_client/api_client.rs
+++ b/crates/rust-client/src/rpc/tonic_client/api_client.rs
@@ -1,6 +1,6 @@
+use alloc::string::String;
 use core::ops::{Deref, DerefMut};
 
-use alloc::string::String;
 use api_client_wrapper::{ApiClient, InnerClient};
 use tonic::{
     metadata::{AsciiMetadataValue, errors::InvalidMetadataValue},
@@ -16,10 +16,12 @@ compile_error!("The `web-tonic` feature is only supported when targeting wasm32.
 #[cfg(feature = "web-tonic")]
 pub(crate) mod api_client_wrapper {
 
+    use alloc::string::String;
+
+    use tonic::service::interceptor::InterceptedService;
+
     use super::{MetadataInterceptor, accept_header_interceptor};
     use crate::rpc::{RpcError, generated::rpc::api_client::ApiClient as ProtoClient};
-    use alloc::string::String;
-    use tonic::service::interceptor::InterceptedService;
 
     pub type WasmClient = tonic_web_wasm_client::Client;
     pub type InnerClient = ProtoClient<InterceptedService<WasmClient, MetadataInterceptor>>;
@@ -38,11 +40,13 @@ pub(crate) mod api_client_wrapper {
 
 #[cfg(feature = "tonic")]
 pub(crate) mod api_client_wrapper {
-    use super::{MetadataInterceptor, accept_header_interceptor};
-    use crate::rpc::{RpcError, generated::rpc::api_client::ApiClient as ProtoClient};
     use alloc::{boxed::Box, string::String};
     use core::time::Duration;
+
     use tonic::{service::interceptor::InterceptedService, transport::Channel};
+
+    use super::{MetadataInterceptor, accept_header_interceptor};
+    use crate::rpc::{RpcError, generated::rpc::api_client::ApiClient as ProtoClient};
 
     pub type InnerClient = ProtoClient<InterceptedService<Channel, MetadataInterceptor>>;
     #[derive(Clone)]

--- a/crates/rust-client/src/rpc/tonic_client/api_client.rs
+++ b/crates/rust-client/src/rpc/tonic_client/api_client.rs
@@ -1,3 +1,9 @@
+use alloc::string::String;
+use tonic::{
+    metadata::{AsciiMetadataValue, errors::InvalidMetadataValue},
+    service::Interceptor,
+};
+
 #[cfg(all(not(target_arch = "wasm32"), feature = "web-tonic"))]
 compile_error!("The `web-tonic` feature is only supported when targeting wasm32.");
 
@@ -21,23 +27,86 @@ pub(crate) mod api_client_wrapper {
 
 #[cfg(feature = "tonic")]
 pub(crate) mod api_client_wrapper {
+    use super::MetadataInterceptor;
+    use crate::rpc::{RpcError, generated::rpc::api_client::ApiClient as ProtoClient};
     use alloc::{boxed::Box, string::String};
-    use core::time::Duration;
+    use core::{
+        ops::{Deref, DerefMut},
+        time::Duration,
+    };
+    use tonic::{service::interceptor::InterceptedService, transport::Channel};
 
-    use crate::rpc::RpcError;
+    type InnerClient = ProtoClient<InterceptedService<Channel, MetadataInterceptor>>;
+    #[derive(Clone)]
+    pub struct ApiClient(InnerClient);
 
-    pub type ApiClient =
-        crate::rpc::generated::rpc::api_client::ApiClient<tonic::transport::Channel>;
+    impl Deref for ApiClient {
+        type Target = InnerClient;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    impl DerefMut for ApiClient {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.0
+        }
+    }
 
     impl ApiClient {
+        /// Connects to the Miden node API using the provided URL and timeout.
+        ///
+        /// The client is configured with an interceptor that sets all requisite request metadata.
         pub async fn new_client(endpoint: String, timeout_ms: u64) -> Result<ApiClient, RpcError> {
+            // Setup connection channel.
             let endpoint = tonic::transport::Endpoint::try_from(endpoint)
                 .map_err(|err| RpcError::ConnectionError(Box::new(err)))?
                 .timeout(Duration::from_millis(timeout_ms));
-
-            ApiClient::connect(endpoint)
+            let channel = endpoint
+                .connect()
                 .await
-                .map_err(|err| RpcError::ConnectionError(Box::new(err)))
+                .map_err(|err| RpcError::ConnectionError(Box::new(err)))?;
+
+            // Set up the accept metadata interceptor.
+            let version = env!("CARGO_PKG_VERSION");
+            let accept_value = format!("application/vnd.miden.{version}+grpc");
+            let interceptor = MetadataInterceptor::default()
+                .with_metadata("accept", accept_value)
+                .expect("valid key/value metadata for interceptor");
+
+            // Return the connected client.
+            Ok(ApiClient(ProtoClient::with_interceptor(channel, interceptor)))
         }
+    }
+}
+
+// INTERCEPTOR
+// ================================================================================================
+
+/// Interceptor designed to inject required metadata into all [`ApiClient`] requests.
+#[derive(Default, Clone)]
+pub struct MetadataInterceptor {
+    metadata: alloc::collections::BTreeMap<&'static str, AsciiMetadataValue>,
+}
+
+impl MetadataInterceptor {
+    /// Adds or overwrites metadata to the interceptor.
+    pub fn with_metadata(
+        mut self,
+        key: &'static str,
+        value: String,
+    ) -> Result<Self, InvalidMetadataValue> {
+        self.metadata.insert(key, AsciiMetadataValue::try_from(value)?);
+        Ok(self)
+    }
+}
+
+impl Interceptor for MetadataInterceptor {
+    fn call(&mut self, request: tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status> {
+        let mut request = request;
+        for (key, value) in &self.metadata {
+            request.metadata_mut().insert(*key, value.clone());
+        }
+        Ok(request)
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "prettier": "^3.4.2"
+    "prettier": "^3.5.3"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "devDependencies": {


### PR DESCRIPTION
### Context

Relates to https://github.com/0xMiden/miden-node/issues/804 and https://github.com/0xMiden/miden-node/pull/844.

With https://github.com/0xMiden/miden-node/pull/844, we added support for ACCEPT headers in RPC requests to allow servers to match version requirements against clients that provide a valid header.

### Changes

Update the RPC client to set the ACCEPT header based on the version in `Cargo.toml`.

Note that the server requires an exact major and minor version match (excluding patch).

There didn't appear to be any tests that use `new_client()` here so I haven't added any tests here. The code is more or less duplicate to that in miden-node which has comprehensive tests via https://github.com/0xMiden/miden-node/pull/844.

This does not update the WASM client.

I have not updated the docs because the error that comes out of the server is clear - it specifies there is a client/server version mismatch and which version is required by the server. https://github.com/0xMiden/miden-node/pull/844 did update the relevant docs there however.