### PR TITLE
docs: locked install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ CODEGEN=CODEGEN=1
 
 FEATURES_WEB_CLIENT=--features "testing"
 FEATURES_CLIENT=--features "testing, concurrent" --no-default-features
-FEATURES_CLI=--features "concurrent"
 WARNINGS=RUSTDOCFLAGS="-D warnings"
 
 PROVER_DIR="miden-base"
@@ -26,7 +25,7 @@ PROVER_PORT=50051
 
 .PHONY: clippy
  clippy: ## Run Clippy with configs
-	cargo clippy --workspace --exclude miden-client-web --all-targets $(FEATURES_CLI) -- -D warnings
+	cargo clippy --workspace --exclude miden-client-web --all-targets -- -D warnings
 
 .PHONY: clippy-wasm
  clippy-wasm: ## Run Clippy for the miden-client-web package
@@ -34,7 +33,7 @@ PROVER_PORT=50051
 
 .PHONY: fix
 fix: ## Run Fix with configs
-	cargo +nightly fix --workspace --exclude miden-client-web --allow-staged --allow-dirty --all-targets $(FEATURES_CLI)
+	cargo +nightly fix --workspace --exclude miden-client-web --allow-staged --allow-dirty --all-targets
 
 .PHONY: fix-wasm
 fix-wasm: ## Run Fix for the miden-client-web package
@@ -94,7 +93,7 @@ stop-node: ## Stop the testing node server
 
 .PHONY: integration-test
 integration-test: ## Run integration tests
-	$(CODEGEN) cargo nextest run --workspace --exclude miden-client-web --release --test=integration $(FEATURES_CLI)
+	$(CODEGEN) cargo nextest run --workspace --exclude miden-client-web --release --test=integration
 
 .PHONY: integration-test-web-client
 integration-test-web-client: ## Run integration tests for the web client
@@ -106,8 +105,8 @@ integration-test-remote-prover-web-client: ## Run integration tests for the web 
 
 .PHONY: integration-test-full
 integration-test-full: ## Run the integration test binary with ignored tests included
-	$(CODEGEN) cargo nextest run --workspace --exclude miden-client-web --release --test=integration $(FEATURES_CLI)
-	cargo nextest run --workspace --exclude miden-client-web --release --test=integration $(FEATURES_CLI) --run-ignored ignored-only -- test_import_genesis_accounts_can_be_used_for_transactions
+	$(CODEGEN) cargo nextest run --workspace --exclude miden-client-web --release --test=integration
+	cargo nextest run --workspace --exclude miden-client-web --release --test=integration --run-ignored ignored-only -- test_import_genesis_accounts_can_be_used_for_transactions
 
 .PHONY: clean-prover
 clean-prover: ## Uninstall prover
@@ -139,12 +138,12 @@ kill-prover: ## Kill prover process
 # --- Installing ----------------------------------------------------------------------------------
 
 install: ## Install the CLI binary
-	cargo install $(FEATURES_CLI) --path bin/miden-cli --locked
+	cargo install --path bin/miden-cli --locked
 
 # --- Building ------------------------------------------------------------------------------------
 
 build: ## Build the CLI binary and client library in release mode
-	CODEGEN=1 cargo build --workspace --exclude miden-client-web --release $(FEATURES_CLI)
+	CODEGEN=1 cargo build --workspace --exclude miden-client-web --release
 
 build-wasm: ## Build the client library for wasm32
 	CODEGEN=1 cargo build --package miden-client-web --target wasm32-unknown-unknown $(FEATURES_WEB_CLIENT)
@@ -153,7 +152,7 @@ build-wasm: ## Build the client library for wasm32
 
 .PHONY: check
 check: ## Build the CLI binary and client library in release mode
-	cargo check --workspace --exclude miden-client-web --release $(FEATURES_CLI)
+	cargo check --workspace --exclude miden-client-web --release
 
 .PHONY: check-wasm
 check-wasm: ## Build the client library for wasm32

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ test-docs: ## Run documentation tests
 
 .PHONY: start-node
 start-node: ## Start the testing node server
-	RUST_LOG=info cargo run --release --package node-builder
+	RUST_LOG=info cargo run --release --package node-builder --locked
 
 .PHONY: start-node-background
 start-node-background: ## Start the testing node server in background

--- a/bin/miden-cli/Cargo.toml
+++ b/bin/miden-cli/Cargo.toml
@@ -21,12 +21,10 @@ workspace = true
 
 [features]
 default = []
-concurrent = ["miden-client/concurrent"]
 
 [[test]]
 name = "integration"
 path = "tests/cli.rs"
-required-features = ["concurrent"]
 
 [dev-dependencies]
 assert_cmd = { version = "2.0" }

--- a/bin/miden-cli/README.md
+++ b/bin/miden-cli/README.md
@@ -11,17 +11,15 @@ Before you can use the Miden client, you'll need to make sure you have both [Rus
 You can either build from source with:
 
 ```bash
-cargo build --release --features "concurrent" --locked
+cargo build --release --locked
 ```
-
-The `concurrent` feature is enabled to improve execution and proving times.
 
 Once the binary is built, you can find it on `./target/release/miden`.
 
 Or you can install the CLI from crates.io with:
 
 ```bash
-cargo install --features "concurrent" miden-cli --locked
+cargo install miden-cli --locked
 ```
 
 These actions can also be executed when inside the repository via the Makefile with `make build` or `make install`.

