### PR TITLE
Fix the rollup.config.js wasm-opt args

### DIFF
--- a/crates/web-client/rollup.config.js
+++ b/crates/web-client/rollup.config.js
@@ -5,6 +5,11 @@ import copy from "rollup-plugin-copy";
 
 // Flag that indicates if the build is meant for testing purposes.
 const testing = process.env.MIDEN_WEB_TESTING === "true";
+const wasmOptArgs = [
+  "-O4",
+  "--enable-bulk-memory",
+  "--enable-nontrapping-float-to-int",
+];
 
 /**
  * Rollup configuration file for building a Cargo project and creating a WebAssembly (WASM) module,
@@ -48,13 +53,17 @@ export default [
             `build.rustflags=["-C", "target-feature=+atomics,+bulk-memory,+mutable-globals", "-C", "link-arg=--max-memory=4294967296"]`,
             "--no-default-features",
           ],
-          wasmOpt: testing
-            ? ["-O0", "--enable-threads", "--enable-bulk-memory-opt"]
-            : ["--enable-threads", "--enable-bulk-memory-opt"],
+          // We need to pass an invalid flag to silently skip the wasm optimization
+          // The correct way of doing this is to build the wasm with the optimize: { release: false }
+          // but building the wasm with the dev profile fails due to a too many locals error
+          // And the plugin doesn't allow us to directly skip the wasm-opt step or specify a non-release/dev profile
+          // We should change this when this issue is fixed: https://github.com/wasm-tool/rollup-plugin-rust/issues/50
+          ...(testing ? { wasmOpt: ["--an-invalid-option"]} : { wasmOpt: wasmOptArgs }),
         },
         experimental: {
           typescriptDeclarationDir: "dist/crates",
         },
+        optimize: { release: true, rustc: true },
       }),
       resolve(),
       commonjs(),


### PR DESCRIPTION
The issue with wasmOpt has been resolved by removing the invalid option `--enable-bulk-memory-opt`. This option caused Wasmopt to fail silently with a warning, resulting in a successful build despite the failure.

To resolve this issue, the solution was to remove the invalid option, allowing WasmOpt to function correctly. 
Although this change increases the build time by approximately 45 seconds to a minute, it results in a significant improvement in performance. 

In testing, this change yielded around a 25% faster improvement for creating new wallets.

I tested it with this branch: https://github.com/demox-labs/miden-client/tree/investigate/account-slow 
For the wasm call to `createWallet` for a private immutable wallet without a seed:

Before:
```
Average: 7313.53ms
Min: 765.74ms
Max: 33621.57ms
All timings: 10912.93, 12244.78, 1240.48, 787.17, 6073.67, 6873.93, 33621.57, 4326.34, 2115.14, 11700.06, 6459.99, 2962.37, 7196.78, 765.74, 5637.33, 3007.66, 2522.94, 9537.67, 20903.81, 1208.49, 5120.15, 2987.92, 11692.99, 6880.08, 6058.19
```

After:
```
Average: 5254.26ms
Min: 758.00ms
Max: 16598.55ms
All timings: 1233.97, 9275.52, 5779.14, 2297.96, 1168.27, 758.00, 6212.18, 768.31, 2421.03, 7895.36, 4496.00, 8637.89, 10762.14, 1597.08, 4943.79, 5783.90, 9524.69, 9044.50, 2862.70, 7428.73, 4969.38, 759.30, 4510.98, 1627.14, 16598.55
```
