### PR TITLE
fix: various CLI issues

### DIFF
--- a/bin/miden-cli/src/commands/sync.rs
+++ b/bin/miden-cli/src/commands/sync.rs
@@ -12,6 +12,7 @@ impl SyncCmd {
         let new_details = client.sync_state().await?;
 
         println!("State synced to block {}", new_details.block_num);
+        println!("New public notes: {}", new_details.new_public_notes.len());
         println!("Committed notes: {}", new_details.committed_notes.len());
         println!("Tracked notes consumed: {}", new_details.consumed_notes.len());
         println!("Tracked accounts updated: {}", new_details.updated_accounts.len());

--- a/bin/miden-cli/tests/cli.rs
+++ b/bin/miden-cli/tests/cli.rs
@@ -571,11 +571,14 @@ fn sync_cli(cli_path: &Path) -> u64 {
         if output.status.success() {
             let updated_notes = String::from_utf8(output.stdout)
                 .unwrap()
-                .split_whitespace()
-                .skip_while(|&word| word != "notes:")
-                .find(|word| word.parse::<u64>().is_ok())
-                .unwrap()
-                .parse()
+                .lines()
+                .find_map(|line| {
+                    if let Some(rest) = line.strip_prefix("Committed notes: ") {
+                        rest.trim().parse::<u64>().ok()
+                    } else {
+                        None
+                    }
+                })
                 .unwrap();
 
             return updated_notes;

--- a/crates/rust-client/src/rpc/mod.rs
+++ b/crates/rust-client/src/rpc/mod.rs
@@ -100,7 +100,7 @@ pub trait NodeRpcClient: Send + Sync {
     async fn submit_proven_transaction(
         &self,
         proven_transaction: ProvenTransaction,
-    ) -> Result<(), RpcError>;
+    ) -> Result<BlockNumber, RpcError>;
 
     /// Given a block number, fetches the block header corresponding to that height from the node
     /// using the `/GetBlockHeaderByNumber` endpoint.

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -86,21 +86,21 @@ impl NodeRpcClient for TonicRpcClient {
     async fn submit_proven_transaction(
         &self,
         proven_transaction: ProvenTransaction,
-    ) -> Result<(), RpcError> {
+    ) -> Result<BlockNumber, RpcError> {
         let request = SubmitProvenTransactionRequest {
             transaction: proven_transaction.to_bytes(),
         };
 
         let mut rpc_api = self.ensure_connected().await?;
 
-        rpc_api.submit_proven_transaction(request).await.map_err(|err| {
+        let api_response = rpc_api.submit_proven_transaction(request).await.map_err(|err| {
             RpcError::RequestError(
                 NodeRpcClientEndpoint::SubmitProvenTx.to_string(),
                 err.to_string(),
             )
         })?;
 
-        Ok(())
+        Ok(BlockNumber::from(api_response.into_inner().block_height))
     }
 
     async fn get_block_header_by_number(

--- a/crates/rust-client/src/store/sqlite_store/transaction.rs
+++ b/crates/rust-client/src/store/sqlite_store/transaction.rs
@@ -152,6 +152,7 @@ impl SqliteStore {
             input_note_nullifiers: nullifiers,
             output_notes: output_notes.clone(),
             block_num: executed_transaction.block_header().block_num(),
+            submition_height: tx_update.submition_height(),
             expiration_block_num: executed_transaction.expiration_block_num(),
         };
 

--- a/crates/rust-client/src/store/sqlite_store/transaction.rs
+++ b/crates/rust-client/src/store/sqlite_store/transaction.rs
@@ -152,7 +152,7 @@ impl SqliteStore {
             input_note_nullifiers: nullifiers,
             output_notes: output_notes.clone(),
             block_num: executed_transaction.block_header().block_num(),
-            submition_height: tx_update.submition_height(),
+            submission_height: tx_update.submission_height(),
             expiration_block_num: executed_transaction.expiration_block_num(),
         };
 

--- a/crates/rust-client/src/store/web_store/transaction/mod.rs
+++ b/crates/rust-client/src/store/web_store/transaction/mod.rs
@@ -94,7 +94,7 @@ impl WebStore {
         // Transaction Data
         insert_proven_transaction_data(
             tx_update.executed_transaction(),
-            tx_update.submition_height(),
+            tx_update.submission_height(),
         )
         .await?;
 

--- a/crates/rust-client/src/store/web_store/transaction/mod.rs
+++ b/crates/rust-client/src/store/web_store/transaction/mod.rs
@@ -92,7 +92,11 @@ impl WebStore {
         tx_update: TransactionStoreUpdate,
     ) -> Result<(), StoreError> {
         // Transaction Data
-        insert_proven_transaction_data(tx_update.executed_transaction()).await?;
+        insert_proven_transaction_data(
+            tx_update.executed_transaction(),
+            tx_update.submition_height(),
+        )
+        .await?;
 
         // Account Data
         update_account(tx_update.updated_account()).await.map_err(|err| {

--- a/crates/rust-client/src/store/web_store/transaction/utils.rs
+++ b/crates/rust-client/src/store/web_store/transaction/utils.rs
@@ -5,6 +5,7 @@ use alloc::{
 
 use miden_objects::{
     Digest,
+    block::BlockNumber,
     transaction::{ExecutedTransaction, ToInputNoteCommitments, TransactionScript},
 };
 use miden_tx::utils::Serializable;
@@ -33,6 +34,7 @@ pub struct SerializedTransactionData {
 
 pub async fn insert_proven_transaction_data(
     executed_transaction: &ExecutedTransaction,
+    submition_height: BlockNumber,
 ) -> Result<(), StoreError> {
     // Build transaction record
     let nullifiers: Vec<Digest> = executed_transaction
@@ -50,6 +52,7 @@ pub async fn insert_proven_transaction_data(
         input_note_nullifiers: nullifiers,
         output_notes: output_notes.clone(),
         block_num: executed_transaction.block_header().block_num(),
+        submition_height,
         expiration_block_num: executed_transaction.expiration_block_num(),
     };
 

--- a/crates/rust-client/src/store/web_store/transaction/utils.rs
+++ b/crates/rust-client/src/store/web_store/transaction/utils.rs
@@ -32,9 +32,11 @@ pub struct SerializedTransactionData {
 
 // ================================================================================================
 
+/// Converts an `ExecutedTransaction` into a `TransactionRecord` and inserts it into the store.
+/// `submission_height` is the block number at which the transaction was submitted to the network.
 pub async fn insert_proven_transaction_data(
     executed_transaction: &ExecutedTransaction,
-    submition_height: BlockNumber,
+    submission_height: BlockNumber,
 ) -> Result<(), StoreError> {
     // Build transaction record
     let nullifiers: Vec<Digest> = executed_transaction
@@ -52,7 +54,7 @@ pub async fn insert_proven_transaction_data(
         input_note_nullifiers: nullifiers,
         output_notes: output_notes.clone(),
         block_num: executed_transaction.block_header().block_num(),
-        submition_height,
+        submission_height,
         expiration_block_num: executed_transaction.expiration_block_num(),
     };
 

--- a/crates/rust-client/src/sync/state_sync_update.rs
+++ b/crates/rust-client/src/sync/state_sync_update.rs
@@ -203,7 +203,7 @@ impl TransactionUpdateTracker {
         if let Some(tx_graceful_blocks) = tx_graceful_blocks {
             self.discard_transaction_with_predicate(
                 |transaction| {
-                    transaction.details.block_num
+                    transaction.details.submition_height
                         < new_sync_height.checked_sub(tx_graceful_blocks).unwrap_or_default()
                 },
                 DiscardCause::Stale,

--- a/crates/rust-client/src/sync/state_sync_update.rs
+++ b/crates/rust-client/src/sync/state_sync_update.rs
@@ -203,7 +203,7 @@ impl TransactionUpdateTracker {
         if let Some(tx_graceful_blocks) = tx_graceful_blocks {
             self.discard_transaction_with_predicate(
                 |transaction| {
-                    transaction.details.submition_height
+                    transaction.details.submission_height
                         < new_sync_height.checked_sub(tx_graceful_blocks).unwrap_or_default()
                 },
                 DiscardCause::Stale,

--- a/crates/rust-client/src/test_utils/mock.rs
+++ b/crates/rust-client/src/test_utils/mock.rs
@@ -299,7 +299,7 @@ impl NodeRpcClient for MockRpcApi {
     async fn submit_proven_transaction(
         &self,
         proven_transaction: ProvenTransaction,
-    ) -> Result<(), RpcError> {
+    ) -> Result<BlockNumber, RpcError> {
         // TODO: add some basic validations to test error cases
         let notes: Vec<OutputNote> = proven_transaction.output_notes().iter().cloned().collect();
 
@@ -316,7 +316,7 @@ impl NodeRpcClient for MockRpcApi {
             account_id: Some(proven_transaction.account_id().into()),
         });
 
-        Ok(())
+        Ok(self.get_chain_tip_block_num())
     }
 
     async fn get_account_details(

--- a/docs/src/get-started/create-account-use-faucet.md
+++ b/docs/src/get-started/create-account-use-faucet.md
@@ -103,6 +103,7 @@ You will see something like this as output:
 
 ```sh
 State synced to block 179672
+New public notes: 0
 Committed notes: 1
 Tracked notes consumed: 0
 Tracked accounts updated: 0


### PR DESCRIPTION
Found a couple of issues when testing the CLI with the released node:
1. The `miden sync` was not showing the new `new_public_notes` field.
2. Transactions were using the sync height to test for staleness but they should use submition height.