--- a/bin/miden-cli/README.md
+++ b/bin/miden-cli/README.md
@@ -11,7 +11,7 @@ Before you can use the Miden client, you'll need to make sure you have both [Rus
 You can either build from source with:
 
 ```bash
-cargo build --release --features "concurrent"
+cargo build --release --features "concurrent" --locked
 ```
 
 The `concurrent` feature is enabled to improve execution and proving times.
@@ -21,7 +21,7 @@ Once the binary is built, you can find it on `./target/release/miden`.
 Or you can install the CLI from crates.io with:
 
 ```bash
-cargo install --features "concurrent" miden-cli
+cargo install --features "concurrent" miden-cli --locked
 ```
 
 These actions can also be executed when inside the repository via the Makefile with `make build` or `make install`.

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["lib"]
 workspace = true
 
 [features]
-concurrent = ["miden-tx/concurrent"]
+concurrent = ["miden-tx/concurrent", "std"]
 default = ["std", "tonic/channel"]
 idxdb = ["dep:base64", "dep:serde-wasm-bindgen", "dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:serde", "dep:getrandom"]
 sqlite = ["dep:rusqlite", "dep:deadpool", "dep:deadpool-sync", "dep:rusqlite_migration", "std"]

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -19,11 +19,11 @@ crate-type = ["lib"]
 workspace = true
 
 [features]
-concurrent = ["miden-tx/concurrent", "std"]
+concurrent = ["miden-tx/concurrent"]
 default = ["std", "tonic/channel"]
 idxdb = ["dep:base64", "dep:serde-wasm-bindgen", "dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:serde", "dep:getrandom"]
 sqlite = ["dep:rusqlite", "dep:deadpool", "dep:deadpool-sync", "dep:rusqlite_migration", "std"]
-std = ["miden-objects/std","miden-proving-service-client/std"]
+std = ["miden-objects/std", "miden-proving-service-client/std", "concurrent"]
 testing = ["miden-objects/testing", "miden-lib/testing", "miden-tx/testing", "dep:miden-testing", "dep:uuid", "dep:toml"]
 tonic = ["std", "tonic/transport", "tonic/tls-ring", "tonic/tls-native-roots"]
 web-tonic = ["dep:tonic-web-wasm-client", "dep:getrandom"]

--- a/docs/src/get-started/create-account-use-faucet.md
+++ b/docs/src/get-started/create-account-use-faucet.md
@@ -17,7 +17,7 @@ The Miden client facilitates interaction with the Miden rollup and provides a wa
 2. Install the Miden client.
 
       ```shell
-      cargo install miden-cli --features concurrent
+      cargo install miden-cli --features concurrent --locked
       ```
       You can now use the `miden --version` command, and you should see `Miden 0.9.0`.
 

--- a/docs/src/get-started/create-account-use-faucet.md
+++ b/docs/src/get-started/create-account-use-faucet.md
@@ -17,7 +17,7 @@ The Miden client facilitates interaction with the Miden rollup and provides a wa
 2. Install the Miden client.
 
       ```shell
-      cargo install miden-cli --features concurrent --locked
+      cargo install miden-cli --locked
       ```
       You can now use the `miden --version` command, and you should see `Miden 0.9.0`.
 

--- a/docs/src/install-and-run.md
+++ b/docs/src/install-and-run.md
@@ -4,19 +4,13 @@
 
 ## Install the client
 
-We currently recommend installing and running the client with the [`concurrent`](#concurrent-feature) feature.
-
 Run the following command to install the miden-client:
 
 ```sh
-cargo install miden-cli --features concurrent --locked
+cargo install miden-cli --locked
 ```
 
-This installs the `miden` binary (at `~/.cargo/bin/miden`) with the [`concurrent`](#concurrent-feature) feature.
-
-### `Concurrent` feature
-
-The `concurrent` flag enables optimizations that result in faster transaction execution and proving times.
+This installs the `miden` binary (at `~/.cargo/bin/miden`).
 
 ## Run the client
 

--- a/docs/src/install-and-run.md
+++ b/docs/src/install-and-run.md
@@ -9,7 +9,7 @@ We currently recommend installing and running the client with the [`concurrent`]
 Run the following command to install the miden-client:
 
 ```sh
-cargo install miden-cli --features concurrent
+cargo install miden-cli --features concurrent --locked
 ```
 
 This installs the `miden` binary (at `~/.cargo/bin/miden`) with the [`concurrent`](#concurrent-feature) feature.

--- a/scripts/start-node-bg.sh
+++ b/scripts/start-node-bg.sh
@@ -2,12 +2,12 @@
 
 # Starts the node in the background and checks that it has not exited
 
-if ! cargo build --release --package node-builder; then
+if ! cargo build --release --package node-builder --locked; then
     echo "Failed to build node server";
     exit 1;
 fi;
 
-RUST_LOG=none cargo run --release --package node-builder & echo $! > .node.pid;
+RUST_LOG=none cargo run --release --package node-builder --locked & echo $! > .node.pid;
 sleep 4;
 if ! ps -p $(cat .node.pid) > /dev/null; then
     echo "Failed to start node server";


### PR DESCRIPTION
Updates the documentation to specify using lock files when installing/building. Addressing [this last comment](https://github.com/0xMiden/miden-node/issues/940#issuecomment-2958003501)