### PR TITLE
feat: Add HTTP ACCEPT header support to web client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,7 +1625,7 @@ dependencies = [
  "toml",
  "tonic 0.13.1",
  "tonic-build 0.13.1",
- "tonic-web-wasm-client 0.7.0",
+ "tonic-web-wasm-client 0.7.1",
  "tracing",
  "uuid",
  "wasm-bindgen",
@@ -3712,9 +3712,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-web-wasm-client"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12abe1160d2a9a3e4bf578e2e37fd8b4f65c5e64fca6037d6f1ed6c0e02a78ac"
+checksum = "66e3bb7acca55e6790354be650f4042d418fcf8e2bc42ac382348f2b6bf057e5"
 dependencies = [
  "base64",
  "byteorder",

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ WARNINGS=RUSTDOCFLAGS="-D warnings"
 
 PROVER_DIR="miden-base"
 PROVER_REPO="https://github.com/0xMiden/miden-base.git"
-PROVER_BRANCH="next"
+PROVER_BRANCH="main"
 PROVER_FEATURES_TESTING=--features "testing"
 PROVER_PORT=50051
 

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -48,7 +48,7 @@ serde = { workspace = true, optional = true }
 serde-wasm-bindgen = { version = "0.6", optional = true }
 thiserror = { workspace = true }
 tonic = { version = "0.13", default-features = false, features = ["prost", "codegen"] }
-tonic-web-wasm-client = { version = "0.7", optional = true, default-features = false }
+tonic-web-wasm-client = { version = "0.7.1", optional = true, default-features = false }
 tracing = { workspace = true }
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"], optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }

--- a/crates/rust-client/src/rpc/tonic_client/api_client.rs
+++ b/crates/rust-client/src/rpc/tonic_client/api_client.rs
@@ -1,6 +1,5 @@
-use core::ops::{Deref, DerefMut};
-
 use alloc::string::String;
+use core::ops::{Deref, DerefMut};
 
 use api_client_wrapper::{ApiClient, InnerClient};
 use tonic::{
@@ -11,8 +10,8 @@ use tonic::{
 // WEB CLIENT
 // ================================================================================================
 
-//#[cfg(all(not(target_arch = "wasm32"), feature = "web-tonic"))]
-//compile_error!("The `web-tonic` feature is only supported when targeting wasm32.");
+#[cfg(all(not(target_arch = "wasm32"), feature = "web-tonic"))]
+compile_error!("The `web-tonic` feature is only supported when targeting wasm32.");
 
 #[cfg(feature = "web-tonic")]
 pub(crate) mod api_client_wrapper {

--- a/crates/rust-client/src/rpc/tonic_client/api_client.rs
+++ b/crates/rust-client/src/rpc/tonic_client/api_client.rs
@@ -1,5 +1,8 @@
+use core::ops::{Deref, DerefMut};
+
 use alloc::string::String;
 
+use api_client_wrapper::{ApiClient, InnerClient};
 use tonic::{
     metadata::{AsciiMetadataValue, errors::InvalidMetadataValue},
     service::Interceptor,
@@ -41,10 +44,7 @@ pub(crate) mod api_client_wrapper {
 #[cfg(feature = "tonic")]
 pub(crate) mod api_client_wrapper {
     use alloc::{boxed::Box, string::String};
-    use core::{
-        ops::{Deref, DerefMut},
-        time::Duration,
-    };
+    use core::time::Duration;
 
     use tonic::{service::interceptor::InterceptedService, transport::Channel};
 
@@ -78,18 +78,18 @@ pub(crate) mod api_client_wrapper {
             Ok(ApiClient(ProtoClient::with_interceptor(channel, interceptor)))
         }
     }
+}
 
-    impl Deref for ApiClient {
-        type Target = InnerClient;
-        fn deref(&self) -> &Self::Target {
-            &self.0
-        }
+impl Deref for ApiClient {
+    type Target = InnerClient;
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
+}
 
-    impl DerefMut for ApiClient {
-        fn deref_mut(&mut self) -> &mut Self::Target {
-            &mut self.0
-        }
+impl DerefMut for ApiClient {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 


### PR DESCRIPTION
Closes #921

### Context

We added server-side enforcement of ACCEPT headers in https://github.com/0xMiden/miden-node/pull/844.

We added support for HTTP ACCEPT header requests for the rust-client in #912.

We found that the web-client was already using the ACCEPT header by default. So we had to relax the enforcement of the header value in https://github.com/0xMiden/miden-node/pull/866.

In this PR, we are adding the HTTP ACCEPT header to web-client requests. The intention is to override the default web-client header found [here](https://github.com/devashishdxt/tonic-web-wasm-client/blob/75762cbc8777d4c493648983e94f014e25e6af6b/src/call.rs#L44-L46).