### PR TITLE
refactor: remove `TransactionExecutor` from client and note screener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [BREAKING] Renamed `miden-cli` crate to `miden-client-cli`, and the `miden` executable to `miden-client` (#960).
 * [BREAKING] Merged `concurrent` feature with `std` (#974).
 * [BREAKING] Changed `TransactionRequest` to use expected output recipients instead of output notes (#976).
+* [BREAKING] Removed `TransactionExecutor` from `Client` and `NoteScreener` (#998).
 
 ### Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,9 +904,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1199,9 +1199,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1541,7 +1541,7 @@ dependencies = [
 [[package]]
 name = "miden-block-prover"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#2daf42f0ed56d74cb45ceaca19bb82269d15839c"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#d6ce850950d20bef72a55f73136b45a9f683daf2"
 dependencies = [
  "miden-lib",
  "miden-objects",
@@ -1563,7 +1563,7 @@ dependencies = [
  "miden-lib",
  "miden-node-proto-build",
  "miden-objects",
- "miden-proving-service-client",
+ "miden-remote-prover-client",
  "miden-testing",
  "miden-tx",
  "miette",
@@ -1690,7 +1690,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#2daf42f0ed56d74cb45ceaca19bb82269d15839c"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#d6ce850950d20bef72a55f73136b45a9f683daf2"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -1745,7 +1745,7 @@ dependencies = [
 [[package]]
 name = "miden-node-block-producer"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-update-map-entries#7d6206387751a1c7c9a3a6ac542f616450406537"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#5130f7512558334d20e1d14c82cf96bd01c0c424"
 dependencies = [
  "anyhow",
  "futures",
@@ -1756,7 +1756,7 @@ dependencies = [
  "miden-node-proto-build",
  "miden-node-utils",
  "miden-objects",
- "miden-proving-service-client",
+ "miden-remote-prover-client",
  "miden-tx",
  "miden-tx-batch-prover",
  "rand 0.9.1",
@@ -1773,7 +1773,7 @@ dependencies = [
 [[package]]
 name = "miden-node-ntx-builder"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-update-map-entries#7d6206387751a1c7c9a3a6ac542f616450406537"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#5130f7512558334d20e1d14c82cf96bd01c0c424"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1784,7 +1784,7 @@ dependencies = [
  "miden-node-proto-build",
  "miden-node-utils",
  "miden-objects",
- "miden-proving-service-client",
+ "miden-remote-prover-client",
  "miden-tx",
  "rand 0.9.1",
  "thiserror 2.0.12",
@@ -1800,7 +1800,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-update-map-entries#7d6206387751a1c7c9a3a6ac542f616450406537"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#5130f7512558334d20e1d14c82cf96bd01c0c424"
 dependencies = [
  "anyhow",
  "hex",
@@ -1819,7 +1819,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto-build"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-update-map-entries#7d6206387751a1c7c9a3a6ac542f616450406537"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#5130f7512558334d20e1d14c82cf96bd01c0c424"
 dependencies = [
  "anyhow",
  "prost",
@@ -1830,7 +1830,7 @@ dependencies = [
 [[package]]
 name = "miden-node-rpc"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-update-map-entries#7d6206387751a1c7c9a3a6ac542f616450406537"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#5130f7512558334d20e1d14c82cf96bd01c0c424"
 dependencies = [
  "anyhow",
  "futures",
@@ -1856,7 +1856,7 @@ dependencies = [
 [[package]]
 name = "miden-node-store"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-update-map-entries#7d6206387751a1c7c9a3a6ac542f616450406537"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#5130f7512558334d20e1d14c82cf96bd01c0c424"
 dependencies = [
  "anyhow",
  "deadpool",
@@ -1881,7 +1881,7 @@ dependencies = [
 [[package]]
 name = "miden-node-utils"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-update-map-entries#7d6206387751a1c7c9a3a6ac542f616450406537"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#5130f7512558334d20e1d14c82cf96bd01c0c424"
 dependencies = [
  "anyhow",
  "figment",
@@ -1905,7 +1905,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#2daf42f0ed56d74cb45ceaca19bb82269d15839c"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#d6ce850950d20bef72a55f73136b45a9f683daf2"
 dependencies = [
  "bech32",
  "getrandom 0.3.3",
@@ -1951,9 +1951,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "miden-proving-service-client"
+name = "miden-remote-prover-client"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-update-map-entries#7d6206387751a1c7c9a3a6ac542f616450406537"
+source = "git+https://github.com/0xMiden/miden-node?branch=next#5130f7512558334d20e1d14c82cf96bd01c0c424"
 dependencies = [
  "async-trait",
  "getrandom 0.3.3",
@@ -1984,7 +1984,7 @@ dependencies = [
 [[package]]
 name = "miden-testing"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#2daf42f0ed56d74cb45ceaca19bb82269d15839c"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#d6ce850950d20bef72a55f73136b45a9f683daf2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2002,7 +2002,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#2daf42f0ed56d74cb45ceaca19bb82269d15839c"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#d6ce850950d20bef72a55f73136b45a9f683daf2"
 dependencies = [
  "async-trait",
  "miden-lib",
@@ -2018,7 +2018,7 @@ dependencies = [
 [[package]]
 name = "miden-tx-batch-prover"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#2daf42f0ed56d74cb45ceaca19bb82269d15839c"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#d6ce850950d20bef72a55f73136b45a9f683daf2"
 dependencies = [
  "miden-objects",
  "miden-tx",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,6 +1214,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,7 +1552,7 @@ dependencies = [
 [[package]]
 name = "miden-block-prover"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#d6ce850950d20bef72a55f73136b45a9f683daf2"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#a57860a99430dbfbae6b04860637b2af7e70bed9"
 dependencies = [
  "miden-lib",
  "miden-objects",
@@ -1690,7 +1701,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#d6ce850950d20bef72a55f73136b45a9f683daf2"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#a57860a99430dbfbae6b04860637b2af7e70bed9"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -1745,7 +1756,7 @@ dependencies = [
 [[package]]
 name = "miden-node-block-producer"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#5130f7512558334d20e1d14c82cf96bd01c0c424"
+source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-update-lexicographic-words#35acee5d6f23e40d791da2cdb3df5283d372a084"
 dependencies = [
  "anyhow",
  "futures",
@@ -1773,7 +1784,7 @@ dependencies = [
 [[package]]
 name = "miden-node-ntx-builder"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#5130f7512558334d20e1d14c82cf96bd01c0c424"
+source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-update-lexicographic-words#35acee5d6f23e40d791da2cdb3df5283d372a084"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1800,7 +1811,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#5130f7512558334d20e1d14c82cf96bd01c0c424"
+source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-update-lexicographic-words#35acee5d6f23e40d791da2cdb3df5283d372a084"
 dependencies = [
  "anyhow",
  "hex",
@@ -1819,7 +1830,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto-build"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#5130f7512558334d20e1d14c82cf96bd01c0c424"
+source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-update-lexicographic-words#35acee5d6f23e40d791da2cdb3df5283d372a084"
 dependencies = [
  "anyhow",
  "prost",
@@ -1830,7 +1841,7 @@ dependencies = [
 [[package]]
 name = "miden-node-rpc"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#5130f7512558334d20e1d14c82cf96bd01c0c424"
+source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-update-lexicographic-words#35acee5d6f23e40d791da2cdb3df5283d372a084"
 dependencies = [
  "anyhow",
  "futures",
@@ -1856,7 +1867,7 @@ dependencies = [
 [[package]]
 name = "miden-node-store"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#5130f7512558334d20e1d14c82cf96bd01c0c424"
+source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-update-lexicographic-words#35acee5d6f23e40d791da2cdb3df5283d372a084"
 dependencies = [
  "anyhow",
  "deadpool",
@@ -1881,7 +1892,7 @@ dependencies = [
 [[package]]
 name = "miden-node-utils"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#5130f7512558334d20e1d14c82cf96bd01c0c424"
+source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-update-lexicographic-words#35acee5d6f23e40d791da2cdb3df5283d372a084"
 dependencies = [
  "anyhow",
  "figment",
@@ -1905,7 +1916,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#d6ce850950d20bef72a55f73136b45a9f683daf2"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#a57860a99430dbfbae6b04860637b2af7e70bed9"
 dependencies = [
  "bech32",
  "getrandom 0.3.3",
@@ -1953,7 +1964,7 @@ dependencies = [
 [[package]]
 name = "miden-remote-prover-client"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#5130f7512558334d20e1d14c82cf96bd01c0c424"
+source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-update-lexicographic-words#35acee5d6f23e40d791da2cdb3df5283d372a084"
 dependencies = [
  "async-trait",
  "getrandom 0.3.3",
@@ -1984,7 +1995,7 @@ dependencies = [
 [[package]]
 name = "miden-testing"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#d6ce850950d20bef72a55f73136b45a9f683daf2"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#a57860a99430dbfbae6b04860637b2af7e70bed9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1995,6 +2006,7 @@ dependencies = [
  "miden-tx",
  "rand 0.9.1",
  "rand_chacha 0.9.0",
+ "thiserror 2.0.12",
  "winter-maybe-async",
  "winterfell",
 ]
@@ -2002,7 +2014,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#d6ce850950d20bef72a55f73136b45a9f683daf2"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#a57860a99430dbfbae6b04860637b2af7e70bed9"
 dependencies = [
  "async-trait",
  "miden-lib",
@@ -2018,7 +2030,7 @@ dependencies = [
 [[package]]
 name = "miden-tx-batch-prover"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#d6ce850950d20bef72a55f73136b45a9f683daf2"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#a57860a99430dbfbae6b04860637b2af7e70bed9"
 dependencies = [
  "miden-objects",
  "miden-tx",
@@ -3452,17 +3464,19 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "1140bb80481756a8cbe10541f37433b459c5aa1e727b4c020fbfebdc25bf3ec4"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "atomic"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
 dependencies = [
  "bytemuck",
 ]
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
@@ -544,9 +544,9 @@ dependencies = [
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -670,12 +670,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1344,9 +1344,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
 dependencies = [
  "bitflags",
  "libc",
@@ -1541,7 +1541,7 @@ dependencies = [
 [[package]]
 name = "miden-block-prover"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#507b98708db37e383283ff280f9b1a05918d2ae8"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#2daf42f0ed56d74cb45ceaca19bb82269d15839c"
 dependencies = [
  "miden-lib",
  "miden-objects",
@@ -1690,7 +1690,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#507b98708db37e383283ff280f9b1a05918d2ae8"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#2daf42f0ed56d74cb45ceaca19bb82269d15839c"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -1745,7 +1745,7 @@ dependencies = [
 [[package]]
 name = "miden-node-block-producer"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#3e76073dc6af9923a8411d04a8fa476d4d720792"
+source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-update-map-entries#7d6206387751a1c7c9a3a6ac542f616450406537"
 dependencies = [
  "anyhow",
  "futures",
@@ -1773,7 +1773,7 @@ dependencies = [
 [[package]]
 name = "miden-node-ntx-builder"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#3e76073dc6af9923a8411d04a8fa476d4d720792"
+source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-update-map-entries#7d6206387751a1c7c9a3a6ac542f616450406537"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1800,7 +1800,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#3e76073dc6af9923a8411d04a8fa476d4d720792"
+source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-update-map-entries#7d6206387751a1c7c9a3a6ac542f616450406537"
 dependencies = [
  "anyhow",
  "hex",
@@ -1819,7 +1819,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto-build"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#3e76073dc6af9923a8411d04a8fa476d4d720792"
+source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-update-map-entries#7d6206387751a1c7c9a3a6ac542f616450406537"
 dependencies = [
  "anyhow",
  "prost",
@@ -1830,7 +1830,7 @@ dependencies = [
 [[package]]
 name = "miden-node-rpc"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#3e76073dc6af9923a8411d04a8fa476d4d720792"
+source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-update-map-entries#7d6206387751a1c7c9a3a6ac542f616450406537"
 dependencies = [
  "anyhow",
  "futures",
@@ -1856,7 +1856,7 @@ dependencies = [
 [[package]]
 name = "miden-node-store"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#3e76073dc6af9923a8411d04a8fa476d4d720792"
+source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-update-map-entries#7d6206387751a1c7c9a3a6ac542f616450406537"
 dependencies = [
  "anyhow",
  "deadpool",
@@ -1881,7 +1881,7 @@ dependencies = [
 [[package]]
 name = "miden-node-utils"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#3e76073dc6af9923a8411d04a8fa476d4d720792"
+source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-update-map-entries#7d6206387751a1c7c9a3a6ac542f616450406537"
 dependencies = [
  "anyhow",
  "figment",
@@ -1905,7 +1905,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#507b98708db37e383283ff280f9b1a05918d2ae8"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#2daf42f0ed56d74cb45ceaca19bb82269d15839c"
 dependencies = [
  "bech32",
  "getrandom 0.3.3",
@@ -1953,10 +1953,11 @@ dependencies = [
 [[package]]
 name = "miden-proving-service-client"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#3e76073dc6af9923a8411d04a8fa476d4d720792"
+source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-update-map-entries#7d6206387751a1c7c9a3a6ac542f616450406537"
 dependencies = [
  "async-trait",
  "getrandom 0.3.3",
+ "miden-node-proto-build",
  "miden-objects",
  "miden-tx",
  "miette",
@@ -1983,12 +1984,11 @@ dependencies = [
 [[package]]
 name = "miden-testing"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#507b98708db37e383283ff280f9b1a05918d2ae8"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#2daf42f0ed56d74cb45ceaca19bb82269d15839c"
 dependencies = [
  "anyhow",
  "async-trait",
  "miden-block-prover",
- "miden-crypto",
  "miden-lib",
  "miden-objects",
  "miden-processor",
@@ -2002,7 +2002,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#507b98708db37e383283ff280f9b1a05918d2ae8"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#2daf42f0ed56d74cb45ceaca19bb82269d15839c"
 dependencies = [
  "async-trait",
  "miden-lib",
@@ -2018,7 +2018,7 @@ dependencies = [
 [[package]]
 name = "miden-tx-batch-prover"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#507b98708db37e383283ff280f9b1a05918d2ae8"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#2daf42f0ed56d74cb45ceaca19bb82269d15839c"
 dependencies = [
  "miden-objects",
  "miden-tx",
@@ -2355,9 +2355,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
-version = "4.2.1"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
+checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 
 [[package]]
 name = "parking_lot"
@@ -2534,9 +2534,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -3280,9 +3280,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4244,6 +4244,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ miden-lib = { git = "https://github.com/0xMiden/miden-base", branch = "next" , d
 miden-objects = { git = "https://github.com/0xMiden/miden-base", branch = "next" , default-features = false }
 miden-tx = { git = "https://github.com/0xMiden/miden-base", branch = "next" , default-features = false, features = ["async"] }
 miden-testing = { git = "https://github.com/0xMiden/miden-base", branch = "next" , default-features = false, features = ["async"] }
-miden-proving-service-client = { git = "https://github.com/0xMiden/miden-node", branch = "tomyrd-update-map-entries" ,  default-features = false, features = ["tx-prover"] }
+miden-remote-prover-client = { git = "https://github.com/0xMiden/miden-node", branch = "next" ,  default-features = false, features = ["tx-prover"] }
 miette = { version = "7.2", features = ["fancy"] }
 rand = { version = "0.9" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ miden-lib = { git = "https://github.com/0xMiden/miden-base", branch = "next" , d
 miden-objects = { git = "https://github.com/0xMiden/miden-base", branch = "next" , default-features = false }
 miden-tx = { git = "https://github.com/0xMiden/miden-base", branch = "next" , default-features = false, features = ["async"] }
 miden-testing = { git = "https://github.com/0xMiden/miden-base", branch = "next" , default-features = false, features = ["async"] }
-miden-proving-service-client = { git = "https://github.com/0xMiden/miden-node", branch = "next" ,  default-features = false, features = ["tx-prover"] }
+miden-proving-service-client = { git = "https://github.com/0xMiden/miden-node", branch = "tomyrd-update-map-entries" ,  default-features = false, features = ["tx-prover"] }
 miette = { version = "7.2", features = ["fancy"] }
 rand = { version = "0.9" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ miden-lib = { git = "https://github.com/0xMiden/miden-base", branch = "next" , d
 miden-objects = { git = "https://github.com/0xMiden/miden-base", branch = "next" , default-features = false }
 miden-tx = { git = "https://github.com/0xMiden/miden-base", branch = "next" , default-features = false, features = ["async"] }
 miden-testing = { git = "https://github.com/0xMiden/miden-base", branch = "next" , default-features = false, features = ["async"] }
-miden-remote-prover-client = { git = "https://github.com/0xMiden/miden-node", branch = "next" ,  default-features = false, features = ["tx-prover"] }
+miden-remote-prover-client = { git = "https://github.com/0xMiden/miden-node", branch = "tomyrd-update-lexicographic-words" ,  default-features = false, features = ["tx-prover"] }
 miette = { version = "7.2", features = ["fancy"] }
 rand = { version = "0.9" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ build-prover: update-prover-branch ## Build the prover binary with specified fea
 
 .PHONY: start-prover
 start-prover: ## Run prover. This requires the base repo to be present at `miden-base`
-	cd $(PROVER_DIR) && RUST_LOG=info cargo run -p miden-proving-service --release --locked -- start-worker --port $(PROVER_PORT) --prover-type transaction
+	cd $(PROVER_DIR) && RUST_LOG=info cargo run -p miden-proving-service --release --locked -- start-worker --port $(PROVER_PORT) --proof-type transaction
 
 .PHONY: kill-prover
 kill-prover: ## Kill prover process

--- a/bin/miden-cli/src/commands/exec.rs
+++ b/bin/miden-cli/src/commands/exec.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeSet, path::PathBuf};
 
 use clap::Parser;
-use miden_client::{Client, Felt, Word};
+use miden_client::{Client, Felt};
 use miden_objects::{Digest, vm::AdviceInputs};
 use serde::{Deserialize, Deserializer, Serialize, de};
 
@@ -76,10 +76,13 @@ impl ExecCmd {
             None => vec![],
         };
 
-        let tx_script = client.compile_tx_script(inputs, &program)?;
+        let mut advice_inputs = AdviceInputs::default();
+        advice_inputs.extend_map(inputs);
+
+        let tx_script = client.compile_tx_script(&program)?;
 
         let result = client
-            .execute_program(account_id, tx_script, AdviceInputs::default(), BTreeSet::new())
+            .execute_program(account_id, tx_script, advice_inputs, BTreeSet::new())
             .await;
 
         match result {
@@ -169,7 +172,7 @@ where
         })
 }
 
-fn deserialize_tx_inputs(serialized: &str) -> Result<Vec<(Word, Vec<Felt>)>, CliError> {
+fn deserialize_tx_inputs(serialized: &str) -> Result<Vec<(Digest, Vec<Felt>)>, CliError> {
     let cli_inputs: CliTxInputs = toml::from_str(serialized).map_err(|err| {
         CliError::Exec(
             "error deserializing transaction inputs".into(),
@@ -179,7 +182,7 @@ fn deserialize_tx_inputs(serialized: &str) -> Result<Vec<(Word, Vec<Felt>)>, Cli
     cli_inputs
         .into_iter()
         .map(|input| {
-            let word = Digest::try_from(input.key).map_err(|err| err.to_string())?.into();
+            let word = Digest::try_from(input.key).map_err(|err| err.to_string())?;
             let felts = input.values.into_iter().map(Felt::new).collect();
             Ok((word, felts))
         })

--- a/bin/miden-cli/src/commands/notes.rs
+++ b/bin/miden-cli/src/commands/notes.rs
@@ -181,8 +181,8 @@ async fn show_note(client: Client, note_id: String, with_code: bool) -> Result<(
         ref p2id_root if p2id_root == &WellKnownNote::P2ID.script_root().to_string() => {
             script_root += " (P2ID)";
         },
-        ref p2idr_root if p2idr_root == &WellKnownNote::P2IDR.script_root().to_string() => {
-            script_root += " (P2IDR)";
+        ref p2idr_root if p2idr_root == &WellKnownNote::P2IDE.script_root().to_string() => {
+            script_root += " (P2IDE)";
         },
         ref swap_root if swap_root == &WellKnownNote::SWAP.script_root().to_string() => {
             script_root += " (SWAP)";

--- a/bin/miden-cli/tests/cli.rs
+++ b/bin/miden-cli/tests/cli.rs
@@ -9,7 +9,7 @@ use std::{
 
 use assert_cmd::Command;
 use miden_client::{
-    self, Client, Felt,
+    self, Client, ExecutionOptions, Felt,
     account::{AccountId, AccountStorageMode},
     crypto::{FeltRng, RpoRandomCoin},
     note::{
@@ -28,6 +28,7 @@ use miden_client::{
     utils::Serializable,
 };
 use miden_client_cli::CliKeyStore;
+use miden_objects::{MAX_TX_EXECUTION_CYCLES, MIN_TX_EXECUTION_CYCLES};
 use predicates::str::contains;
 use rand::Rng;
 use toml::Table;
@@ -771,7 +772,13 @@ async fn create_rust_client_with_store_path(store_path: &Path) -> (TestClient, C
             rng,
             store,
             std::sync::Arc::new(keystore.clone()),
-            true,
+            ExecutionOptions::new(
+                Some(MAX_TX_EXECUTION_CYCLES),
+                MIN_TX_EXECUTION_CYCLES,
+                false,
+                true,
+            )
+            .expect("Default executor's options should always be valid"),
             None,
             None,
         ),

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -70,7 +70,7 @@ tokio = { workspace = true }
 web-sys = { version = "0.3", features = ["console"]}
 
 [build-dependencies]
-miden-node-proto-build = { git = "https://github.com/0xMiden/miden-node", branch = "next", default-features = false }
+miden-node-proto-build = { git = "https://github.com/0xMiden/miden-node", branch = "tomyrd-update-lexicographic-words", default-features = false }
 miden-lib = { workspace = true }
 miden-objects = { workspace = true }
 miette = { workspace = true }

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -70,7 +70,7 @@ tokio = { workspace = true }
 web-sys = { version = "0.3", features = ["console"]}
 
 [build-dependencies]
-miden-node-proto-build = { git = "https://github.com/0xMiden/miden-node", branch = "next", default-features = false }
+miden-node-proto-build = { git = "https://github.com/0xMiden/miden-node", branch = "tomyrd-update-map-entries", default-features = false }
 miden-lib = { workspace = true }
 miden-objects = { workspace = true }
 miette = { workspace = true }

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 default = ["std", "tonic/channel"]
 idxdb = ["dep:base64", "dep:serde-wasm-bindgen", "dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:serde", "dep:getrandom"]
 sqlite = ["dep:rusqlite", "dep:deadpool", "dep:deadpool-sync", "dep:rusqlite_migration", "std"]
-std = ["miden-objects/std", "miden-proving-service-client/std", "miden-tx/concurrent"]
+std = ["miden-objects/std", "miden-remote-prover-client/std", "miden-tx/concurrent"]
 testing = ["miden-objects/testing", "miden-lib/testing", "miden-tx/testing", "dep:miden-testing", "dep:uuid", "dep:toml"]
 tonic = ["std", "tonic/transport", "tonic/tls-ring", "tonic/tls-native-roots"]
 web-tonic = ["dep:tonic-web-wasm-client", "dep:getrandom"]
@@ -35,7 +35,7 @@ deadpool = { version = "0.12", features = ["managed", "rt_tokio_1"], default-fea
 deadpool-sync = { version = "0.1", optional = true }
 getrandom = { version = "0.3", optional = true, features = ["wasm_js"] }
 hex = { version = "0.4" }
-miden-proving-service-client = { workspace = true, default-features = false, features = ["tx-prover"] }
+miden-remote-prover-client = { workspace = true, default-features = false, features = ["tx-prover"] }
 miden-lib = { workspace = true }
 miden-objects = { workspace = true }
 miden-testing = { workspace = true, optional = true }
@@ -70,7 +70,7 @@ tokio = { workspace = true }
 web-sys = { version = "0.3", features = ["console"]}
 
 [build-dependencies]
-miden-node-proto-build = { git = "https://github.com/0xMiden/miden-node", branch = "tomyrd-update-map-entries", default-features = false }
+miden-node-proto-build = { git = "https://github.com/0xMiden/miden-node", branch = "next", default-features = false }
 miden-lib = { workspace = true }
 miden-objects = { workspace = true }
 miette = { workspace = true }

--- a/crates/rust-client/src/builder.rs
+++ b/crates/rust-client/src/builder.rs
@@ -5,10 +5,10 @@ use alloc::{
 use std::boxed::Box;
 
 use miden_objects::{
-    Felt,
+    Felt, MAX_TX_EXECUTION_CYCLES, MIN_TX_EXECUTION_CYCLES,
     crypto::rand::{FeltRng, RpoRandomCoin},
 };
-use miden_tx::auth::TransactionAuthenticator;
+use miden_tx::{ExecutionOptions, auth::TransactionAuthenticator};
 use rand::Rng;
 
 #[cfg(feature = "tonic")]
@@ -236,7 +236,13 @@ impl ClientBuilder {
             rng,
             arc_store,
             authenticator,
-            self.in_debug_mode,
+            ExecutionOptions::new(
+                Some(MAX_TX_EXECUTION_CYCLES),
+                MIN_TX_EXECUTION_CYCLES,
+                false,
+                self.in_debug_mode,
+            )
+            .expect("Default executor's options should always be valid"),
             self.tx_graceful_blocks,
             self.max_block_number_delta,
         ))

--- a/crates/rust-client/src/errors.rs
+++ b/crates/rust-client/src/errors.rs
@@ -58,7 +58,9 @@ pub enum ClientError {
     AddNewAccountWithoutSeed,
     #[error("error with merkle path")]
     MerkleError(#[from] MerkleError),
-    #[error("the transaction didn't produce the expected output note recipient digests ({0:?})")]
+    #[error(
+        "the transaction didn't produce the output notes with the expected recipient digests ({0:?})"
+    )]
     MissingOutputRecipients(Vec<Digest>),
     #[error("note error")]
     NoteError(#[from] NoteError),

--- a/crates/rust-client/src/errors.rs
+++ b/crates/rust-client/src/errors.rs
@@ -59,7 +59,7 @@ pub enum ClientError {
     #[error("error with merkle path")]
     MerkleError(#[from] MerkleError),
     #[error("the transaction didn't produce the expected recipients corresponding to digests")]
-    MissingOutputRecipient(Vec<Digest>),
+    MissingOutputRecipients(Vec<Digest>),
     #[error("note error")]
     NoteError(#[from] NoteError),
     #[error("note import error: {0}")]

--- a/crates/rust-client/src/errors.rs
+++ b/crates/rust-client/src/errors.rs
@@ -58,8 +58,8 @@ pub enum ClientError {
     AddNewAccountWithoutSeed,
     #[error("error with merkle path")]
     MerkleError(#[from] MerkleError),
-    #[error("the transaction didn't produce the expected notes corresponding to note ids")]
-    MissingOutputNotes(Vec<NoteId>),
+    #[error("the transaction didn't produce the expected recipients corresponding to digests")]
+    MissingOutputRecipient(Vec<Digest>),
     #[error("note error")]
     NoteError(#[from] NoteError),
     #[error("note import error: {0}")]

--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -175,7 +175,7 @@ pub mod crypto {
 
 pub use errors::{AuthenticationError, ClientError, IdPrefixFetchError};
 pub use miden_objects::{Felt, ONE, StarkField, Word, ZERO};
-pub use miden_proving_service_client::proving_service::tx_prover::RemoteTransactionProver;
+pub use miden_remote_prover_client::remote_prover::tx_prover::RemoteTransactionProver;
 
 /// Provides various utilities that are commonly used throughout the Miden
 /// client library.
@@ -230,7 +230,6 @@ pub struct Client {
     /// An instance of a [`TransactionAuthenticator`] which will be used by the transaction
     /// executor whenever a signature is requested from within the VM.
     authenticator: Option<Arc<dyn TransactionAuthenticator>>,
-    /// Flag to enable the debug mode for scripts compilation and execution.
     in_debug_mode: bool,
     /// The number of blocks that are considered old enough to discard pending transactions.
     tx_graceful_blocks: Option<u32>,
@@ -292,7 +291,7 @@ impl Client {
     }
 
     /// Returns true if the client is in debug mode.
-    pub fn is_in_debug_mode(&self) -> bool {
+    pub fn in_debug_mode(&self) -> bool {
         self.in_debug_mode
     }
 

--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -237,7 +237,7 @@ pub struct Client {
     /// An instance of a [`TransactionAuthenticator`] which will be used by the transaction
     /// executor whenever a signature is requested from within the VM.
     authenticator: Option<Arc<dyn TransactionAuthenticator>>,
-    /// Execution options for the transaction executor.
+    /// Options that control the transaction executor’s runtime behaviour (e.g. debug mode).
     exec_options: ExecutionOptions,
     /// The number of blocks that are considered old enough to discard pending transactions.
     tx_graceful_blocks: Option<u32>,
@@ -263,8 +263,8 @@ impl Client {
     ///   provide persistence.
     /// - `authenticator`: Defines the transaction authenticator that will be used by the
     ///   transaction executor whenever a signature is requested from within the VM.
-    /// - `exec_options`: Execution options for the transaction executor, which can be used to
-    ///   configure the execution environment, such as whether to enable debug mode.
+    /// - `exec_options`: Options that control the transaction executor’s runtime behaviour (e.g.
+    ///   debug mode).
     /// - `tx_graceful_blocks`: The number of blocks that are considered old enough to discard
     ///   pending transactions.
     /// - `max_block_number_delta`: Determines the maximum number of blocks that the client can be

--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -250,11 +250,10 @@ impl Client {
     ///
     /// - `api`: An instance of [`NodeRpcClient`] which provides a way for the client to connect to
     ///   the Miden node.
+    /// - `rng`: An instance of [`FeltRng`] which provides randomness tools for generating new keys,
+    ///   serial numbers, etc. This can be any RNG that implements the [`FeltRng`] trait.
     /// - `store`: An instance of [`Store`], which provides a way to write and read entities to
     ///   provide persistence.
-    /// - `executor_store`: An instance of [`Store`] that provides a way for [`TransactionExecutor`]
-    ///   to retrieve relevant inputs at the moment of transaction execution. It should be the same
-    ///   store as the one for `store`, but it doesn't have to be the **same instance**.
     /// - `authenticator`: Defines the transaction authenticator that will be used by the
     ///   transaction executor whenever a signature is requested from within the VM.
     /// - `in_debug_mode`: Instantiates the transaction executor (and in turn, its compiler) in

--- a/crates/rust-client/src/note/mod.rs
+++ b/crates/rust-client/src/note/mod.rs
@@ -123,8 +123,7 @@ impl Client {
     ) -> Result<Vec<(InputNoteRecord, Vec<NoteConsumability>)>, ClientError> {
         let commited_notes = self.store.get_input_notes(NoteFilter::Committed).await?;
 
-        let note_screener =
-            NoteScreener::new(self.store.clone(), &self.tx_executor, self.mast_store.clone());
+        let note_screener = NoteScreener::new(self.store.clone(), self.authenticator.clone());
 
         let mut relevant_notes = Vec::new();
         for input_note in commited_notes {
@@ -154,8 +153,7 @@ impl Client {
         &self,
         note: InputNoteRecord,
     ) -> Result<Vec<NoteConsumability>, ClientError> {
-        let note_screener =
-            NoteScreener::new(self.store.clone(), &self.tx_executor, self.mast_store.clone());
+        let note_screener = NoteScreener::new(self.store.clone(), self.authenticator.clone());
         note_screener
             .check_relevance(&note.clone().try_into()?)
             .await

--- a/crates/rust-client/src/note/mod.rs
+++ b/crates/rust-client/src/note/mod.rs
@@ -74,7 +74,7 @@ mod note_update_tracker;
 // ================================================================================================
 
 pub use miden_lib::note::{
-    create_p2id_note, create_p2idr_note, create_swap_note,
+    create_p2id_note, create_swap_note,
     utils::{build_p2id_recipient, build_swap_tag},
     well_known_note::WellKnownNote,
 };
@@ -191,7 +191,7 @@ impl Client {
     ///
     /// The assembler uses the debug mode if the client was instantiated with debug mode on.
     pub fn compile_note_script(&self, note_script: &str) -> Result<NoteScript, ClientError> {
-        let assembler = TransactionKernel::assembler().with_debug_mode(self.in_debug_mode);
+        let assembler = TransactionKernel::assembler().with_debug_mode(self.in_debug_mode());
         NoteScript::compile(note_script, assembler).map_err(ClientError::NoteError)
     }
 }

--- a/crates/rust-client/src/note/note_screener.rs
+++ b/crates/rust-client/src/note/note_screener.rs
@@ -94,8 +94,8 @@ impl NoteScreener {
                     // p2idr
                     let script_root = note.script().root();
 
-                    if script_root == WellKnownNote::P2IDR.script_root() {
-                        if let Some(relevance) = Self::check_p2idr_recall_consumability(note, &id)?
+                    if script_root == WellKnownNote::P2IDE.script_root() {
+                        if let Some(relevance) = Self::check_p2ide_recall_consumability(note, &id)?
                         {
                             note_relevances.push((id, relevance));
                         }
@@ -152,13 +152,13 @@ impl NoteScreener {
 
     /// Special relevance check for P2IDR notes. It checks if the sender account can consume and
     /// recall the note.
-    fn check_p2idr_recall_consumability(
+    fn check_p2ide_recall_consumability(
         note: &Note,
         account_id: &AccountId,
     ) -> Result<Option<NoteRelevance>, NoteScreenerError> {
         let note_inputs = note.inputs().values();
-        if note_inputs.len() != 3 {
-            return Err(InvalidNoteInputsError::WrongNumInputs(note.id(), 3).into());
+        if note_inputs.len() != 4 {
+            return Err(InvalidNoteInputsError::WrongNumInputs(note.id(), 4).into());
         }
 
         let recall_height_felt = note_inputs[2];

--- a/crates/rust-client/src/note/note_screener.rs
+++ b/crates/rust-client/src/note/note_screener.rs
@@ -11,12 +11,12 @@ use miden_objects::{
 };
 use miden_tx::{
     NoteAccountExecution, NoteConsumptionChecker, TransactionExecutor, TransactionExecutorError,
-    TransactionMastStore,
+    auth::TransactionAuthenticator,
 };
 use thiserror::Error;
 
 use crate::{
-    store::{Store, StoreError},
+    store::{Store, StoreError, data_store::ClientDataStore},
     transaction::{TransactionRequestBuilder, TransactionRequestError},
 };
 
@@ -50,26 +50,19 @@ impl fmt::Display for NoteRelevance {
 /// tracked in the provided `store`. This can be derived in a number of ways, such as looking
 /// at the combination of script root and note inputs. For example, a P2ID note is relevant
 /// for a specific account ID if this ID is its first note input.
-pub struct NoteScreener<'a> {
+pub struct NoteScreener {
     /// A reference to the client's store, used to fetch necessary data to check consumability.
     store: Arc<dyn Store>,
-    /// A consumption checker, used to check whether a note can be consumed by an account.
-    consumption_checker: NoteConsumptionChecker<'a>,
-    /// A MAST store, used to provide code inputs to the VM.
-    mast_store: Arc<TransactionMastStore>,
+    /// A reference to the transaction authenticator
+    authenticator: Option<Arc<dyn TransactionAuthenticator>>,
 }
 
-impl<'a> NoteScreener<'a> {
+impl NoteScreener {
     pub fn new(
         store: Arc<dyn Store>,
-        tx_executor: &'a TransactionExecutor,
-        mast_store: Arc<TransactionMastStore>,
+        authenticator: Option<Arc<dyn TransactionAuthenticator>>,
     ) -> Self {
-        Self {
-            store,
-            consumption_checker: NoteConsumptionChecker::new(tx_executor),
-            mast_store,
-        }
+        Self { store, authenticator }
     }
 
     /// Returns a vector of tuples describing the relevance of the provided note to the
@@ -134,10 +127,14 @@ impl<'a> NoteScreener<'a> {
         let input_notes = InputNotes::new(vec![InputNote::unauthenticated(note.clone())])
             .expect("Single note should be valid");
 
-        self.mast_store.load_account_code(account.code());
+        let data_store = ClientDataStore::new(self.store.clone());
+        let transaction_executor =
+            TransactionExecutor::new(&data_store, self.authenticator.as_deref());
+        let consumption_checker = NoteConsumptionChecker::new(&transaction_executor);
 
-        if let NoteAccountExecution::Success = self
-            .consumption_checker
+        data_store.mast_store().load_account_code(account.code());
+
+        if let NoteAccountExecution::Success = consumption_checker
             .check_notes_consumability(
                 account.id(),
                 self.store.get_sync_height().await?,

--- a/crates/rust-client/src/rpc/errors.rs
+++ b/crates/rust-client/src/rpc/errors.rs
@@ -51,6 +51,8 @@ impl From<RpcConversionError> for RpcError {
 
 #[derive(Debug, Error)]
 pub enum RpcConversionError {
+    #[error("failed to deserialize: {0}")]
+    DeserializationError(#[from] DeserializationError),
     #[error("value is not in the range 0..modulus")]
     NotAValidFelt,
     #[error("invalid note type value")]

--- a/crates/rust-client/src/rpc/generated/nostd/note.rs
+++ b/crates/rust-client/src/rpc/generated/nostd/note.rs
@@ -22,32 +22,33 @@ pub struct NoteMetadata {
     #[prost(fixed64, tag = "5")]
     pub aux: u64,
 }
+/// Represents a committed note.
+///
+/// A committed note is a note that has been included in a block.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CommittedNote {
+    /// Either private, public, or network note.
+    #[prost(message, optional, tag = "1")]
+    pub note: ::core::option::Option<Note>,
+    /// The data needed to prove that the note is present in the chain.
+    #[prost(message, optional, tag = "2")]
+    pub inclusion_proof: ::core::option::Option<NoteInclusionInBlockProof>,
+}
 /// Represents a note.
+///
+/// The note is composed of the note metadata and its serialized details.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Note {
-    /// The block number in which the note was created.
-    #[prost(fixed32, tag = "1")]
-    pub block_num: u32,
-    /// The index of the note in the block.
-    #[prost(uint32, tag = "2")]
-    pub note_index: u32,
-    /// The ID of the note.
-    #[prost(message, optional, tag = "3")]
-    pub note_id: ::core::option::Option<super::digest::Digest>,
     /// The note's metadata.
-    #[prost(message, optional, tag = "4")]
+    #[prost(message, optional, tag = "1")]
     pub metadata: ::core::option::Option<NoteMetadata>,
-    /// The note's inclusion proof in the block.
-    #[prost(message, optional, tag = "5")]
-    pub merkle_path: ::core::option::Option<super::merkle::MerklePath>,
-    /// Serialized details of the public note (empty for private notes).
-    #[prost(bytes = "vec", optional, tag = "6")]
+    /// Serialized note details (empty for private notes).
+    #[prost(bytes = "vec", optional, tag = "2")]
     pub details: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
 }
 /// Represents a network note.
 ///
-/// The note is composed of the note metadata and its serialized details. The note's tag
-/// must express that the note is for network usage instead of local.
+/// The note is composed of the note metadata and its serialized details.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NetworkNote {
     /// The note's metadata.

--- a/crates/rust-client/src/rpc/generated/nostd/responses.rs
+++ b/crates/rust-client/src/rpc/generated/nostd/responses.rs
@@ -196,7 +196,7 @@ pub struct SubmitProvenTransactionResponse {
 pub struct GetNotesByIdResponse {
     /// Lists Note's returned by the database.
     #[prost(message, repeated, tag = "1")]
-    pub notes: ::prost::alloc::vec::Vec<super::note::Note>,
+    pub notes: ::prost::alloc::vec::Vec<super::note::CommittedNote>,
 }
 /// Represents the result of getting account details.
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/crates/rust-client/src/rpc/generated/nostd/responses.rs
+++ b/crates/rust-client/src/rpc/generated/nostd/responses.rs
@@ -275,7 +275,7 @@ pub struct AccountStateHeader {
     #[prost(message, repeated, tag = "4")]
     pub storage_maps: ::prost::alloc::vec::Vec<StorageSlotMapProof>,
 }
-/// Represents a single storage slot with the reuqested keys and their respective values.
+/// Represents a single storage slot with the requested keys and their respective values.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StorageSlotMapProof {
     /// The storage slot index (\[0..255\]).

--- a/crates/rust-client/src/rpc/generated/std/note.rs
+++ b/crates/rust-client/src/rpc/generated/std/note.rs
@@ -22,32 +22,33 @@ pub struct NoteMetadata {
     #[prost(fixed64, tag = "5")]
     pub aux: u64,
 }
+/// Represents a committed note.
+///
+/// A committed note is a note that has been included in a block.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CommittedNote {
+    /// Either private, public, or network note.
+    #[prost(message, optional, tag = "1")]
+    pub note: ::core::option::Option<Note>,
+    /// The data needed to prove that the note is present in the chain.
+    #[prost(message, optional, tag = "2")]
+    pub inclusion_proof: ::core::option::Option<NoteInclusionInBlockProof>,
+}
 /// Represents a note.
+///
+/// The note is composed of the note metadata and its serialized details.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Note {
-    /// The block number in which the note was created.
-    #[prost(fixed32, tag = "1")]
-    pub block_num: u32,
-    /// The index of the note in the block.
-    #[prost(uint32, tag = "2")]
-    pub note_index: u32,
-    /// The ID of the note.
-    #[prost(message, optional, tag = "3")]
-    pub note_id: ::core::option::Option<super::digest::Digest>,
     /// The note's metadata.
-    #[prost(message, optional, tag = "4")]
+    #[prost(message, optional, tag = "1")]
     pub metadata: ::core::option::Option<NoteMetadata>,
-    /// The note's inclusion proof in the block.
-    #[prost(message, optional, tag = "5")]
-    pub merkle_path: ::core::option::Option<super::merkle::MerklePath>,
-    /// Serialized details of the public note (empty for private notes).
-    #[prost(bytes = "vec", optional, tag = "6")]
+    /// Serialized note details (empty for private notes).
+    #[prost(bytes = "vec", optional, tag = "2")]
     pub details: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
 }
 /// Represents a network note.
 ///
-/// The note is composed of the note metadata and its serialized details. The note's tag
-/// must express that the note is for network usage instead of local.
+/// The note is composed of the note metadata and its serialized details.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NetworkNote {
     /// The note's metadata.

--- a/crates/rust-client/src/rpc/generated/std/responses.rs
+++ b/crates/rust-client/src/rpc/generated/std/responses.rs
@@ -196,7 +196,7 @@ pub struct SubmitProvenTransactionResponse {
 pub struct GetNotesByIdResponse {
     /// Lists Note's returned by the database.
     #[prost(message, repeated, tag = "1")]
-    pub notes: ::prost::alloc::vec::Vec<super::note::Note>,
+    pub notes: ::prost::alloc::vec::Vec<super::note::CommittedNote>,
 }
 /// Represents the result of getting account details.
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/crates/rust-client/src/rpc/generated/std/responses.rs
+++ b/crates/rust-client/src/rpc/generated/std/responses.rs
@@ -275,7 +275,7 @@ pub struct AccountStateHeader {
     #[prost(message, repeated, tag = "4")]
     pub storage_maps: ::prost::alloc::vec::Vec<StorageSlotMapProof>,
 }
-/// Represents a single storage slot with the reuqested keys and their respective values.
+/// Represents a single storage slot with the requested keys and their respective values.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StorageSlotMapProof {
     /// The storage slot index (\[0..255\]).

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -115,8 +115,7 @@ impl Client {
     pub async fn sync_state(&mut self) -> Result<SyncSummary, ClientError> {
         _ = self.ensure_genesis_in_place().await?;
 
-        let note_screener =
-            NoteScreener::new(self.store.clone(), &self.tx_executor, self.mast_store.clone());
+        let note_screener = NoteScreener::new(self.store.clone(), self.authenticator.clone());
 
         let state_sync = StateSync::new(
             self.rpc_api.clone(),

--- a/crates/rust-client/src/test_utils/mock.rs
+++ b/crates/rust-client/src/test_utils/mock.rs
@@ -94,7 +94,7 @@ impl MockRpcApi {
             mock_chain.add_pending_nullifier(nullifier);
         }
 
-        mock_chain.prove_next_block();
+        mock_chain.prove_next_block().unwrap();
     }
 
     /// Returns the current MMR of the blockchain.

--- a/crates/rust-client/src/tests.rs
+++ b/crates/rust-client/src/tests.rs
@@ -809,7 +809,7 @@ async fn execute_program() {
         end
         ";
 
-    let tx_script = client.compile_tx_script(vec![], code).unwrap();
+    let tx_script = client.compile_tx_script(code).unwrap();
 
     let output_stack = client
         .execute_program(wallet.id(), tx_script, AdviceInputs::default(), BTreeSet::new())

--- a/crates/rust-client/src/tests.rs
+++ b/crates/rust-client/src/tests.rs
@@ -8,7 +8,7 @@ use miden_lib::{
         auth::RpoFalcon512, faucets::BasicFungibleFaucet, interface::AccountInterfaceError,
         wallets::BasicWallet,
     },
-    note::utils,
+    note::{utils, well_known_note::WellKnownNote},
     transaction::TransactionKernel,
 };
 use miden_objects::{
@@ -22,10 +22,13 @@ use miden_objects::{
         dsa::rpo_falcon512::SecretKey,
         rand::{FeltRng, RpoRandomCoin},
     },
-    note::{Note, NoteAssets, NoteExecutionHint, NoteFile, NoteMetadata, NoteTag, NoteType},
+    note::{
+        Note, NoteAssets, NoteExecutionHint, NoteFile, NoteInputs, NoteMetadata, NoteRecipient,
+        NoteTag, NoteType,
+    },
     testing::account_id::{
-        ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1, ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_2,
-        ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE,
+        ACCOUNT_ID_PRIVATE_SENDER, ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1,
+        ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_2, ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE,
         ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE,
         ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE,
     },
@@ -1563,4 +1566,38 @@ async fn subsequent_discarded_transactions() {
         account_after_sync.account().commitment(),
         account_before_tx.account().commitment(),
     );
+}
+
+#[tokio::test]
+async fn missing_recipient_digest() {
+    let (mut client, _, keystore) = create_test_client().await;
+
+    let (faucet, _seed) =
+        insert_new_fungible_faucet(&mut client, AccountStorageMode::Private, &keystore)
+            .await
+            .unwrap();
+
+    let dummy_recipient = NoteRecipient::new(
+        Word::default(),
+        WellKnownNote::SWAP.script(),
+        NoteInputs::new(vec![]).unwrap(),
+    );
+
+    let dummy_recipient_digest = dummy_recipient.digest();
+
+    let tx_request = TransactionRequestBuilder::new()
+        .with_expected_output_recipients(vec![dummy_recipient])
+        .build_mint_fungible_asset(
+            FungibleAsset::new(faucet.id(), 5u64).unwrap(),
+            AccountId::try_from(ACCOUNT_ID_PRIVATE_SENDER).unwrap(),
+            NoteType::Public,
+            client.rng(),
+        )
+        .unwrap();
+
+    let error = client.new_transaction(faucet.id(), tx_request).await.unwrap_err();
+
+    if let ClientError::MissingOutputRecipients(digests) = error {
+        assert!(digests == vec![dummy_recipient_digest]);
+    }
 }

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -1145,13 +1145,12 @@ impl Client {
         &'auth self,
         data_store: &'store ClientDataStore,
     ) -> TransactionExecutor<'store, 'auth> {
-        let tx_executor = TransactionExecutor::new(data_store, self.authenticator.as_deref());
-
-        if self.in_debug_mode() {
-            tx_executor.with_debug_mode()
-        } else {
-            tx_executor
-        }
+        TransactionExecutor::with_options(
+            data_store,
+            self.authenticator.as_deref(),
+            self.exec_options,
+        )
+        .unwrap()
     }
 }
 

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -637,7 +637,7 @@ impl Client {
 
         // Execute the transaction and get the witness
         let executed_transaction = self
-            .build_executor(&data_store)
+            .build_executor(&data_store)?
             .execute_transaction(
                 account_id,
                 block_num,
@@ -976,7 +976,7 @@ impl Client {
         loop {
             let data_store = ClientDataStore::new(self.store.clone());
 
-            let execution = NoteConsumptionChecker::new(&self.build_executor(&data_store))
+            let execution = NoteConsumptionChecker::new(&self.build_executor(&data_store)?)
                 .check_notes_consumability(
                     account_id,
                     self.store.get_sync_height().await?,
@@ -1129,7 +1129,7 @@ impl Client {
         }
 
         Ok(self
-            .build_executor(&data_store)
+            .build_executor(&data_store)?
             .execute_tx_view_script(
                 account_id,
                 block_ref,
@@ -1144,13 +1144,12 @@ impl Client {
     pub(crate) fn build_executor<'store, 'auth>(
         &'auth self,
         data_store: &'store ClientDataStore,
-    ) -> TransactionExecutor<'store, 'auth> {
+    ) -> Result<TransactionExecutor<'store, 'auth>, TransactionExecutorError> {
         TransactionExecutor::with_options(
             data_store,
             self.authenticator.as_deref(),
             self.exec_options,
         )
-        .unwrap()
     }
 }
 

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -527,8 +527,8 @@ impl Client {
     ///
     /// # Errors
     ///
-    /// - Returns [`ClientError::MissingOutputNotes`] if the [`TransactionRequest`] ouput notes are
-    ///   not a subset of executor's output notes.
+    /// - Returns [`ClientError::MissingOutputRecipients`] if the [`TransactionRequest`] ouput notes
+    ///   are not a subset of executor's output notes.
     /// - Returns a [`ClientError::TransactionExecutorError`] if the execution fails.
     /// - Returns a [`ClientError::TransactionRequestError`] if the request is invalid.
     pub async fn new_transaction(
@@ -1253,7 +1253,7 @@ fn validate_executed_transaction(
         .collect();
 
     if !missing_recipient_digest.is_empty() {
-        return Err(ClientError::MissingOutputRecipient(missing_recipient_digest));
+        return Err(ClientError::MissingOutputRecipients(missing_recipient_digest));
     }
 
     Ok(())

--- a/crates/rust-client/src/transaction/request/builder.rs
+++ b/crates/rust-client/src/transaction/request/builder.rs
@@ -1,7 +1,7 @@
 //! Contains structures and functions related to transaction creation.
 use alloc::{collections::BTreeMap, string::ToString, vec::Vec};
 
-use miden_lib::note::{create_p2id_note, create_p2idr_note, create_swap_note};
+use miden_lib::note::{create_p2id_note, create_p2ide_note, create_swap_note};
 use miden_objects::{
     Digest, Felt, FieldElement,
     account::AccountId,
@@ -302,13 +302,14 @@ impl TransactionRequestBuilder {
         }
 
         let created_note = if let Some(recall_height) = recall_height {
-            create_p2idr_note(
+            create_p2ide_note(
                 sender_account_id,
                 target_account_id,
                 assets,
+                Some(recall_height),
+                None, //TODO: Add support for timelock P2IDE notes
                 note_type,
                 Felt::ZERO,
-                recall_height,
                 rng,
             )?
         } else {

--- a/crates/rust-client/src/transaction/request/mod.rs
+++ b/crates/rust-client/src/transaction/request/mod.rs
@@ -205,12 +205,9 @@ impl TransactionRequest {
             ..
         } = self;
 
-        let mut tx_args = TransactionArgs::new(
-            Some(tx_script),
-            note_args.into(),
-            advice_map,
-            foreign_account_inputs,
-        );
+        let mut tx_args = TransactionArgs::new(advice_map, foreign_account_inputs)
+            .with_tx_script(tx_script)
+            .with_note_args(note_args);
 
         tx_args
             .extend_output_note_recipients(expected_output_recipients.into_values().map(Box::new));
@@ -238,7 +235,6 @@ impl TransactionRequest {
                 if account_interface.auth().is_empty() {
                     let empty_script = TransactionScript::compile(
                         "begin nop end",
-                        [],
                         TransactionKernel::assembler(),
                     )?;
 

--- a/crates/testing/node-builder/Cargo.toml
+++ b/crates/testing/node-builder/Cargo.toml
@@ -21,11 +21,11 @@ workspace = true
 anyhow                    = "1.0"
 miden-objects             = { workspace = true }
 miden-lib                 = { workspace = true }
-miden-node-block-producer = { git = "https://github.com/0xMiden/miden-node", branch = "next" }
-miden-node-rpc            = { git = "https://github.com/0xMiden/miden-node", branch = "next" }
-miden-node-store          = { git = "https://github.com/0xMiden/miden-node", branch = "next" }
-miden-node-utils          = { git = "https://github.com/0xMiden/miden-node", branch = "next" }
-miden-node-ntx-builder    = { git = "https://github.com/0xMiden/miden-node", branch = "next" }
+miden-node-block-producer = { git = "https://github.com/0xMiden/miden-node", branch = "tomyrd-update-map-entries" }
+miden-node-rpc            = { git = "https://github.com/0xMiden/miden-node", branch = "tomyrd-update-map-entries" }
+miden-node-store          = { git = "https://github.com/0xMiden/miden-node", branch = "tomyrd-update-map-entries" }
+miden-node-utils          = { git = "https://github.com/0xMiden/miden-node", branch = "tomyrd-update-map-entries" }
+miden-node-ntx-builder    = { git = "https://github.com/0xMiden/miden-node", branch = "tomyrd-update-map-entries" }
 rand_chacha               = { version = "0.9" }
 rand                      = { workspace = true }
 tokio                     = { version = "1.0", features = ["full"] }

--- a/crates/testing/node-builder/Cargo.toml
+++ b/crates/testing/node-builder/Cargo.toml
@@ -21,11 +21,11 @@ workspace = true
 anyhow                    = "1.0"
 miden-objects             = { workspace = true }
 miden-lib                 = { workspace = true }
-miden-node-block-producer = { git = "https://github.com/0xMiden/miden-node", branch = "tomyrd-update-map-entries" }
-miden-node-rpc            = { git = "https://github.com/0xMiden/miden-node", branch = "tomyrd-update-map-entries" }
-miden-node-store          = { git = "https://github.com/0xMiden/miden-node", branch = "tomyrd-update-map-entries" }
-miden-node-utils          = { git = "https://github.com/0xMiden/miden-node", branch = "tomyrd-update-map-entries" }
-miden-node-ntx-builder    = { git = "https://github.com/0xMiden/miden-node", branch = "tomyrd-update-map-entries" }
+miden-node-block-producer = { git = "https://github.com/0xMiden/miden-node", branch = "next" }
+miden-node-rpc            = { git = "https://github.com/0xMiden/miden-node", branch = "next" }
+miden-node-store          = { git = "https://github.com/0xMiden/miden-node", branch = "next" }
+miden-node-utils          = { git = "https://github.com/0xMiden/miden-node", branch = "next" }
+miden-node-ntx-builder    = { git = "https://github.com/0xMiden/miden-node", branch = "next" }
 rand_chacha               = { version = "0.9" }
 rand                      = { workspace = true }
 tokio                     = { version = "1.0", features = ["full"] }

--- a/crates/testing/node-builder/Cargo.toml
+++ b/crates/testing/node-builder/Cargo.toml
@@ -21,11 +21,11 @@ workspace = true
 anyhow                    = "1.0"
 miden-objects             = { workspace = true }
 miden-lib                 = { workspace = true }
-miden-node-block-producer = { git = "https://github.com/0xMiden/miden-node", branch = "next" }
-miden-node-rpc            = { git = "https://github.com/0xMiden/miden-node", branch = "next" }
-miden-node-store          = { git = "https://github.com/0xMiden/miden-node", branch = "next" }
-miden-node-utils          = { git = "https://github.com/0xMiden/miden-node", branch = "next" }
-miden-node-ntx-builder    = { git = "https://github.com/0xMiden/miden-node", branch = "next" }
+miden-node-block-producer = { git = "https://github.com/0xMiden/miden-node", branch = "tomyrd-update-lexicographic-words" }
+miden-node-rpc            = { git = "https://github.com/0xMiden/miden-node", branch = "tomyrd-update-lexicographic-words" }
+miden-node-store          = { git = "https://github.com/0xMiden/miden-node", branch = "tomyrd-update-lexicographic-words" }
+miden-node-utils          = { git = "https://github.com/0xMiden/miden-node", branch = "tomyrd-update-lexicographic-words" }
+miden-node-ntx-builder    = { git = "https://github.com/0xMiden/miden-node", branch = "tomyrd-update-lexicographic-words" }
 rand_chacha               = { version = "0.9" }
 rand                      = { workspace = true }
 tokio                     = { version = "1.0", features = ["full"] }

--- a/crates/web-client/package-lock.json
+++ b/crates/web-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@demox-labs/miden-sdk",
-  "version": "0.10.0-next.1",
+  "version": "0.10.0-next.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@demox-labs/miden-sdk",
-      "version": "0.10.0-next.1",
+      "version": "0.10.0-next.2",
       "dependencies": {
         "chai-as-promised": "^8.0.0",
         "dexie": "^4.0.1",

--- a/crates/web-client/src/lib.rs
+++ b/crates/web-client/src/lib.rs
@@ -3,12 +3,14 @@ use alloc::sync::Arc;
 use std::fmt::Write;
 
 use miden_client::{
-    Client,
+    Client, ExecutionOptions,
     keystore::WebKeyStore,
     rpc::{Endpoint, TonicRpcClient},
     store::web_store::WebStore,
 };
-use miden_objects::{Felt, crypto::rand::RpoRandomCoin};
+use miden_objects::{
+    Felt, MAX_TX_EXECUTION_CYCLES, MIN_TX_EXECUTION_CYCLES, crypto::rand::RpoRandomCoin,
+};
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use wasm_bindgen::prelude::*;
 
@@ -88,7 +90,13 @@ impl WebClient {
             Box::new(rng),
             web_store.clone(),
             Arc::new(keystore.clone()),
-            false,
+            ExecutionOptions::new(
+                Some(MAX_TX_EXECUTION_CYCLES),
+                MIN_TX_EXECUTION_CYCLES,
+                false,
+                false,
+            )
+            .expect("Default executor's options should always be valid"),
             None,
             None,
         ));

--- a/crates/web-client/src/models/note.rs
+++ b/crates/web-client/src/models/note.rs
@@ -67,8 +67,8 @@ impl Note {
         NativeNote::new(assets.into(), metadata, recipient).into()
     }
 
-    #[wasm_bindgen(js_name = "createP2IDRNote")]
-    pub fn create_p2idr_note(
+    #[wasm_bindgen(js_name = "createP2IDENote")]
+    pub fn create_p2ide_note(
         sender: &AccountId,
         target: &AccountId,
         assets: &NoteAssets,
@@ -77,7 +77,7 @@ impl Note {
         recall_height: u32,
         aux: &Felt,
     ) -> Self {
-        let note_script = WellKnownNote::P2IDR.script();
+        let note_script = WellKnownNote::P2IDE.script();
 
         let inputs = NativeNoteInputs::new(vec![
             target.suffix().into(),

--- a/crates/web-client/src/models/note_script.rs
+++ b/crates/web-client/src/models/note_script.rs
@@ -12,7 +12,7 @@ impl NoteScript {
     }
 
     pub fn p2idr() -> Self {
-        WellKnownNote::P2IDR.script().into()
+        WellKnownNote::P2IDE.script().into()
     }
 
     pub fn swap() -> Self {

--- a/crates/web-client/src/models/transaction_script.rs
+++ b/crates/web-client/src/models/transaction_script.rs
@@ -1,14 +1,8 @@
-use miden_objects::{
-    Felt as NativeFelt, Word as NativeWord,
-    transaction::TransactionScript as NativeTransactionScript,
-};
+use miden_objects::transaction::TransactionScript as NativeTransactionScript;
 use wasm_bindgen::prelude::*;
 
 use super::rpo_digest::RpoDigest;
-use crate::{
-    js_error_with_context,
-    models::{assembler::Assembler, transaction_script_inputs::TransactionScriptInputPairArray},
-};
+use crate::{js_error_with_context, models::assembler::Assembler};
 
 #[derive(Clone)]
 #[wasm_bindgen]
@@ -20,18 +14,9 @@ impl TransactionScript {
         self.0.root().into()
     }
 
-    pub fn compile(
-        script_code: &str,
-        inputs: TransactionScriptInputPairArray,
-        assembler: &Assembler,
-    ) -> Result<TransactionScript, JsValue> {
-        let native_inputs: Vec<(NativeWord, Vec<NativeFelt>)> = inputs.into();
-
-        let native_tx_script =
-            NativeTransactionScript::compile(script_code, native_inputs, assembler.into())
-                .map_err(|err| {
-                    js_error_with_context(err, "failed to compile transaction script")
-                })?;
+    pub fn compile(script_code: &str, assembler: &Assembler) -> Result<TransactionScript, JsValue> {
+        let native_tx_script = NativeTransactionScript::compile(script_code, assembler.into())
+            .map_err(|err| js_error_with_context(err, "failed to compile transaction script"))?;
 
         Ok(TransactionScript(native_tx_script))
     }

--- a/crates/web-client/src/transactions.rs
+++ b/crates/web-client/src/transactions.rs
@@ -32,7 +32,7 @@ impl WebClient {
     pub fn compile_tx_script(&mut self, script: &str) -> Result<TransactionScript, JsValue> {
         if let Some(client) = self.get_mut_inner() {
             let native_tx_script: NativeTransactionScript =
-                client.compile_tx_script(vec![], script).map_err(|err| {
+                client.compile_tx_script(script).map_err(|err| {
                     js_error_with_context(err, "failed to compile transaction script")
                 })?;
             Ok(native_tx_script.into())

--- a/crates/web-client/test/fpi.test.ts
+++ b/crates/web-client/test/fpi.test.ts
@@ -72,7 +72,6 @@ export const testStandardFpi = async (): Promise<void> => {
                     call.::miden::contracts::auth::basic::auth_tx_rpo_falcon512 
                 end
             `,
-      new window.TransactionScriptInputPairArray(),
       window.TransactionKernel.assembler()
     );
 
@@ -123,7 +122,6 @@ export const testStandardFpi = async (): Promise<void> => {
 
     let compiledTxScript = window.TransactionScript.compile(
       txScript,
-      new window.TransactionScriptInputPairArray(),
       window.TransactionKernel.assembler()
     );
 

--- a/crates/web-client/test/new_transactions.test.ts
+++ b/crates/web-client/test/new_transactions.test.ts
@@ -685,11 +685,8 @@ export const customAccountComponent = async (): Promise<void> => {
         accountCode
       );
 
-    const inputs = new window.TransactionScriptInputPairArray();
-
     let txScript = window.TransactionScript.compile(
       scriptCode,
-      inputs,
       assembler.withLibrary(accountComponentLib)
     );
 

--- a/crates/web-client/yarn.lock
+++ b/crates/web-client/yarn.lock
@@ -93,7 +93,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
+"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -180,7 +180,7 @@
   dependencies:
     "@shikijs/types" "3.2.1"
 
-"@shikijs/types@3.2.1", "@shikijs/types@^3.2.1":
+"@shikijs/types@^3.2.1", "@shikijs/types@3.2.1":
   version "3.2.1"
   resolved "https://registry.npmjs.org/@shikijs/types/-/types-3.2.1.tgz"
   integrity sha512-/NTWAk4KE2M8uac0RhOsIhYQf4pdU0OywQuYDGIGAJ6Mjunxl2cGiuLkvu4HLCMn+OTTLRWkjZITp+aYJv60yA==
@@ -465,6 +465,11 @@ binary-extensions@^2.0.0:
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz"
   integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
 
+binaryen@^121.0.0:
+  version "121.0.0"
+  resolved "https://registry.npmjs.org/binaryen/-/binaryen-121.0.0.tgz"
+  integrity sha512-St5LX+CmVdDQMf+DDHWdne7eDK+8tH9TE4Kc+Xk3s5+CzVYIKeJbWuXgsKVbkdLJXGUc2eflFqjThQy555mBag==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
@@ -538,7 +543,7 @@ chai-as-promised@^8.0.0:
   dependencies:
     check-error "^2.0.0"
 
-chai@^5.1.1:
+chai@^5.1.1, "chai@>= 2.1.2 < 6":
   version "5.1.1"
   resolved "https://registry.npmjs.org/chai/-/chai-5.1.1.tgz"
   integrity sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==
@@ -637,15 +642,15 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
-  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
-
 color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-name@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
+  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
 colorette@^1.1.0:
   version "1.4.0"
@@ -718,19 +723,19 @@ data-uri-to-buffer@^6.0.2:
   resolved "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz"
   integrity sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==
 
-debug@4, debug@^4.1.1, debug@^4.3.4, debug@^4.3.5, debug@^4.3.6:
-  version "4.3.6"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz"
-  integrity sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==
-  dependencies:
-    ms "2.1.2"
-
 debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.1.1, debug@^4.3.4, debug@^4.3.5, debug@^4.3.6, debug@4:
+  version "4.3.6"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz"
+  integrity sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==
+  dependencies:
+    ms "2.1.2"
 
 decamelize@^4.0.0:
   version "4.0.0"
@@ -765,7 +770,7 @@ degenerator@^5.0.0:
     escodegen "^2.1.0"
     esprima "^4.0.1"
 
-devtools-protocol@0.0.1330662:
+devtools-protocol@*, devtools-protocol@0.0.1330662:
   version "0.0.1330662"
   resolved "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1330662.tgz"
   integrity sha512-pzh6YQ8zZfz3iKlCvgzVCu22NdpZ8hNmwU6WnQjNVquh0A9iVosPtNLWDwaWVGyrntQlltPFztTMK5Cg6lfCuw==
@@ -1102,7 +1107,18 @@ glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^8.0.3, glob@^8.1.0:
+glob@^8.0.3:
+  version "8.1.0"
+  resolved "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
+
+glob@^8.1.0:
   version "8.1.0"
   resolved "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz"
   integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
@@ -1538,7 +1554,14 @@ minimatch@^5.0.1, minimatch@^5.1.6:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^9.0.4, minimatch@^9.0.5:
+minimatch@^9.0.4:
+  version "9.0.5"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz"
+  integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimatch@^9.0.5:
   version "9.0.5"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz"
   integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
@@ -1606,15 +1629,15 @@ mocha@^10.7.3:
     yargs-parser "^20.2.9"
     yargs-unparser "^2.0.0"
 
-ms@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
-  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
-
 ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+ms@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 netmask@^2.0.2:
   version "2.0.2"
@@ -1944,7 +1967,7 @@ rollup-plugin-copy@^3.5.0:
     globby "10.0.1"
     is-plain-object "^3.0.0"
 
-rollup@^3.27.2:
+rollup@^1.20.0||^2.0.0||^3.0.0||^4.0.0, rollup@^2.68.0||^3.0.0||^4.0.0, rollup@^2.78.0||^3.0.0||^4.0.0, rollup@^3.27.2:
   version "3.29.4"
   resolved "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz"
   integrity sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==
@@ -1958,7 +1981,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-safe-buffer@5.1.2, safe-buffer@^5.1.0:
+safe-buffer@^5.1.0, safe-buffer@5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -2236,7 +2259,7 @@ typedoc-plugin-markdown@^4.6.0:
   resolved "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.6.1.tgz"
   integrity sha512-SrJv9zkpCWdG1cvtWniFU6M7MkCZuheN2R3fuqDPF+O+PeZ8bzmfj1ju/BJwoPWIKyFJVPhK8Sg6tBrM1y+VoA==
 
-typedoc@^0.28.1:
+typedoc@^0.28.1, typedoc@0.28.x:
   version "0.28.1"
   resolved "https://registry.npmjs.org/typedoc/-/typedoc-0.28.1.tgz"
   integrity sha512-Mn2VPNMaxoe/hlBiLriG4U55oyAa3Xo+8HbtEwV7F5WEOPXqtxzGuMZhJYHaqFJpajeQ6ZDUC2c990NAtTbdgw==
@@ -2247,7 +2270,7 @@ typedoc@^0.28.1:
     minimatch "^9.0.5"
     yaml "^2.7.0 "
 
-typescript@^5.5.4:
+typescript@^5.5.4, typescript@>=2.7, typescript@>=4.9.5, "typescript@5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x":
   version "5.5.4"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz"
   integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==

--- a/docs/src/web-client/api/classes/Note.md
+++ b/docs/src/web-client/api/classes/Note.md
@@ -82,45 +82,9 @@
 
 ***
 
-### createP2IDNote()
+### createP2IDENote()
 
-> `static` **createP2IDNote**(`sender`, `target`, `assets`, `note_type`, `serial_num`, `aux`): `Note`
-
-#### Parameters
-
-##### sender
-
-[`AccountId`](AccountId.md)
-
-##### target
-
-[`AccountId`](AccountId.md)
-
-##### assets
-
-[`NoteAssets`](NoteAssets.md)
-
-##### note\_type
-
-[`NoteType`](../enumerations/NoteType.md)
-
-##### serial\_num
-
-[`Word`](Word.md)
-
-##### aux
-
-[`Felt`](Felt.md)
-
-#### Returns
-
-`Note`
-
-***
-
-### createP2IDRNote()
-
-> `static` **createP2IDRNote**(`sender`, `target`, `assets`, `note_type`, `serial_num`, `recall_height`, `aux`): `Note`
+> `static` **createP2IDENote**(`sender`, `target`, `assets`, `note_type`, `serial_num`, `recall_height`, `aux`): `Note`
 
 #### Parameters
 
@@ -147,6 +111,42 @@
 ##### recall\_height
 
 `number`
+
+##### aux
+
+[`Felt`](Felt.md)
+
+#### Returns
+
+`Note`
+
+***
+
+### createP2IDNote()
+
+> `static` **createP2IDNote**(`sender`, `target`, `assets`, `note_type`, `serial_num`, `aux`): `Note`
+
+#### Parameters
+
+##### sender
+
+[`AccountId`](AccountId.md)
+
+##### target
+
+[`AccountId`](AccountId.md)
+
+##### assets
+
+[`NoteAssets`](NoteAssets.md)
+
+##### note\_type
+
+[`NoteType`](../enumerations/NoteType.md)
+
+##### serial\_num
+
+[`Word`](Word.md)
 
 ##### aux
 

--- a/docs/src/web-client/api/classes/TransactionScript.md
+++ b/docs/src/web-client/api/classes/TransactionScript.md
@@ -30,17 +30,13 @@
 
 ### compile()
 
-> `static` **compile**(`script_code`, `inputs`, `assembler`): `TransactionScript`
+> `static` **compile**(`script_code`, `assembler`): `TransactionScript`
 
 #### Parameters
 
 ##### script\_code
 
 `string`
-
-##### inputs
-
-[`TransactionScriptInputPairArray`](TransactionScriptInputPairArray.md)
 
 ##### assembler
 

--- a/tests/src/custom_transactions_tests.rs
+++ b/tests/src/custom_transactions_tests.rs
@@ -93,7 +93,7 @@ async fn transaction_request() {
 
     let failure_code = code.replace("{asserted_value}", "1");
 
-    let tx_script = client.compile_tx_script(vec![], &failure_code).unwrap();
+    let tx_script = client.compile_tx_script(&failure_code).unwrap();
 
     let transaction_request = TransactionRequestBuilder::new()
         .with_authenticated_input_notes(note_args_map.clone())
@@ -109,7 +109,7 @@ async fn transaction_request() {
 
     let success_code = code.replace("{asserted_value}", "0");
 
-    let tx_script = client.compile_tx_script(vec![], &success_code).unwrap();
+    let tx_script = client.compile_tx_script(&success_code).unwrap();
 
     let transaction_request = TransactionRequestBuilder::new()
         .with_authenticated_input_notes(note_args_map)
@@ -206,7 +206,7 @@ async fn merkle_store() {
     code += "call.auth_tx::auth_tx_rpo_falcon512 end";
 
     // Build the transaction
-    let tx_script = client.compile_tx_script(vec![], &code).unwrap();
+    let tx_script = client.compile_tx_script(&code).unwrap();
 
     let transaction_request = TransactionRequestBuilder::new()
         .with_authenticated_input_notes(note_args_map)

--- a/tests/src/fpi_tests.rs
+++ b/tests/src/fpi_tests.rs
@@ -80,7 +80,7 @@ async fn fpi_execute_program() {
         account_id_suffix = foreign_account_id.suffix(),
     );
 
-    let tx_script = client.compile_tx_script(vec![], &code).unwrap();
+    let tx_script = client.compile_tx_script(&code).unwrap();
     _ = client.sync_state().await.unwrap();
 
     // Wait for a couple of blocks so that the account gets committed
@@ -192,8 +192,7 @@ async fn nested_fpi_calls() {
         account_id_suffix = outer_foreign_account_id.suffix(),
     );
 
-    let tx_script =
-        TransactionScript::compile(tx_script, vec![], TransactionKernel::assembler()).unwrap();
+    let tx_script = TransactionScript::compile(tx_script, TransactionKernel::assembler()).unwrap();
     client.sync_state().await.unwrap();
 
     // Wait for a couple of blocks so that the account gets committed
@@ -278,8 +277,7 @@ async fn standard_fpi(storage_mode: AccountStorageMode) {
         account_id_suffix = foreign_account_id.suffix(),
     );
 
-    let tx_script =
-        TransactionScript::compile(tx_script, vec![], TransactionKernel::assembler()).unwrap();
+    let tx_script = TransactionScript::compile(tx_script, TransactionKernel::assembler()).unwrap();
     _ = client.sync_state().await.unwrap();
 
     // Wait for a couple of blocks so that the account gets committed
@@ -388,7 +386,6 @@ async fn deploy_foreign_account(
         "begin 
                 call.::miden::contracts::auth::basic::auth_tx_rpo_falcon512 
             end",
-        vec![],
         TransactionKernel::assembler(),
     )
     .unwrap();

--- a/tests/src/main_tests.rs
+++ b/tests/src/main_tests.rs
@@ -37,7 +37,7 @@ async fn client_builder_initializes_client_with_endpoint() -> Result<(), ClientE
         .build()
         .await?;
 
-    assert!(client.is_in_debug_mode());
+    assert!(client.in_debug_mode());
 
     let sync_summary = client.sync_state().await.expect("Sync state failed");
 

--- a/tests/src/network_transaction_tests.rs
+++ b/tests/src/network_transaction_tests.rs
@@ -214,8 +214,6 @@ async fn recall_note_before_ntx_consumes_it() {
         .unwrap()
         .0;
 
-    println!("A");
-
     let assembler = TransactionKernel::assembler()
         .with_debug_mode(true)
         .with_library(library)
@@ -232,22 +230,31 @@ async fn recall_note_before_ntx_consumes_it() {
         .build(&assembler)
         .unwrap();
 
+    // Prepare both transactions
     let tx_request = TransactionRequestBuilder::new()
         .with_own_output_notes(vec![OutputNote::Full(network_note.clone())])
         .build()
         .unwrap();
 
-    println!("B");
-
-    // Create the note directed to the network account
-    execute_tx_and_sync(&mut client, wallet.id(), tx_request).await;
+    let bump_transaction = client.new_transaction(wallet.id(), tx_request).await.unwrap();
+    client.testing_apply_transaction(bump_transaction.clone()).await.unwrap();
 
     let tx_request = TransactionRequestBuilder::new()
-        .build_consume_notes(vec![network_note.id()])
+        .with_unauthenticated_input_notes(vec![(network_note, None)])
+        .build()
         .unwrap();
 
-    // Consume the note before the network transaction
-    execute_tx_and_sync(&mut client, native_account.id(), tx_request).await;
+    let consume_transaction =
+        client.new_transaction(native_account.id(), tx_request).await.unwrap();
+
+    let bump_proof = client.testing_prove_transaction(&bump_transaction).await.unwrap();
+    let consume_proof = client.testing_prove_transaction(&consume_transaction).await.unwrap();
+
+    // Submit both transactions
+    client.testing_submit_proven_transaction(bump_proof).await.unwrap();
+    client.testing_submit_proven_transaction(consume_proof).await.unwrap();
+
+    client.testing_apply_transaction(consume_transaction).await.unwrap();
 
     wait_for_blocks(&mut client, 2).await;
 

--- a/tests/src/network_transaction_tests.rs
+++ b/tests/src/network_transaction_tests.rs
@@ -68,7 +68,6 @@ async fn deploy_counter_contract(
         begin
             call.counter_contract::increment_count
         end",
-        [],
         assembler.with_library(&library).unwrap(),
     )
     .unwrap();


### PR DESCRIPTION
This PR updates the version of the `miden-base` dependencies. This includes a couple of significant changes I'll specify below:
- The `TransactionExecutor` was changed and now it receives references to it's internal components. We don't need to own the executor in the client anymore. These changes close #987
- The client now receives `ExecutionOptions` that are passed to the executor when built.
- The P2IDR note was changed to P2IDE, with come changes. This PR makes only the most basic changes (as stated in this [comment](https://github.com/0xMiden/miden-client/pull/998#discussion_r2178335304)).
- The tx script no longer receives inputs, these are now passed to the Advice map.