### PR TITLE
fix: remove `.once` from web test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
@@ -363,9 +363,9 @@ checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
 
 [[package]]
 name = "byteorder"
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "chrono"
@@ -432,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -442,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstream",
  "anstyle",
@@ -454,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -466,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "colorchoice"
@@ -484,7 +484,7 @@ checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
 dependencies = [
  "crossterm",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.1",
 ]
 
 [[package]]
@@ -952,9 +952,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -967,7 +967,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -978,9 +978,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1243,7 +1243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -1372,7 +1372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.0",
+ "windows-targets 0.53.1",
 ]
 
 [[package]]
@@ -1523,7 +1523,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f8cc7106155f10bdf99a6f379688f543ad6596a415375b36a59a054ceda1198"
 dependencies = [
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -1574,13 +1574,13 @@ dependencies = [
  "smallvec",
  "thiserror 2.0.12",
  "tracing",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.1",
 ]
 
 [[package]]
 name = "miden-block-prover"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#8946d59db9639ce44ccd66c136ec44193e618c9e"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
 dependencies = [
  "miden-lib",
  "miden-objects",
@@ -1602,7 +1602,7 @@ dependencies = [
  "miden-lib",
  "miden-node-proto-build",
  "miden-objects",
- "miden-proving-service-client",
+ "miden-proving-service-client 0.10.0 (git+https://github.com/0xMiden/miden-node?branch=igamigo-midenp-lib-nostd)",
  "miden-testing",
  "miden-tx",
  "miette",
@@ -1729,7 +1729,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#8946d59db9639ce44ccd66c136ec44193e618c9e"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -1784,7 +1784,7 @@ dependencies = [
 [[package]]
 name = "miden-node-block-producer"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#55658aaa0a4fcd1b698d59fc2bdd39735587424d"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#46b2b71b12aad1df9a74fb045b2672cdd4bc6c35"
 dependencies = [
  "anyhow",
  "futures",
@@ -1792,9 +1792,10 @@ dependencies = [
  "miden-block-prover",
  "miden-lib",
  "miden-node-proto",
+ "miden-node-proto-build",
  "miden-node-utils",
  "miden-objects",
- "miden-proving-service-client",
+ "miden-proving-service-client 0.10.0 (git+https://github.com/0xMiden/miden-node?branch=next)",
  "miden-tx",
  "miden-tx-batch-prover",
  "rand 0.9.1",
@@ -1802,6 +1803,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic 0.12.3",
+ "tonic-reflection",
  "tower-http 0.6.6",
  "tracing",
  "url",
@@ -1810,7 +1812,7 @@ dependencies = [
 [[package]]
 name = "miden-node-ntx-builder"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#55658aaa0a4fcd1b698d59fc2bdd39735587424d"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#46b2b71b12aad1df9a74fb045b2672cdd4bc6c35"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1818,15 +1820,17 @@ dependencies = [
  "lru",
  "miden-lib",
  "miden-node-proto",
+ "miden-node-proto-build",
  "miden-node-utils",
  "miden-objects",
- "miden-proving-service-client",
+ "miden-proving-service-client 0.10.0 (git+https://github.com/0xMiden/miden-node?branch=next)",
  "miden-tx",
  "rand 0.9.1",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tonic 0.12.3",
+ "tonic-reflection",
  "tower-http 0.6.6",
  "tracing",
  "url",
@@ -1835,7 +1839,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#55658aaa0a4fcd1b698d59fc2bdd39735587424d"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#46b2b71b12aad1df9a74fb045b2672cdd4bc6c35"
 dependencies = [
  "anyhow",
  "hex",
@@ -1854,7 +1858,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto-build"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#55658aaa0a4fcd1b698d59fc2bdd39735587424d"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#46b2b71b12aad1df9a74fb045b2672cdd4bc6c35"
 dependencies = [
  "anyhow",
  "prost",
@@ -1865,12 +1869,13 @@ dependencies = [
 [[package]]
 name = "miden-node-rpc"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#55658aaa0a4fcd1b698d59fc2bdd39735587424d"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#46b2b71b12aad1df9a74fb045b2672cdd4bc6c35"
 dependencies = [
  "anyhow",
  "futures",
  "http",
  "miden-node-proto",
+ "miden-node-proto-build",
  "miden-node-utils",
  "miden-objects",
  "miden-tx",
@@ -1879,6 +1884,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic 0.12.3",
+ "tonic-reflection",
  "tonic-web",
  "tower 0.5.2",
  "tower-http 0.6.6",
@@ -1889,7 +1895,7 @@ dependencies = [
 [[package]]
 name = "miden-node-store"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#55658aaa0a4fcd1b698d59fc2bdd39735587424d"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#46b2b71b12aad1df9a74fb045b2672cdd4bc6c35"
 dependencies = [
  "anyhow",
  "deadpool",
@@ -1897,6 +1903,7 @@ dependencies = [
  "hex",
  "miden-lib",
  "miden-node-proto",
+ "miden-node-proto-build",
  "miden-node-utils",
  "miden-objects",
  "rusqlite",
@@ -1905,6 +1912,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic 0.12.3",
+ "tonic-reflection",
  "tower-http 0.6.6",
  "tracing",
 ]
@@ -1912,7 +1920,7 @@ dependencies = [
 [[package]]
 name = "miden-node-utils"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#55658aaa0a4fcd1b698d59fc2bdd39735587424d"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#46b2b71b12aad1df9a74fb045b2672cdd4bc6c35"
 dependencies = [
  "anyhow",
  "figment",
@@ -1935,7 +1943,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#8946d59db9639ce44ccd66c136ec44193e618c9e"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
 dependencies = [
  "bech32",
  "getrandom 0.3.3",
@@ -1983,7 +1991,27 @@ dependencies = [
 [[package]]
 name = "miden-proving-service-client"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#8946d59db9639ce44ccd66c136ec44193e618c9e"
+source = "git+https://github.com/0xMiden/miden-node?branch=igamigo-midenp-lib-nostd#0535d4f226a90108a4ddd707c316cd34dc0e39bc"
+dependencies = [
+ "async-trait",
+ "getrandom 0.3.3",
+ "miden-objects",
+ "miden-tx",
+ "miette",
+ "prost",
+ "prost-build",
+ "protox 0.7.2",
+ "thiserror 2.0.12",
+ "tokio",
+ "tonic 0.12.3",
+ "tonic-build 0.12.3",
+ "tonic-web-wasm-client 0.6.2",
+]
+
+[[package]]
+name = "miden-proving-service-client"
+version = "0.10.0"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#46b2b71b12aad1df9a74fb045b2672cdd4bc6c35"
 dependencies = [
  "async-trait",
  "getrandom 0.3.3",
@@ -2013,7 +2041,7 @@ dependencies = [
 [[package]]
 name = "miden-testing"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#8946d59db9639ce44ccd66c136ec44193e618c9e"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2032,7 +2060,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#8946d59db9639ce44ccd66c136ec44193e618c9e"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
 dependencies = [
  "async-trait",
  "miden-lib",
@@ -2048,7 +2076,7 @@ dependencies = [
 [[package]]
 name = "miden-tx-batch-prover"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#8946d59db9639ce44ccd66c136ec44193e618c9e"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
 dependencies = [
  "miden-objects",
  "miden-tx",
@@ -2111,9 +2139,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
@@ -2935,9 +2963,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustc-hash"
@@ -3325,9 +3353,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3424,7 +3452,7 @@ checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "smawk",
  "unicode-linebreak",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.1",
 ]
 
 [[package]]
@@ -3689,6 +3717,19 @@ dependencies = [
  "prost-types",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tonic-reflection"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "878d81f52e7fcfd80026b7fdb6a9b578b3c3653ba987f87f0dce4b64043cba27"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.12.3",
 ]
 
 [[package]]
@@ -4000,9 +4041,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "unicode-xid"
@@ -4261,9 +4302,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
+checksum = "e2b85ac982d24496e0b49912479da8a89c0ba7b1d8bf6de49df12af42e94b325"
 dependencies = [
  "windows-collections",
  "windows-core",
@@ -4329,9 +4370,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "d3bfe459f85da17560875b8bf1423d6f113b7a87a5d942e7da0ac71be7c61f8b"
 
 [[package]]
 name = "windows-numerics"
@@ -4421,9 +4462,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "30357ec391cde730f8fbfcdc29adc47518b06504528df977ab5af02ef23fdee9"
 dependencies = [
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1372,7 +1372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.1",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "miden-block-prover"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#e6fa50d819d68571d49055db479301546de08a8f"
 dependencies = [
  "miden-lib",
  "miden-objects",
@@ -1602,7 +1602,7 @@ dependencies = [
  "miden-lib",
  "miden-node-proto-build",
  "miden-objects",
- "miden-proving-service-client 0.10.0 (git+https://github.com/0xMiden/miden-node?branch=igamigo-midenp-lib-nostd)",
+ "miden-proving-service-client",
  "miden-testing",
  "miden-tx",
  "miette",
@@ -1729,7 +1729,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#e6fa50d819d68571d49055db479301546de08a8f"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -1784,7 +1784,7 @@ dependencies = [
 [[package]]
 name = "miden-node-block-producer"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#46b2b71b12aad1df9a74fb045b2672cdd4bc6c35"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#831b9098b4bd2531121135a3ef190c781acd22d1"
 dependencies = [
  "anyhow",
  "futures",
@@ -1795,7 +1795,7 @@ dependencies = [
  "miden-node-proto-build",
  "miden-node-utils",
  "miden-objects",
- "miden-proving-service-client 0.10.0 (git+https://github.com/0xMiden/miden-node?branch=next)",
+ "miden-proving-service-client",
  "miden-tx",
  "miden-tx-batch-prover",
  "rand 0.9.1",
@@ -1812,7 +1812,7 @@ dependencies = [
 [[package]]
 name = "miden-node-ntx-builder"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#46b2b71b12aad1df9a74fb045b2672cdd4bc6c35"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#831b9098b4bd2531121135a3ef190c781acd22d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1823,7 +1823,7 @@ dependencies = [
  "miden-node-proto-build",
  "miden-node-utils",
  "miden-objects",
- "miden-proving-service-client 0.10.0 (git+https://github.com/0xMiden/miden-node?branch=next)",
+ "miden-proving-service-client",
  "miden-tx",
  "rand 0.9.1",
  "thiserror 2.0.12",
@@ -1839,7 +1839,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#46b2b71b12aad1df9a74fb045b2672cdd4bc6c35"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#831b9098b4bd2531121135a3ef190c781acd22d1"
 dependencies = [
  "anyhow",
  "hex",
@@ -1858,7 +1858,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto-build"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#46b2b71b12aad1df9a74fb045b2672cdd4bc6c35"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#831b9098b4bd2531121135a3ef190c781acd22d1"
 dependencies = [
  "anyhow",
  "prost",
@@ -1869,7 +1869,7 @@ dependencies = [
 [[package]]
 name = "miden-node-rpc"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#46b2b71b12aad1df9a74fb045b2672cdd4bc6c35"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#831b9098b4bd2531121135a3ef190c781acd22d1"
 dependencies = [
  "anyhow",
  "futures",
@@ -1895,7 +1895,7 @@ dependencies = [
 [[package]]
 name = "miden-node-store"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#46b2b71b12aad1df9a74fb045b2672cdd4bc6c35"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#831b9098b4bd2531121135a3ef190c781acd22d1"
 dependencies = [
  "anyhow",
  "deadpool",
@@ -1920,7 +1920,7 @@ dependencies = [
 [[package]]
 name = "miden-node-utils"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#46b2b71b12aad1df9a74fb045b2672cdd4bc6c35"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#831b9098b4bd2531121135a3ef190c781acd22d1"
 dependencies = [
  "anyhow",
  "figment",
@@ -1943,7 +1943,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#e6fa50d819d68571d49055db479301546de08a8f"
 dependencies = [
  "bech32",
  "getrandom 0.3.3",
@@ -1991,27 +1991,7 @@ dependencies = [
 [[package]]
 name = "miden-proving-service-client"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=igamigo-midenp-lib-nostd#0535d4f226a90108a4ddd707c316cd34dc0e39bc"
-dependencies = [
- "async-trait",
- "getrandom 0.3.3",
- "miden-objects",
- "miden-tx",
- "miette",
- "prost",
- "prost-build",
- "protox 0.7.2",
- "thiserror 2.0.12",
- "tokio",
- "tonic 0.12.3",
- "tonic-build 0.12.3",
- "tonic-web-wasm-client 0.6.2",
-]
-
-[[package]]
-name = "miden-proving-service-client"
-version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#46b2b71b12aad1df9a74fb045b2672cdd4bc6c35"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#831b9098b4bd2531121135a3ef190c781acd22d1"
 dependencies = [
  "async-trait",
  "getrandom 0.3.3",
@@ -2041,7 +2021,7 @@ dependencies = [
 [[package]]
 name = "miden-testing"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#e6fa50d819d68571d49055db479301546de08a8f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2060,7 +2040,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#e6fa50d819d68571d49055db479301546de08a8f"
 dependencies = [
  "async-trait",
  "miden-lib",
@@ -2076,7 +2056,7 @@ dependencies = [
 [[package]]
 name = "miden-tx-batch-prover"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#e6fa50d819d68571d49055db479301546de08a8f"
 dependencies = [
  "miden-objects",
  "miden-tx",
@@ -2861,9 +2841,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags",
 ]
@@ -4302,9 +4282,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.61.2"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b85ac982d24496e0b49912479da8a89c0ba7b1d8bf6de49df12af42e94b325"
+checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
 dependencies = [
  "windows-collections",
  "windows-core",
@@ -4370,9 +4350,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.2"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3bfe459f85da17560875b8bf1423d6f113b7a87a5d942e7da0ac71be7c61f8b"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-numerics"
@@ -4462,9 +4442,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30357ec391cde730f8fbfcdc29adc47518b06504528df977ab5af02ef23fdee9"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
 dependencies = [
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ miden-lib = { git = "https://github.com/0xMiden/miden-base", branch = "next" , d
 miden-objects = { git = "https://github.com/0xMiden/miden-base", branch = "next" , default-features = false }
 miden-tx = { git = "https://github.com/0xMiden/miden-base", branch = "next" , default-features = false, features = ["async"] }
 miden-testing = { git = "https://github.com/0xMiden/miden-base", branch = "next" , default-features = false, features = ["async"] }
-miden-proving-service-client = { git = "https://github.com/0xMiden/miden-base", branch = "next" ,  default-features = false, features = ["tx-prover"] }
+miden-proving-service-client = { git = "https://github.com/0xMiden/miden-node", branch = "igamigo-midenp-lib-nostd" ,  default-features = false, features = ["tx-prover"] }
 miette = { version = "7.2", features = ["fancy"] }
 rand = { version = "0.9" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ miden-lib = { git = "https://github.com/0xMiden/miden-base", branch = "next" , d
 miden-objects = { git = "https://github.com/0xMiden/miden-base", branch = "next" , default-features = false }
 miden-tx = { git = "https://github.com/0xMiden/miden-base", branch = "next" , default-features = false, features = ["async"] }
 miden-testing = { git = "https://github.com/0xMiden/miden-base", branch = "next" , default-features = false, features = ["async"] }
-miden-proving-service-client = { git = "https://github.com/0xMiden/miden-node", branch = "igamigo-midenp-lib-nostd" ,  default-features = false, features = ["tx-prover"] }
+miden-proving-service-client = { git = "https://github.com/0xMiden/miden-node", branch = "next" ,  default-features = false, features = ["tx-prover"] }
 miette = { version = "7.2", features = ["fancy"] }
 rand = { version = "0.9" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ update-prover-branch: setup-miden-base ## Checkout and update the specified bran
 
 .PHONY: build-prover
 build-prover: update-prover-branch ## Build the prover binary with specified features
-	cd $(PROVER_DIR) && cargo build -p miden-proving-service --locked --release
+	cd $(PROVER_DIR) && cargo update && cargo build -p miden-proving-service --locked --release
 
 .PHONY: start-prover
 start-prover: ## Run prover. This requires the base repo to be present at `miden-base`

--- a/bin/miden-cli/tests/cli.rs
+++ b/bin/miden-cli/tests/cli.rs
@@ -13,8 +13,8 @@ use miden_client::{
     account::{AccountId, AccountStorageMode},
     crypto::{FeltRng, RpoRandomCoin},
     note::{
-        Note, NoteAssets, NoteExecutionHint, NoteExecutionMode, NoteFile, NoteId, NoteInputs,
-        NoteMetadata, NoteRecipient, NoteTag, NoteType,
+        Note, NoteAssets, NoteExecutionHint, NoteFile, NoteId, NoteInputs, NoteMetadata,
+        NoteRecipient, NoteTag, NoteType,
     },
     rpc::{Endpoint, TonicRpcClient},
     store::sqlite_store::SqliteStore,
@@ -468,7 +468,7 @@ async fn debug_mode_outputs_logs() {
     let note_metadata = NoteMetadata::new(
         account.id(),
         NoteType::Private,
-        NoteTag::from_account_id(account.id(), NoteExecutionMode::Local).unwrap(),
+        NoteTag::from_account_id(account.id()),
         NoteExecutionHint::None,
         Felt::default(),
     )

--- a/crates/rust-client/src/account/mod.rs
+++ b/crates/rust-client/src/account/mod.rs
@@ -132,7 +132,7 @@ impl Client {
             None => {
                 // If the account is not being tracked, insert it into the store regardless of the
                 // `overwrite` flag
-                self.store.add_note_tag(account.try_into()?).await?;
+                self.store.add_note_tag(account.into()).await?;
 
                 self.store
                     .insert_account(account, account_seed)

--- a/crates/rust-client/src/note/note_screener.rs
+++ b/crates/rust-client/src/note/note_screener.rs
@@ -134,7 +134,7 @@ impl<'a> NoteScreener<'a> {
         let input_notes = InputNotes::new(vec![InputNote::unauthenticated(note.clone())])
             .expect("Single note should be valid");
 
-        self.mast_store.load_transaction_code(account.code(), &input_notes, &tx_args);
+        self.mast_store.load_account_code(account.code());
 
         if let NoteAccountExecution::Success = self
             .consumption_checker

--- a/crates/rust-client/src/sync/tag.rs
+++ b/crates/rust-client/src/sync/tag.rs
@@ -1,9 +1,8 @@
 use alloc::{string::ToString, vec::Vec};
 
 use miden_objects::{
-    NoteError,
     account::{Account, AccountId},
-    note::{NoteExecutionMode, NoteId, NoteTag},
+    note::{NoteId, NoteTag},
 };
 use miden_tx::utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 use tracing::warn;
@@ -145,12 +144,8 @@ impl TryInto<NoteTagRecord> for &InputNoteRecord {
     }
 }
 
-impl TryInto<NoteTagRecord> for &Account {
-    type Error = NoteError;
-    fn try_into(self) -> Result<NoteTagRecord, Self::Error> {
-        Ok(NoteTagRecord::with_account_source(
-            NoteTag::from_account_id(self.id(), NoteExecutionMode::Local)?,
-            self.id(),
-        ))
+impl From<&Account> for NoteTagRecord {
+    fn from(account: &Account) -> Self {
+        NoteTagRecord::with_account_source(NoteTag::from_account_id(account.id()), account.id())
     }
 }

--- a/crates/rust-client/src/tests.rs
+++ b/crates/rust-client/src/tests.rs
@@ -22,10 +22,7 @@ use miden_objects::{
         dsa::rpo_falcon512::SecretKey,
         rand::{FeltRng, RpoRandomCoin},
     },
-    note::{
-        Note, NoteAssets, NoteExecutionHint, NoteExecutionMode, NoteFile, NoteMetadata, NoteTag,
-        NoteType,
-    },
+    note::{Note, NoteAssets, NoteExecutionHint, NoteFile, NoteMetadata, NoteTag, NoteType},
     testing::account_id::{
         ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1, ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_2,
         ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE,
@@ -763,7 +760,7 @@ async fn test_note_without_asset() {
     // Create note without assets
     let serial_num = client.rng().draw_word();
     let recipient = utils::build_p2id_recipient(wallet.id(), serial_num).unwrap();
-    let tag = NoteTag::from_account_id(wallet.id(), NoteExecutionMode::Local).unwrap();
+    let tag = NoteTag::from_account_id(wallet.id());
     let metadata =
         NoteMetadata::new(wallet.id(), NoteType::Private, tag, NoteExecutionHint::always(), ZERO)
             .unwrap();

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -623,7 +623,7 @@ impl Client {
             .await?
             .ok_or(ClientError::AccountDataNotFound(account_id))?;
         let account: Account = account_record.into();
-        self.mast_store.load_transaction_code(account.code(), &notes, &tx_args);
+        self.mast_store.load_account_code(account.code());
 
         if ignore_invalid_notes {
             // Remove invalid notes

--- a/crates/rust-client/src/transaction/request/builder.rs
+++ b/crates/rust-client/src/transaction/request/builder.rs
@@ -8,7 +8,7 @@ use miden_objects::{
     asset::{Asset, FungibleAsset},
     block::BlockNumber,
     crypto::merkle::{InnerNodeInfo, MerkleStore},
-    note::{Note, NoteDetails, NoteExecutionMode, NoteId, NoteTag, NoteType, PartialNote},
+    note::{Note, NoteDetails, NoteId, NoteTag, NoteType, PartialNote},
     transaction::{OutputNote, TransactionScript},
     vm::AdviceMap,
 };
@@ -348,8 +348,7 @@ impl TransactionRequestBuilder {
             rng,
         )?;
 
-        let payback_tag =
-            NoteTag::from_account_id(swap_data.account_id(), NoteExecutionMode::Local)?;
+        let payback_tag = NoteTag::from_account_id(swap_data.account_id());
 
         self.with_expected_future_notes(vec![(payback_note_details, payback_tag)])
             .with_own_output_notes(vec![OutputNote::Full(created_note)])

--- a/crates/rust-client/src/transaction/request/mod.rs
+++ b/crates/rust-client/src/transaction/request/mod.rs
@@ -348,7 +348,7 @@ mod tests {
         account::{AccountBuilder, AccountId, AccountType},
         asset::FungibleAsset,
         crypto::rand::{FeltRng, RpoRandomCoin},
-        note::{NoteExecutionMode, NoteTag, NoteType},
+        note::{NoteTag, NoteType},
         testing::{
             account_component::AccountMockComponent,
             account_id::{
@@ -406,7 +406,7 @@ mod tests {
             .with_expected_output_notes(vec![notes.pop().unwrap()])
             .with_expected_future_notes(vec![(
                 notes.pop().unwrap().into(),
-                NoteTag::from_account_id(sender_id, NoteExecutionMode::Local).unwrap(),
+                NoteTag::from_account_id(sender_id),
             )])
             .extend_advice_map(advice_vec)
             .with_foreign_accounts([

--- a/crates/web-client/package.json
+++ b/crates/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demox-labs/miden-sdk",
-  "version": "0.10.0",
+  "version": "0.10.0-next.1",
   "description": "Miden Wasm SDK",
   "collaborators": [
     "Miden",

--- a/crates/web-client/src/models/note.rs
+++ b/crates/web-client/src/models/note.rs
@@ -1,7 +1,7 @@
 use miden_client::note::{
-    NoteExecutionHint as NativeNoteExecutionHint, NoteExecutionMode as NativeNoteExecutionMode,
-    NoteInputs as NativeNoteInputs, NoteMetadata as NativeNoteMetadata,
-    NoteRecipient as NativeNoteRecipient, NoteTag as NativeNoteTag, WellKnownNote,
+    NoteExecutionHint as NativeNoteExecutionHint, NoteInputs as NativeNoteInputs,
+    NoteMetadata as NativeNoteMetadata, NoteRecipient as NativeNoteRecipient,
+    NoteTag as NativeNoteTag, WellKnownNote,
 };
 use miden_lib::note::utils;
 use miden_objects::note::Note as NativeNote;
@@ -53,11 +53,7 @@ impl Note {
         aux: &Felt,
     ) -> Self {
         let recipient = utils::build_p2id_recipient(target.into(), serial_num.into()).unwrap();
-        let tag = NativeNoteTag::from_account_id(
-            target.into(),
-            miden_client::note::NoteExecutionMode::Local,
-        )
-        .unwrap();
+        let tag = NativeNoteTag::from_account_id(target.into());
 
         let metadata = NativeNoteMetadata::new(
             sender.into(),
@@ -92,8 +88,7 @@ impl Note {
 
         let recipient = NativeNoteRecipient::new(serial_num.into(), note_script, inputs);
 
-        let tag =
-            NativeNoteTag::from_account_id(target.into(), NativeNoteExecutionMode::Local).unwrap();
+        let tag = NativeNoteTag::from_account_id(target.into());
 
         let metadata = NativeNoteMetadata::new(
             sender.into(),

--- a/crates/web-client/src/models/note_tag.rs
+++ b/crates/web-client/src/models/note_tag.rs
@@ -13,11 +13,9 @@ pub struct NoteTag(NativeNoteTag);
 #[wasm_bindgen]
 impl NoteTag {
     #[wasm_bindgen(js_name = "fromAccountId")]
-    pub fn from_account_id(account_id: &AccountId, execution: &NoteExecutionMode) -> NoteTag {
+    pub fn from_account_id(account_id: &AccountId) -> NoteTag {
         let native_account_id: NativeAccountId = account_id.into();
-        let native_execution: NativeNoteExecutionMode = execution.into();
-        let native_note_tag =
-            NativeNoteTag::from_account_id(native_account_id, native_execution).unwrap();
+        let native_note_tag = NativeNoteTag::from_account_id(native_account_id);
         NoteTag(native_note_tag)
     }
 

--- a/crates/web-client/test/fpi.test.ts
+++ b/crates/web-client/test/fpi.test.ts
@@ -152,7 +152,7 @@ export const testStandardFpi = async (): Promise<void> => {
 };
 
 describe("fpi test", () => {
-  it.only("runs the standard fpi test successfully", async () => {
+  it("runs the standard fpi test successfully", async () => {
     await expect(testStandardFpi()).to.be.fulfilled;
   }).timeout(50000);
 });

--- a/docs/src/web-client/api/classes/NoteTag.md
+++ b/docs/src/web-client/api/classes/NoteTag.md
@@ -84,17 +84,13 @@
 
 ### fromAccountId()
 
-> `static` **fromAccountId**(`account_id`, `execution`): `NoteTag`
+> `static` **fromAccountId**(`account_id`): `NoteTag`
 
 #### Parameters
 
 ##### account\_id
 
 [`AccountId`](AccountId.md)
-
-##### execution
-
-[`NoteExecutionMode`](NoteExecutionMode.md)
 
 #### Returns
 

--- a/tests/src/custom_transactions_tests.rs
+++ b/tests/src/custom_transactions_tests.rs
@@ -15,10 +15,7 @@ use miden_objects::{
         merkle::{MerkleStore, MerkleTree, NodeIndex},
         rand::{FeltRng, RpoRandomCoin},
     },
-    note::{
-        Note, NoteAssets, NoteExecutionMode, NoteInputs, NoteMetadata, NoteRecipient, NoteTag,
-        NoteType,
-    },
+    note::{Note, NoteAssets, NoteInputs, NoteMetadata, NoteRecipient, NoteTag, NoteType},
     transaction::OutputNote,
     vm::AdviceMap,
 };
@@ -263,7 +260,7 @@ async fn test_onchain_notes_sync_with_tag() {
     let note_metadata = NoteMetadata::new(
         basic_account_1.id(),
         NoteType::Public,
-        NoteTag::from_account_id(basic_account_1.id(), NoteExecutionMode::Local).unwrap(),
+        NoteTag::from_account_id(basic_account_1.id()),
         NoteExecutionHint::None,
         Default::default(),
     )
@@ -283,9 +280,7 @@ async fn test_onchain_notes_sync_with_tag() {
 
     // Load tag into client 2
     client_2
-        .add_note_tag(
-            NoteTag::from_account_id(basic_account_1.id(), NoteExecutionMode::Local).unwrap(),
-        )
+        .add_note_tag(NoteTag::from_account_id(basic_account_1.id()))
         .await
         .unwrap();
 
@@ -343,7 +338,7 @@ fn create_custom_note(
     let note_metadata = NoteMetadata::new(
         faucet_account_id,
         NoteType::Private,
-        NoteTag::from_account_id(target_account_id, NoteExecutionMode::Local).unwrap(),
+        NoteTag::from_account_id(target_account_id),
         NoteExecutionHint::None,
         Default::default(),
     )

--- a/tests/src/onchain_tests.rs
+++ b/tests/src/onchain_tests.rs
@@ -4,7 +4,7 @@ use miden_client::{
     Felt, Word, ZERO,
     account::{Account, AccountBuilder, StorageSlot, build_wallet_id},
     auth::AuthSecretKey,
-    note::{NoteExecutionMode, NoteTag},
+    note::NoteTag,
     store::{InputNoteState, NoteFilter},
     testing::{common::*, note::NoteBuilder},
     transaction::{
@@ -523,11 +523,7 @@ async fn test_counter_contract_ntx() {
                     call.counter_contract::increment_count
                 end",
                 )
-                .tag(
-                    NoteTag::from_account_id(network_account.id(), NoteExecutionMode::Network)
-                        .unwrap()
-                        .into(),
-                )
+                .tag(NoteTag::from_account_id(network_account.id()).into())
                 .build(&assembler)
                 .unwrap(),
         ));


### PR DESCRIPTION
It seems that a `.once` test was accidentally added in https://github.com/0xMiden/miden-client/pull/958. This meant that the web tests were running that single test instead of the whole suite.