### PR TITLE
Pass in StdRng instead of FeltRng for new SecretKey

### DIFF
--- a/crates/web-client/src/helpers.rs
+++ b/crates/web-client/src/helpers.rs
@@ -28,20 +28,20 @@ pub(crate) async fn generate_wallet(
     mutable: bool,
     seed: Option<Vec<u8>>,
 ) -> Result<(Account, [Felt; 4], SecretKey), JsValue> {
-    let mut rng: &mut Box<dyn FeltRng> = match seed {
+    let mut rng = match seed {
         Some(seed_bytes) => {
             // Attempt to convert the seed slice into a 32-byte array.
             let seed_array: [u8; 32] = seed_bytes
                 .try_into()
                 .map_err(|_| JsValue::from_str("Seed must be exactly 32 bytes"))?;
-            let mut std_rng = StdRng::from_seed(seed_array);
-            let coin_seed: [u64; 4] = std_rng.random();
-            &mut (Box::new(RpoRandomCoin::new(coin_seed.map(Felt::new))) as Box<dyn FeltRng>)
+            StdRng::from_seed(seed_array)
         },
-        None => client.rng().inner_mut(),
+        None => StdRng::from_os_rng(),
     };
     let key_pair = SecretKey::with_rng(&mut rng);
 
+    let coin_seed: [u64; 4] = rng.random();
+    let mut rng = Box::new(RpoRandomCoin::new(coin_seed.map(Felt::new)));
     let mut init_seed = [0u8; 32];
     rng.fill_bytes(&mut init_seed);
 


### PR DESCRIPTION
## Summary

The goal of this PR is to address the issue of slow wallet creation: https://github.com/0xMiden/miden-client/issues/892. Currently, creating a new wallet takes approximately 8 seconds, which is unacceptably slow. This change reduces the creation time to under a second. The primary problem lies in the fact that a FeltRng was being passed to SecretKey::with_rng. In a wasm context, FeltRng is significantly slower than StdRng, with a performance difference of at least 10x.

It's not ready to merge without a discussion as it will remove the ability to restore for users who already created accounts.

## Discussion

1. The first question is, why are we using a FeltRng as opposed to a StdRng when it seems like in both the cases of the web client and the CLI, we are actually using an StdRng to initialize a FeltRng? In the cases where we use a FeltRng, we can always recreate it from the StdRng, so why are we saving a reference in the Rust client to a FeltRng. 
2. The second major question is why are we storing a reference to an RNG at all in the client. It really isn't clear to me why the entire client needs a single seed.
- It seems like in the cases where you want a new wallet, we should just sample randomness as we need it. 
- And in the cases where you want to restore an account from a seed, we should pass in the seed to that method specifically. 

## Investigation

I added a bunch of logging to the client to figure out what was slow in this branch: https://github.com/demox-labs/miden-client/tree/investigate/account-slow
I found that 95%+ of the time is spent in the SecretKey generation. 

I created this benchmark in the miden crypto library: https://github.com/demox-labs/crypto/tree/investigate/account-slow
Below is a screenshot of the results

<img width="881" alt="Screenshot 2025-05-30 at 5 01 16 PM" src="https://github.com/user-attachments/assets/0fd2c7df-68c0-47ac-ad00-88d91b0d29e8" />


