### PR TITLE
feat: update Miden VM in client

### DIFF
--- a/.github/workflows/web-docs-check.yml
+++ b/.github/workflows/web-docs-check.yml
@@ -15,11 +15,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Install Rust toolchain
+        run: rustup update --no-self-update
+
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: '20'
-      
+
       - name: Add WASM target
         run: rustup target add wasm32-unknown-unknown
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1531,23 +1531,11 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miden-air"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e2e77c57ae798e02553af158c04d467f6479ab798a8c84459d343a89ff9c50"
-dependencies = [
- "miden-core 0.13.2",
- "thiserror 2.0.12",
- "winter-air",
- "winter-prover",
-]
-
-[[package]]
-name = "miden-air"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71f9878c75891951ac4e8dd42793a84c4d07e5aaf27a8c88bfc097b70cd2c1cd"
 dependencies = [
- "miden-core 0.14.0",
+ "miden-core",
  "thiserror 2.0.12",
  "winter-air",
  "winter-prover",
@@ -1562,7 +1550,7 @@ dependencies = [
  "aho-corasick",
  "lalrpop",
  "lalrpop-util",
- "miden-core 0.14.0",
+ "miden-core",
  "miden-miette",
  "rustc_version 0.4.1",
  "smallvec",
@@ -1574,7 +1562,8 @@ dependencies = [
 [[package]]
 name = "miden-block-prover"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#291d6620bc157e81f76c37b3dbcfb64ac5f80d8c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58d59a53f9ff3585d1a3a9b9432b949397a014ffa6f9092cab2bd92528a0e382"
 dependencies = [
  "miden-lib",
  "miden-objects",
@@ -1675,25 +1664,6 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7d408e01421b5df2e4cfaf1a91efefe3fb5b729f1c99b668d3a69eec0044a6b"
-dependencies = [
- "lock_api",
- "loom",
- "memchr",
- "miden-crypto",
- "miden-formatting",
- "num-derive",
- "num-traits",
- "parking_lot",
- "thiserror 2.0.12",
- "winter-math",
- "winter-utils",
-]
-
-[[package]]
-name = "miden-core"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134f716ca140dd0e89f5c96527c3554be1f0289f2519c905ac83a48f8db899a8"
@@ -1744,7 +1714,8 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#291d6620bc157e81f76c37b3dbcfb64ac5f80d8c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cb98502ec0b2fb58846cdecbaefd7dc1e1655d86c2302c28a3f80a470cdd1d4"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -1799,7 +1770,7 @@ dependencies = [
 [[package]]
 name = "miden-node-block-producer"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#481cc842fb1ec7c5438b1af40d5d2ab33c518006"
+source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#d6533737754c6e52fe7ed1f1067db7d89d06a2bf"
 dependencies = [
  "anyhow",
  "futures",
@@ -1809,7 +1780,7 @@ dependencies = [
  "miden-node-proto",
  "miden-node-utils",
  "miden-objects",
- "miden-processor 0.13.2",
+ "miden-processor",
  "miden-proving-service-client",
  "miden-tx-batch-prover",
  "rand 0.9.1",
@@ -1825,7 +1796,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#481cc842fb1ec7c5438b1af40d5d2ab33c518006"
+source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#d6533737754c6e52fe7ed1f1067db7d89d06a2bf"
 dependencies = [
  "anyhow",
  "hex",
@@ -1843,7 +1814,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto-build"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#481cc842fb1ec7c5438b1af40d5d2ab33c518006"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#d6533737754c6e52fe7ed1f1067db7d89d06a2bf"
 dependencies = [
  "anyhow",
  "prost",
@@ -1854,7 +1825,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto-build"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#481cc842fb1ec7c5438b1af40d5d2ab33c518006"
+source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#d6533737754c6e52fe7ed1f1067db7d89d06a2bf"
 dependencies = [
  "anyhow",
  "prost",
@@ -1865,7 +1836,7 @@ dependencies = [
 [[package]]
 name = "miden-node-rpc"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#481cc842fb1ec7c5438b1af40d5d2ab33c518006"
+source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#d6533737754c6e52fe7ed1f1067db7d89d06a2bf"
 dependencies = [
  "anyhow",
  "miden-node-proto",
@@ -1883,7 +1854,7 @@ dependencies = [
 [[package]]
 name = "miden-node-store"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#481cc842fb1ec7c5438b1af40d5d2ab33c518006"
+source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#d6533737754c6e52fe7ed1f1067db7d89d06a2bf"
 dependencies = [
  "anyhow",
  "deadpool",
@@ -1906,7 +1877,7 @@ dependencies = [
 [[package]]
 name = "miden-node-utils"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#481cc842fb1ec7c5438b1af40d5d2ab33c518006"
+source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#d6533737754c6e52fe7ed1f1067db7d89d06a2bf"
 dependencies = [
  "anyhow",
  "figment",
@@ -1928,15 +1899,16 @@ dependencies = [
 
 [[package]]
 name = "miden-objects"
-version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#291d6620bc157e81f76c37b3dbcfb64ac5f80d8c"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76b4c5d037aa609fb247141a0707f0012a12ff7e14bba350b6f119a2010a65f9"
 dependencies = [
  "bech32",
  "getrandom 0.3.3",
  "miden-assembly",
- "miden-core 0.14.0",
+ "miden-core",
  "miden-crypto",
- "miden-processor 0.14.0",
+ "miden-processor",
  "miden-verifier",
  "rand 0.9.1",
  "rand_xoshiro",
@@ -1949,25 +1921,12 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e70b053c587014396d06be3502e3952777923bee11729b7514c060fdc0d2c8"
-dependencies = [
- "miden-air 0.13.2",
- "miden-core 0.13.2",
- "thiserror 2.0.12",
- "tracing",
- "winter-prover",
-]
-
-[[package]]
-name = "miden-processor"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796a5c11589731286ca1cb761b13be13e69e4e0606a5469ce815491989402ea"
 dependencies = [
- "miden-air 0.14.0",
- "miden-core 0.14.0",
+ "miden-air",
+ "miden-core",
  "miden-miette",
  "thiserror 2.0.12",
  "tracing",
@@ -1980,8 +1939,8 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89bc4b989306ca1b8bdba364af72547c563419e77220f4cd244ed2bf3557d351"
 dependencies = [
- "miden-air 0.14.0",
- "miden-processor 0.14.0",
+ "miden-air",
+ "miden-processor",
  "tracing",
  "winter-maybe-async",
  "winter-prover",
@@ -1990,7 +1949,8 @@ dependencies = [
 [[package]]
 name = "miden-proving-service-client"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#291d6620bc157e81f76c37b3dbcfb64ac5f80d8c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbd9676d8f6e8b9cbeba33a1c7fb115ef376d2f4101a5f97b5572ce9e10fb47"
 dependencies = [
  "async-trait",
  "getrandom 0.3.3",
@@ -2014,13 +1974,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "887189ccce4f9bbf15dfdaff0e6842fb138a7432a8f21adde756fac114b07184"
 dependencies = [
  "miden-assembly",
- "miden-core 0.14.0",
+ "miden-core",
 ]
 
 [[package]]
 name = "miden-testing"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#291d6620bc157e81f76c37b3dbcfb64ac5f80d8c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84e090a40f3233faf965938c68700fa39697c1c3958847c1cebd2d97f128b879"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2028,7 +1989,7 @@ dependencies = [
  "miden-crypto",
  "miden-lib",
  "miden-objects",
- "miden-processor 0.14.0",
+ "miden-processor",
  "miden-tx",
  "rand 0.9.1",
  "rand_chacha 0.9.0",
@@ -2039,12 +2000,13 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#291d6620bc157e81f76c37b3dbcfb64ac5f80d8c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbea7c2a870e69e86e4d7bdf21936447552442f4ec274e499d2d9b8a90a70653"
 dependencies = [
  "async-trait",
  "miden-lib",
  "miden-objects",
- "miden-processor 0.14.0",
+ "miden-processor",
  "miden-prover",
  "miden-verifier",
  "rand 0.9.1",
@@ -2055,7 +2017,8 @@ dependencies = [
 [[package]]
 name = "miden-tx-batch-prover"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#291d6620bc157e81f76c37b3dbcfb64ac5f80d8c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8ec59ad67da64407aeb62ca248b09289d32defe70d724484e137652a40f9f74"
 dependencies = [
  "miden-objects",
  "miden-tx",
@@ -2067,8 +2030,8 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b6edc80bf70f276be1c001748c1edf10bea6273a57ee3694fd73d79050fc09"
 dependencies = [
- "miden-air 0.14.0",
- "miden-core 0.14.0",
+ "miden-air",
+ "miden-core",
  "thiserror 2.0.12",
  "tracing",
  "winter-verifier",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1062,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1106,21 +1106,22 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1130,30 +1131,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -1161,65 +1142,52 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1235,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1390,12 +1358,12 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -1440,9 +1408,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
@@ -1567,7 +1535,19 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00e2e77c57ae798e02553af158c04d467f6479ab798a8c84459d343a89ff9c50"
 dependencies = [
- "miden-core",
+ "miden-core 0.13.2",
+ "thiserror 2.0.12",
+ "winter-air",
+ "winter-prover",
+]
+
+[[package]]
+name = "miden-air"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71f9878c75891951ac4e8dd42793a84c4d07e5aaf27a8c88bfc097b70cd2c1cd"
+dependencies = [
+ "miden-core 0.14.0",
  "thiserror 2.0.12",
  "winter-air",
  "winter-prover",
@@ -1575,14 +1555,14 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75d1cb02d807c2481f365feca966bedb74c66c765923d04c3c23ea678afaf148"
+checksum = "b4e3d328e85faa193464dff6b51d9a6ede860a0a0b91858f2370931346d67c26"
 dependencies = [
  "aho-corasick",
  "lalrpop",
  "lalrpop-util",
- "miden-core",
+ "miden-core 0.14.0",
  "miden-miette",
  "rustc_version 0.4.1",
  "smallvec",
@@ -1594,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "miden-block-prover"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#3d8c3b28048fffbb63592a971d0fcae5dc58bce9"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#291d6620bc157e81f76c37b3dbcfb64ac5f80d8c"
 dependencies = [
  "miden-lib",
  "miden-objects",
@@ -1704,6 +1684,25 @@ dependencies = [
  "memchr",
  "miden-crypto",
  "miden-formatting",
+ "num-derive",
+ "num-traits",
+ "parking_lot",
+ "thiserror 2.0.12",
+ "winter-math",
+ "winter-utils",
+]
+
+[[package]]
+name = "miden-core"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134f716ca140dd0e89f5c96527c3554be1f0289f2519c905ac83a48f8db899a8"
+dependencies = [
+ "lock_api",
+ "loom",
+ "memchr",
+ "miden-crypto",
+ "miden-formatting",
  "miden-miette",
  "num-derive",
  "num-traits",
@@ -1745,7 +1744,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#3d8c3b28048fffbb63592a971d0fcae5dc58bce9"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#291d6620bc157e81f76c37b3dbcfb64ac5f80d8c"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -1800,7 +1799,7 @@ dependencies = [
 [[package]]
 name = "miden-node-block-producer"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#443e42fcc5b5a73e015ce48689c517bca0b59364"
+source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#481cc842fb1ec7c5438b1af40d5d2ab33c518006"
 dependencies = [
  "anyhow",
  "futures",
@@ -1810,7 +1809,7 @@ dependencies = [
  "miden-node-proto",
  "miden-node-utils",
  "miden-objects",
- "miden-processor",
+ "miden-processor 0.13.2",
  "miden-proving-service-client",
  "miden-tx-batch-prover",
  "rand 0.9.1",
@@ -1818,7 +1817,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic 0.12.3",
- "tower-http 0.6.2",
+ "tower-http 0.6.4",
  "tracing",
  "url",
 ]
@@ -1826,7 +1825,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#443e42fcc5b5a73e015ce48689c517bca0b59364"
+source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#481cc842fb1ec7c5438b1af40d5d2ab33c518006"
 dependencies = [
  "anyhow",
  "hex",
@@ -1844,7 +1843,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto-build"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#9ad7bba92f2857dc213118576a2038fe88ba6800"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#481cc842fb1ec7c5438b1af40d5d2ab33c518006"
 dependencies = [
  "anyhow",
  "prost",
@@ -1855,7 +1854,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto-build"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#443e42fcc5b5a73e015ce48689c517bca0b59364"
+source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#481cc842fb1ec7c5438b1af40d5d2ab33c518006"
 dependencies = [
  "anyhow",
  "prost",
@@ -1866,7 +1865,7 @@ dependencies = [
 [[package]]
 name = "miden-node-rpc"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#443e42fcc5b5a73e015ce48689c517bca0b59364"
+source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#481cc842fb1ec7c5438b1af40d5d2ab33c518006"
 dependencies = [
  "anyhow",
  "miden-node-proto",
@@ -1877,14 +1876,14 @@ dependencies = [
  "tokio-stream",
  "tonic 0.12.3",
  "tonic-web",
- "tower-http 0.6.2",
+ "tower-http 0.6.4",
  "tracing",
 ]
 
 [[package]]
 name = "miden-node-store"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#443e42fcc5b5a73e015ce48689c517bca0b59364"
+source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#481cc842fb1ec7c5438b1af40d5d2ab33c518006"
 dependencies = [
  "anyhow",
  "deadpool",
@@ -1900,14 +1899,14 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic 0.12.3",
- "tower-http 0.6.2",
+ "tower-http 0.6.4",
  "tracing",
 ]
 
 [[package]]
 name = "miden-node-utils"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#443e42fcc5b5a73e015ce48689c517bca0b59364"
+source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#481cc842fb1ec7c5438b1af40d5d2ab33c518006"
 dependencies = [
  "anyhow",
  "figment",
@@ -1930,14 +1929,14 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#3d8c3b28048fffbb63592a971d0fcae5dc58bce9"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#291d6620bc157e81f76c37b3dbcfb64ac5f80d8c"
 dependencies = [
  "bech32",
  "getrandom 0.3.3",
  "miden-assembly",
- "miden-core",
+ "miden-core 0.14.0",
  "miden-crypto",
- "miden-processor",
+ "miden-processor 0.14.0",
  "miden-verifier",
  "rand 0.9.1",
  "rand_xoshiro",
@@ -1954,8 +1953,22 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e70b053c587014396d06be3502e3952777923bee11729b7514c060fdc0d2c8"
 dependencies = [
- "miden-air",
- "miden-core",
+ "miden-air 0.13.2",
+ "miden-core 0.13.2",
+ "thiserror 2.0.12",
+ "tracing",
+ "winter-prover",
+]
+
+[[package]]
+name = "miden-processor"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796a5c11589731286ca1cb761b13be13e69e4e0606a5469ce815491989402ea"
+dependencies = [
+ "miden-air 0.14.0",
+ "miden-core 0.14.0",
+ "miden-miette",
  "thiserror 2.0.12",
  "tracing",
  "winter-prover",
@@ -1963,12 +1976,12 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2baa571449e7811e934dae919285dfea4854fb867f6d20d757d60b0601ef0140"
+checksum = "89bc4b989306ca1b8bdba364af72547c563419e77220f4cd244ed2bf3557d351"
 dependencies = [
- "miden-air",
- "miden-processor",
+ "miden-air 0.14.0",
+ "miden-processor 0.14.0",
  "tracing",
  "winter-maybe-async",
  "winter-prover",
@@ -1977,7 +1990,7 @@ dependencies = [
 [[package]]
 name = "miden-proving-service-client"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#3d8c3b28048fffbb63592a971d0fcae5dc58bce9"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#291d6620bc157e81f76c37b3dbcfb64ac5f80d8c"
 dependencies = [
  "async-trait",
  "getrandom 0.3.3",
@@ -1996,18 +2009,18 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e59c4dd1079bffe8407694b386ae781feaf1f7acb9d1cefa858578bc99cad4"
+checksum = "887189ccce4f9bbf15dfdaff0e6842fb138a7432a8f21adde756fac114b07184"
 dependencies = [
  "miden-assembly",
- "miden-core",
+ "miden-core 0.14.0",
 ]
 
 [[package]]
 name = "miden-testing"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#3d8c3b28048fffbb63592a971d0fcae5dc58bce9"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#291d6620bc157e81f76c37b3dbcfb64ac5f80d8c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2015,7 +2028,7 @@ dependencies = [
  "miden-crypto",
  "miden-lib",
  "miden-objects",
- "miden-processor",
+ "miden-processor 0.14.0",
  "miden-tx",
  "rand 0.9.1",
  "rand_chacha 0.9.0",
@@ -2026,12 +2039,12 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#3d8c3b28048fffbb63592a971d0fcae5dc58bce9"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#291d6620bc157e81f76c37b3dbcfb64ac5f80d8c"
 dependencies = [
  "async-trait",
  "miden-lib",
  "miden-objects",
- "miden-processor",
+ "miden-processor 0.14.0",
  "miden-prover",
  "miden-verifier",
  "rand 0.9.1",
@@ -2042,7 +2055,7 @@ dependencies = [
 [[package]]
 name = "miden-tx-batch-prover"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#3d8c3b28048fffbb63592a971d0fcae5dc58bce9"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#291d6620bc157e81f76c37b3dbcfb64ac5f80d8c"
 dependencies = [
  "miden-objects",
  "miden-tx",
@@ -2050,12 +2063,12 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ae024b022569d7117891a83cf51ccd5bceeda248f30690b394a6dfc4607061"
+checksum = "a2b6edc80bf70f276be1c001748c1edf10bea6273a57ee3694fd73d79050fc09"
 dependencies = [
- "miden-air",
- "miden-core",
+ "miden-air 0.14.0",
+ "miden-core 0.14.0",
  "thiserror 2.0.12",
  "tracing",
  "winter-verifier",
@@ -2488,6 +2501,15 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -3457,9 +3479,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3787,9 +3809,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
+checksum = "0fdb0c213ca27a9f57ab69ddb290fd80d970922355b83ae380b395d3986b8a2e"
 dependencies = [
  "bitflags",
  "bytes",
@@ -3996,12 +4018,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -4256,9 +4272,9 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46ec44dc15085cea82cf9c78f85a9114c463a369786585ad2882d1ff0b0acf40"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -4318,18 +4334,18 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b895b5356fc36103d0f64dd1e94dfa7ac5633f1c9dd6e80fe9ec4adef69e09d"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a7ab927b2637c19b3dbe0965e75d8f2d30bdd697a1516191cad2ec4df8fb28a"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]
@@ -4385,11 +4401,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -4414,6 +4446,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4424,6 +4462,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4438,10 +4482,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4456,6 +4512,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4466,6 +4528,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4480,6 +4548,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4490,6 +4564,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
@@ -4623,16 +4703,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "yansi"
@@ -4642,9 +4716,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -4654,9 +4728,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4712,10 +4786,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4724,9 +4809,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default-members = ["crates/rust-client", "bin/miden-cli"]
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.86"
+rust-version = "1.87"
 license = "MIT"
 authors = ["miden contributors"]
 repository = "https://github.com/0xMiden/miden-client"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ repository = "https://github.com/0xMiden/miden-client"
 
 [workspace.dependencies]
 async-trait = "0.1"
-miden-lib = { git = "https://github.com/0xMiden/miden-base", branch = "next", default-features = false }
-miden-objects = { git = "https://github.com/0xMiden/miden-base", branch = "next", default-features = false }
-miden-tx = { git = "https://github.com/0xMiden/miden-base", branch = "next", default-features = false, features = ["async"] }
-miden-proving-service-client = { git = "https://github.com/0xMiden/miden-base", branch = "next",  default-features = false, features = ["tx-prover"] }
+miden-lib = { version = "0.9" , default-features = false }
+miden-objects = { version = "0.9" , default-features = false }
+miden-tx = { version = "0.9" , default-features = false, features = ["async"] }
+miden-proving-service-client = { version = "0.9" ,  default-features = false, features = ["tx-prover"] }
 miette = { version = "7.2", features = ["fancy"] }
 rand = { version = "0.9" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ WARNINGS=RUSTDOCFLAGS="-D warnings"
 
 PROVER_DIR="miden-base"
 PROVER_REPO="https://github.com/0xMiden/miden-base.git"
-PROVER_BRANCH="3d8c3b28048fffbb63592a971d0fcae5dc58bce9"
+PROVER_BRANCH="next"
 PROVER_FEATURES_TESTING=--features "testing"
 PROVER_PORT=50051
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/0xMiden/miden-client/blob/main/LICENSE)
 [![test](https://github.com/0xMiden/miden-client/actions/workflows/test.yml/badge.svg)](https://github.com/0xMiden/miden-client/actions/workflows/test.yml)
 [![build](https://github.com/0xMiden/miden-client/actions/workflows/build.yml/badge.svg)](https://github.com/0xMiden/miden-client/actions/workflows/build.yml)
-[![RUST_VERSION](https://img.shields.io/badge/rustc-1.86+-lightgray.svg)](https://www.rust-lang.org/tools/install)
+[![RUST_VERSION](https://img.shields.io/badge/rustc-1.87+-lightgray.svg)](https://www.rust-lang.org/tools/install)
 [![crates.io](https://img.shields.io/crates/v/miden-client)](https://crates.io/crates/miden-client)
 
 This repository contains the Miden client, which provides a way to execute and prove transactions, facilitating the interaction with the Miden rollup.

--- a/bin/miden-cli/README.md
+++ b/bin/miden-cli/README.md
@@ -4,7 +4,7 @@ This binary allows the user to interact with the Miden rollup via a simple comma
 
 ## Usage
 
-Before you can use the Miden client, you'll need to make sure you have both [Rust](https://www.rust-lang.org/tools/install) and SQLite3 installed. Miden client requires rust version **1.86** or higher.
+Before you can use the Miden client, you'll need to make sure you have both [Rust](https://www.rust-lang.org/tools/install) and SQLite3 installed. Miden client requires rust version **1.87** or higher.
 
 ### Running `miden-client`'s CLI
 

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -63,7 +63,7 @@ web-sys = { version = "0.3", features = ["console", "Window", "Storage"] }
 miden-client = { path = ".", features = ["testing", "concurrent", "sqlite", "tonic"] }
 miden-lib = { workspace = true, features = ["testing"] }
 miden-objects = { workspace = true, default-features = false, features = ["testing"] }
-miden-testing = { git = "https://github.com/0xMiden/miden-base", branch = "next", default-features = false, features = ["async"] }
+miden-testing = { version = "0.9" , default-features = false, features = ["async"] }
 tokio = { workspace = true }
 uuid = { version = "1.10", features = ["serde", "v4"] }
 web-sys = { version = "0.3", features = ["console"]}

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -74,6 +74,7 @@ use core::fmt::{self};
 use miden_objects::{
     AssetError, Digest, Felt, Word,
     account::{Account, AccountCode, AccountDelta, AccountId},
+    assembly::DefaultSourceManager,
     asset::{Asset, NonFungibleAsset},
     block::BlockNumber,
     note::{Note, NoteDetails, NoteId, NoteTag},
@@ -550,7 +551,13 @@ impl Client {
         // Execute the transaction and get the witness
         let executed_transaction = self
             .tx_executor
-            .execute_transaction(account_id, block_num, notes, tx_args)
+            .execute_transaction(
+                account_id,
+                block_num,
+                notes,
+                tx_args,
+                Arc::new(DefaultSourceManager::default()), // TODO: Use the correct source manager
+            )
             .await?;
 
         // Check that the expected output notes matches the transaction outcome.
@@ -1024,6 +1031,7 @@ impl Client {
                 tx_script,
                 advice_inputs,
                 foreign_account_inputs,
+                Arc::new(DefaultSourceManager::default()), // TODO: Use the correct source manager
             )
             .await?)
     }

--- a/crates/web-client/test/new_transactions.test.ts
+++ b/crates/web-client/test/new_transactions.test.ts
@@ -296,7 +296,7 @@ export const customTransaction = async (
                 mem_loadw
                 # => [NOTE_ARG_1]
 
-                push.${expectedNoteArg1} assert_eqw.err=101
+                push.${expectedNoteArg1} assert_eqw.err="First note argument didn't match expected"
                 # => []
 
                 # read second word
@@ -305,15 +305,15 @@ export const customTransaction = async (
                 mem_loadw
                 # => [NOTE_ARG_2]
 
-                push.${expectedNoteArg2} assert_eqw.err=102
+                push.${expectedNoteArg2} assert_eqw.err="Second note argument didn't match expected"
                 # => []
 
                 # store the note inputs to memory starting at address 0
                 push.0 exec.note::get_inputs
                 # => [num_inputs, inputs_ptr]
 
-                # make sure the number of inputs is 1
-                eq.2 assert.err=103
+                # make sure the number of inputs is 2
+                eq.2 assert.err="P2ID script expects exactly 2 note inputs"
                 # => [inputs_ptr]
 
                 # read the target account id from the note inputs
@@ -324,7 +324,7 @@ export const customTransaction = async (
                 # => [account_id_prefix, target_account_id_prefix, ...]
 
                 # ensure account_id = target_account_id, fails otherwise
-                assert_eq.err=104
+                assert_eq.err="P2ID's target account address and transaction address do not match"
                 # => [...]
 
                 exec.add_note_assets_to_account

--- a/docs/src/install-and-run.md
+++ b/docs/src/install-and-run.md
@@ -1,6 +1,6 @@
 ## Software prerequisites
 
-- [Rust installation](https://www.rust-lang.org/tools/install) minimum version 1.86.
+- [Rust installation](https://www.rust-lang.org/tools/install) minimum version 1.87.
 
 ## Install the client
 

--- a/tests/integration/asm/custom_p2id.masm
+++ b/tests/integration/asm/custom_p2id.masm
@@ -83,7 +83,7 @@ begin
     mem_loadw
     # => [NOTE_ARG_1]
     
-    push.{expected_note_arg_1} assert_eqw.err=101
+    push.{expected_note_arg_1} assert_eqw.err="First note argument didn't match expected"
     # => []
 
     # read second word
@@ -92,15 +92,15 @@ begin
     mem_loadw
     # => [NOTE_ARG_2]
 
-    push.{expected_note_arg_2} assert_eqw.err=102
+    push.{expected_note_arg_2} assert_eqw.err="Second note argument didn't match expected"
     # => []
 
     # store the note inputs to memory starting at address 0
     push.0 exec.note::get_inputs
     # => [num_inputs, inputs_ptr]
 
-    # make sure the number of inputs is 1
-    eq.2 assert.err=103
+    # make sure the number of inputs is 2
+    eq.2 assert.err="P2ID script expects exactly 2 note inputs"
     # => [inputs_ptr]
 
     # read the target account id from the note inputs
@@ -111,7 +111,7 @@ begin
     # => [account_id_prefix, target_account_id_prefix, ...]
 
     # ensure account_id = target_account_id, fails otherwise
-    assert_eq.err=104
+    assert_eq.err="P2ID's target account address and transaction address do not match"
     # => [...]
 
     exec.add_note_assets_to_account

--- a/tests/integration/custom_transactions_tests.rs
+++ b/tests/integration/custom_transactions_tests.rs
@@ -200,7 +200,7 @@ async fn test_merkle_store() {
             push.4000 push.{pos} exec.mmr::get
 
             # check the element matches what was inserted at `pos`
-            push.{expected_element} assert_eqw.err=999
+            push.{expected_element} assert_eqw.err=\"element in merkle store didn't match expected\"
         "
         )
         .as_str();


### PR DESCRIPTION
This PR brings the updates from https://github.com/0xMiden/miden-base/pull/1353 to the client.

One of the main changes is the introduction of the `SourceManager` for the executor. Right now we are just using the default implementation, but ideally we would use the source manager from the assembler used to compile code. The main problem with this is that generally we compile code with freshly instantiated assemblers each time (e.g. for account/note/transaction code) and we mostly don't have access to each one. 

We should look to refactor `miden-base` and `miden-client` to allow to share assemblers at every stage so that the used `SourceManager` can contain all the debug information.