### PR TITLE
chore: remove `with_` prefix from builder functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [BREAKING] Merged `concurrent` feature with `std` (#974).
 * [BREAKING] Changed `TransactionRequest` to use expected output recipients instead of output notes (#976).
 * [BREAKING] Removed `TransactionExecutor` from `Client` and `NoteScreener` (#998).
+* [BREAKING] Removed `with_` prefix from builder functions (#1018).
 
 ### Features
 

--- a/bin/miden-cli/src/commands/new_transactions.rs
+++ b/bin/miden-cli/src/commands/new_transactions.rs
@@ -308,8 +308,8 @@ impl ConsumeNotesCmd {
         }
 
         let transaction_request = TransactionRequestBuilder::new()
-            .with_authenticated_input_notes(authenticated_notes.into_iter().map(|id| (id, None)))
-            .with_unauthenticated_input_notes(unauthenticated_notes)
+            .authenticated_input_notes(authenticated_notes.into_iter().map(|id| (id, None)))
+            .unauthenticated_input_notes(unauthenticated_notes)
             .build()
             .map_err(|err| {
                 CliError::Transaction(

--- a/bin/miden-cli/src/lib.rs
+++ b/bin/miden-cli/src/lib.rs
@@ -115,19 +115,17 @@ impl Cli {
             .map_err(CliError::KeyStore)?;
 
         let mut builder = ClientBuilder::new()
-            .with_sqlite_store(
-                cli_config.store_filepath.to_str().expect("Store path should be valid"),
-            )
-            .with_tonic_rpc_client(
+            .sqlite_store(cli_config.store_filepath.to_str().expect("Store path should be valid"))
+            .tonic_rpc_client(
                 &cli_config.rpc.endpoint.clone().into(),
                 Some(cli_config.rpc.timeout_ms),
             )
-            .with_authenticator(Arc::new(keystore.clone()))
+            .authenticator(Arc::new(keystore.clone()))
             .in_debug_mode(in_debug_mode)
-            .with_tx_graceful_blocks(Some(TX_GRACEFUL_BLOCK_DELTA));
+            .tx_graceful_blocks(Some(TX_GRACEFUL_BLOCK_DELTA));
 
         if let Some(delta) = cli_config.max_block_number_delta {
-            builder = builder.with_max_block_number_delta(delta);
+            builder = builder.max_block_number_delta(delta);
         }
 
         let client = builder.build().await?;

--- a/bin/miden-cli/tests/cli.rs
+++ b/bin/miden-cli/tests/cli.rs
@@ -481,7 +481,7 @@ async fn debug_mode_outputs_logs() {
     // Send transaction and wait for it to be committed
     client.sync_state().await.unwrap();
     let transaction_request = TransactionRequestBuilder::new()
-        .with_own_output_notes(vec![OutputNote::Full(note.clone())])
+        .own_output_notes(vec![OutputNote::Full(note.clone())])
         .build()
         .unwrap();
     execute_tx_and_sync(&mut client, account.id(), transaction_request).await;

--- a/crates/rust-client/src/builder.rs
+++ b/crates/rust-client/src/builder.rs
@@ -53,7 +53,7 @@ pub struct ClientBuilder {
     store: Option<Arc<dyn Store>>,
     /// An optional RNG provided by the user.
     rng: Option<Box<dyn FeltRng>>,
-    /// The store path to use when no store is directly provided via `with_store()`.
+    /// The store path to use when no store is directly provided via `store()`.
     #[cfg(feature = "sqlite")]
     store_path: String,
     /// The keystore configuration provided by the user.
@@ -100,7 +100,7 @@ impl ClientBuilder {
 
     /// Sets a custom RPC client directly.
     #[must_use]
-    pub fn with_rpc(mut self, client: Arc<dyn NodeRpcClient + Send>) -> Self {
+    pub fn rpc(mut self, client: Arc<dyn NodeRpcClient + Send>) -> Self {
         self.rpc_api = Some(client);
         self
     }
@@ -108,7 +108,7 @@ impl ClientBuilder {
     /// Sets the a tonic RPC client from the endpoint and optional timeout.
     #[cfg(feature = "tonic")]
     #[must_use]
-    pub fn with_tonic_rpc_client(mut self, endpoint: &Endpoint, timeout_ms: Option<u64>) -> Self {
+    pub fn tonic_rpc_client(mut self, endpoint: &Endpoint, timeout_ms: Option<u64>) -> Self {
         self.rpc_api = Some(Arc::new(TonicRpcClient::new(endpoint, timeout_ms.unwrap_or(10_000))));
         self
     }
@@ -116,28 +116,28 @@ impl ClientBuilder {
     /// Optionally set a custom store path.
     #[cfg(feature = "sqlite")]
     #[must_use]
-    pub fn with_sqlite_store(mut self, path: &str) -> Self {
+    pub fn sqlite_store(mut self, path: &str) -> Self {
         self.store_path = path.to_string();
         self
     }
 
     /// Optionally provide a store directly.
     #[must_use]
-    pub fn with_store(mut self, store: Arc<dyn Store>) -> Self {
+    pub fn store(mut self, store: Arc<dyn Store>) -> Self {
         self.store = Some(store);
         self
     }
 
     /// Optionally provide a custom RNG.
     #[must_use]
-    pub fn with_rng(mut self, rng: Box<dyn FeltRng>) -> Self {
+    pub fn rng(mut self, rng: Box<dyn FeltRng>) -> Self {
         self.rng = Some(rng);
         self
     }
 
     /// Optionally provide a custom authenticator instance.
     #[must_use]
-    pub fn with_authenticator(mut self, authenticator: Arc<dyn TransactionAuthenticator>) -> Self {
+    pub fn authenticator(mut self, authenticator: Arc<dyn TransactionAuthenticator>) -> Self {
         self.keystore = Some(AuthenticatorConfig::Instance(authenticator));
         self
     }
@@ -145,7 +145,7 @@ impl ClientBuilder {
     /// Optionally set a maximum number of blocks that the client can be behind the network.
     /// By default, there's no maximum.
     #[must_use]
-    pub fn with_max_block_number_delta(mut self, delta: u32) -> Self {
+    pub fn max_block_number_delta(mut self, delta: u32) -> Self {
         self.max_block_number_delta = Some(delta);
         self
     }
@@ -154,7 +154,7 @@ impl ClientBuilder {
     /// `None`, there is no limit and transactions will be kept indefinitely.
     /// By default, the maximum is set to `TX_GRACEFUL_BLOCKS`.
     #[must_use]
-    pub fn with_tx_graceful_blocks(mut self, delta: Option<u32>) -> Self {
+    pub fn tx_graceful_blocks(mut self, delta: Option<u32>) -> Self {
         self.tx_graceful_blocks = delta;
         self
     }
@@ -164,7 +164,7 @@ impl ClientBuilder {
     /// This stores the keystore path as a configuration option so that actual keystore
     /// initialization is deferred until `build()`. This avoids panicking during builder chaining.
     #[must_use]
-    pub fn with_filesystem_keystore(mut self, keystore_path: &str) -> Self {
+    pub fn filesystem_keystore(mut self, keystore_path: &str) -> Self {
         self.keystore = Some(AuthenticatorConfig::Path(keystore_path.to_string()));
         self
     }
@@ -183,7 +183,7 @@ impl ClientBuilder {
             client
         } else {
             return Err(ClientError::ClientInitializationError(
-                "RPC client or endpoint is required. Call `.with_rpc(...)` or `.with_tonic_rpc_client(...)` if `tonic` is enabled."
+                "RPC client or endpoint is required. Call `.rpc(...)` or `.tonic_rpc_client(...)` if `tonic` is enabled."
                     .into(),
             ));
         };
@@ -201,7 +201,7 @@ impl ClientBuilder {
             store
         } else {
             return Err(ClientError::ClientInitializationError(
-                "Store must be specified. Call `.with_store(...)` or `.with_sqlite_store(...)` with a store path if `sqlite` is enabled."
+                "Store must be specified. Call `.store(...)` or `.sqlite_store(...)` with a store path if `sqlite` is enabled."
                     .into(),
             ));
         };
@@ -225,7 +225,7 @@ impl ClientBuilder {
             },
             None => {
                 return Err(ClientError::ClientInitializationError(
-                    "Keystore must be specified. Call `.with_keystore(...)` or `.with_filesystem_keystore(...)` with a keystore path."
+                    "Keystore must be specified. Call `.keystore(...)` or `.filesystem_keystore(...)` with a keystore path."
                         .into(),
                 ))
             }

--- a/crates/rust-client/src/test_utils/common.rs
+++ b/crates/rust-client/src/test_utils/common.rs
@@ -82,12 +82,12 @@ pub async fn create_test_client_builder() -> (ClientBuilder, TestClientKeyStore)
     let keystore = FilesystemKeyStore::new(auth_path.clone()).unwrap();
 
     let builder = ClientBuilder::new()
-        .with_rpc(Arc::new(TonicRpcClient::new(&rpc_endpoint, rpc_timeout)))
-        .with_rng(Box::new(rng))
-        .with_store(store)
-        .with_filesystem_keystore(auth_path.to_str().unwrap())
+        .rpc(Arc::new(TonicRpcClient::new(&rpc_endpoint, rpc_timeout)))
+        .rng(Box::new(rng))
+        .store(store)
+        .filesystem_keystore(auth_path.to_str().unwrap())
         .in_debug_mode(true)
-        .with_tx_graceful_blocks(None);
+        .tx_graceful_blocks(None);
 
     (builder, keystore)
 }
@@ -504,7 +504,7 @@ pub fn mint_multiple_fungible_asset(
         })
         .collect::<Vec<OutputNote>>();
 
-    TransactionRequestBuilder::new().with_own_output_notes(notes).build().unwrap()
+    TransactionRequestBuilder::new().own_output_notes(notes).build().unwrap()
 }
 
 /// Executes a transaction and consumes the resulting unauthenticated notes inmediately without
@@ -524,7 +524,7 @@ pub async fn execute_tx_and_consume_output_notes(
     execute_tx(client, executor, tx_request).await;
 
     let tx_request = TransactionRequestBuilder::new()
-        .with_unauthenticated_input_notes(output_notes)
+        .unauthenticated_input_notes(output_notes)
         .build()
         .unwrap();
     let transaction_id = execute_tx(client, consumer, tx_request).await;

--- a/crates/rust-client/src/tests.rs
+++ b/crates/rust-client/src/tests.rs
@@ -92,12 +92,12 @@ pub async fn create_test_client_builder() -> (ClientBuilder, MockRpcApi, Filesys
     let arc_rpc_api = Arc::new(rpc_api.clone());
 
     let builder = ClientBuilder::new()
-        .with_rpc(arc_rpc_api)
-        .with_rng(Box::new(rng))
-        .with_store(store)
-        .with_filesystem_keystore(keystore_path.to_str().unwrap())
+        .rpc(arc_rpc_api)
+        .rng(Box::new(rng))
+        .store(store)
+        .filesystem_keystore(keystore_path.to_str().unwrap())
         .in_debug_mode(true)
-        .with_tx_graceful_blocks(None);
+        .tx_graceful_blocks(None);
 
     (builder, rpc_api, keystore)
 }
@@ -637,7 +637,7 @@ async fn transaction_request_expiration() {
             .unwrap();
 
     let transaction_request = TransactionRequestBuilder::new()
-        .with_expiration_delta(5)
+        .expiration_delta(5)
         .build_mint_fungible_asset(
             FungibleAsset::new(faucet.id(), 5u64).unwrap(),
             AccountId::try_from(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE).unwrap(),
@@ -688,7 +688,7 @@ async fn import_processing_note_returns_error() {
 
     let input = [(note.try_into().unwrap(), None)];
     let consume_note_request = TransactionRequestBuilder::new()
-        .with_unauthenticated_input_notes(input)
+        .unauthenticated_input_notes(input)
         .build()
         .unwrap();
     let transaction = client
@@ -736,7 +736,7 @@ async fn note_without_asset() {
 
     // Create and execute transaction
     let transaction_request = TransactionRequestBuilder::new()
-        .with_own_output_notes(vec![OutputNote::Full(note)])
+        .own_output_notes(vec![OutputNote::Full(note)])
         .build()
         .unwrap();
 
@@ -751,7 +751,7 @@ async fn note_without_asset() {
     let note = Note::new(vault, metadata, recipient);
 
     let transaction_request = TransactionRequestBuilder::new()
-        .with_own_output_notes(vec![OutputNote::Full(note)])
+        .own_output_notes(vec![OutputNote::Full(note)])
         .build()
         .unwrap();
 
@@ -1390,8 +1390,7 @@ async fn get_output_notes() {
 async fn account_rollback() {
     let (builder, rpc_api, authenticator) = create_test_client_builder().await;
 
-    let mut client =
-        builder.with_tx_graceful_blocks(Some(TX_GRACEFUL_BLOCKS)).build().await.unwrap();
+    let mut client = builder.tx_graceful_blocks(Some(TX_GRACEFUL_BLOCKS)).build().await.unwrap();
 
     client.sync_state().await.unwrap();
 
@@ -1495,7 +1494,7 @@ async fn subsequent_discarded_transactions() {
     // Create a transaction that will expire in 2 blocks
     let asset = FungibleAsset::new(faucet_account_id, TRANSFER_AMOUNT).unwrap();
     let tx_request = TransactionRequestBuilder::new()
-        .with_expiration_delta(2)
+        .expiration_delta(2)
         .build_pay_to_id(
             PaymentTransactionData::new(vec![Asset::Fungible(asset)], account_id, account_id),
             None,
@@ -1589,7 +1588,7 @@ async fn missing_recipient_digest() {
     let dummy_recipient_digest = dummy_recipient.digest();
 
     let tx_request = TransactionRequestBuilder::new()
-        .with_expected_output_recipients(vec![dummy_recipient])
+        .expected_output_recipients(vec![dummy_recipient])
         .build_mint_fungible_asset(
             FungibleAsset::new(faucet.id(), 5u64).unwrap(),
             AccountId::try_from(ACCOUNT_ID_PRIVATE_SENDER).unwrap(),

--- a/crates/rust-client/src/transaction/request/builder.rs
+++ b/crates/rust-client/src/transaction/request/builder.rs
@@ -85,7 +85,7 @@ impl TransactionRequestBuilder {
 
     /// Adds the specified notes as unauthenticated input notes to the transaction request.
     #[must_use]
-    pub fn with_unauthenticated_input_notes(
+    pub fn unauthenticated_input_notes(
         mut self,
         notes: impl IntoIterator<Item = (Note, Option<NoteArgs>)>,
     ) -> Self {
@@ -98,7 +98,7 @@ impl TransactionRequestBuilder {
 
     /// Adds the specified notes as authenticated input notes to the transaction request.
     #[must_use]
-    pub fn with_authenticated_input_notes(
+    pub fn authenticated_input_notes(
         mut self,
         notes: impl IntoIterator<Item = (NoteId, Option<NoteArgs>)>,
     ) -> Self {
@@ -115,7 +115,7 @@ impl TransactionRequestBuilder {
     /// If a transaction script template is already set (e.g. by calling `with_custom_script`), the
     /// [`TransactionRequestBuilder::build`] method will return an error.
     #[must_use]
-    pub fn with_own_output_notes(mut self, notes: impl IntoIterator<Item = OutputNote>) -> Self {
+    pub fn own_output_notes(mut self, notes: impl IntoIterator<Item = OutputNote>) -> Self {
         for note in notes {
             if let OutputNote::Full(note) = &note {
                 self.expected_output_recipients
@@ -133,7 +133,7 @@ impl TransactionRequestBuilder {
     /// If a script template is already set (e.g. by calling `with_own_output_notes`), the
     /// [`TransactionRequestBuilder::build`] method will return an error.
     #[must_use]
-    pub fn with_custom_script(mut self, script: TransactionScript) -> Self {
+    pub fn custom_script(mut self, script: TransactionScript) -> Self {
         self.custom_script = Some(script);
         self
     }
@@ -149,7 +149,7 @@ impl TransactionRequestBuilder {
     /// - **Private accounts**: the node retrieves a proof of the account's existence and injects
     ///   that as advice inputs.
     #[must_use]
-    pub fn with_foreign_accounts(
+    pub fn foreign_accounts(
         mut self,
         foreign_accounts: impl IntoIterator<Item = impl Into<ForeignAccount>>,
     ) -> Self {
@@ -168,7 +168,7 @@ impl TransactionRequestBuilder {
     /// specified expected recipients, but it may also create notes for other recipients not
     /// included in this set.
     #[must_use]
-    pub fn with_expected_output_recipients(mut self, recipients: Vec<NoteRecipient>) -> Self {
+    pub fn expected_output_recipients(mut self, recipients: Vec<NoteRecipient>) -> Self {
         self.expected_output_recipients = recipients
             .into_iter()
             .map(|recipient| (recipient.digest(), recipient))
@@ -182,7 +182,7 @@ impl TransactionRequestBuilder {
     /// For example, after a SWAP note is consumed, a payback note is expected to be created. This
     /// allows the client to track this note accordingly.
     #[must_use]
-    pub fn with_expected_future_notes(mut self, notes: Vec<(NoteDetails, NoteTag)>) -> Self {
+    pub fn expected_future_notes(mut self, notes: Vec<(NoteDetails, NoteTag)>) -> Self {
         self.expected_future_notes =
             notes.into_iter().map(|note| (note.0.id(), note)).collect::<BTreeMap<_, _>>();
         self
@@ -212,7 +212,7 @@ impl TransactionRequestBuilder {
     /// but other code executed during the transaction may impose an even smaller transaction
     /// expiration delta.
     #[must_use]
-    pub fn with_expiration_delta(mut self, expiration_delta: u16) -> Self {
+    pub fn expiration_delta(mut self, expiration_delta: u16) -> Self {
         self.expiration_delta = Some(expiration_delta);
         self
     }
@@ -237,7 +237,7 @@ impl TransactionRequestBuilder {
         note_ids: Vec<NoteId>,
     ) -> Result<TransactionRequest, TransactionRequestError> {
         let input_notes = note_ids.into_iter().map(|id| (id, None));
-        self.with_authenticated_input_notes(input_notes).build()
+        self.authenticated_input_notes(input_notes).build()
     }
 
     /// Consumes the builder and returns a [`TransactionRequest`] for a transaction to mint fungible
@@ -266,7 +266,7 @@ impl TransactionRequestBuilder {
             rng,
         )?;
 
-        self.with_own_output_notes(vec![OutputNote::Full(created_note)]).build()
+        self.own_output_notes(vec![OutputNote::Full(created_note)]).build()
     }
 
     /// Consumes the builder and returns a [`TransactionRequest`] for a transaction to send a P2ID
@@ -323,7 +323,7 @@ impl TransactionRequestBuilder {
             )?
         };
 
-        self.with_own_output_notes(vec![OutputNote::Full(created_note)]).build()
+        self.own_output_notes(vec![OutputNote::Full(created_note)]).build()
     }
 
     /// Consumes the builder and returns a [`TransactionRequest`] for a transaction to send a SWAP
@@ -355,8 +355,8 @@ impl TransactionRequestBuilder {
 
         let payback_tag = NoteTag::from_account_id(swap_data.account_id());
 
-        self.with_expected_future_notes(vec![(payback_note_details, payback_tag)])
-            .with_own_output_notes(vec![OutputNote::Full(created_note)])
+        self.expected_future_notes(vec![(payback_note_details, payback_tag)])
+            .own_output_notes(vec![OutputNote::Full(created_note)])
             .build()
     }
 

--- a/crates/rust-client/src/transaction/request/mod.rs
+++ b/crates/rust-client/src/transaction/request/mod.rs
@@ -435,15 +435,15 @@ mod tests {
 
         // This transaction request wouldn't be valid in a real scenario, it's intended for testing
         let tx_request = TransactionRequestBuilder::new()
-            .with_authenticated_input_notes(vec![(notes.pop().unwrap().id(), None)])
-            .with_unauthenticated_input_notes(vec![(notes.pop().unwrap(), None)])
-            .with_expected_output_recipients(vec![notes.pop().unwrap().recipient().clone()])
-            .with_expected_future_notes(vec![(
+            .authenticated_input_notes(vec![(notes.pop().unwrap().id(), None)])
+            .unauthenticated_input_notes(vec![(notes.pop().unwrap(), None)])
+            .expected_output_recipients(vec![notes.pop().unwrap().recipient().clone()])
+            .expected_future_notes(vec![(
                 notes.pop().unwrap().into(),
                 NoteTag::from_account_id(sender_id),
             )])
             .extend_advice_map(advice_vec)
-            .with_foreign_accounts([
+            .foreign_accounts([
                 ForeignAccount::public(
                     target_id,
                     AccountStorageRequirements::new([(5u8, &[Digest::default()])]),
@@ -451,7 +451,7 @@ mod tests {
                 .unwrap(),
                 ForeignAccount::private(account).unwrap(),
             ])
-            .with_own_output_notes(vec![
+            .own_output_notes(vec![
                 OutputNote::Full(notes.pop().unwrap()),
                 OutputNote::Partial(notes.pop().unwrap().into()),
             ])

--- a/crates/web-client/src/models/transaction_request/transaction_request_builder.rs
+++ b/crates/web-client/src/models/transaction_request/transaction_request_builder.rs
@@ -39,7 +39,7 @@ impl TransactionRequestBuilder {
     #[wasm_bindgen(js_name = "withUnauthenticatedInputNotes")]
     pub fn with_unauthenticated_input_notes(mut self, notes: &NoteAndArgsArray) -> Self {
         let native_note_and_note_args: Vec<(NativeNote, Option<NativeNoteArgs>)> = notes.into();
-        self.0 = self.0.clone().with_unauthenticated_input_notes(native_note_and_note_args);
+        self.0 = self.0.clone().unauthenticated_input_notes(native_note_and_note_args);
         self
     }
 
@@ -47,28 +47,28 @@ impl TransactionRequestBuilder {
     pub fn with_authenticated_input_notes(mut self, notes: &NoteIdAndArgsArray) -> Self {
         let native_note_id_and_note_args: Vec<(NativeNoteId, Option<NativeNoteArgs>)> =
             notes.into();
-        self.0 = self.0.clone().with_authenticated_input_notes(native_note_id_and_note_args);
+        self.0 = self.0.clone().authenticated_input_notes(native_note_id_and_note_args);
         self
     }
 
     #[wasm_bindgen(js_name = "withOwnOutputNotes")]
     pub fn with_own_output_notes(mut self, notes: &OutputNotesArray) -> Self {
         let native_output_notes: Vec<NativeOutputNote> = notes.into();
-        self.0 = self.0.clone().with_own_output_notes(native_output_notes);
+        self.0 = self.0.clone().own_output_notes(native_output_notes);
         self
     }
 
     #[wasm_bindgen(js_name = "withCustomScript")]
     pub fn with_custom_script(mut self, script: &TransactionScript) -> Self {
         let native_script: NativeTransactionScript = script.into();
-        self.0 = self.0.clone().with_custom_script(native_script);
+        self.0 = self.0.clone().custom_script(native_script);
         self
     }
 
     #[wasm_bindgen(js_name = "withExpectedOutputRecipients")]
     pub fn with_expected_output_notes(mut self, recipients: &RecipientArray) -> Self {
         let native_recipients: Vec<NativeNoteRecipient> = recipients.into();
-        self.0 = self.0.clone().with_expected_output_recipients(native_recipients);
+        self.0 = self.0.clone().expected_output_recipients(native_recipients);
         self
     }
 
@@ -79,7 +79,7 @@ impl TransactionRequestBuilder {
     ) -> Self {
         let native_note_details_and_tag: Vec<(NativeNoteDetails, NativeNoteTag)> =
             note_details_and_tag.into();
-        self.0 = self.0.clone().with_expected_future_notes(native_note_details_and_tag);
+        self.0 = self.0.clone().expected_future_notes(native_note_details_and_tag);
         self
     }
 
@@ -94,7 +94,7 @@ impl TransactionRequestBuilder {
     pub fn with_foreign_accounts(mut self, foreign_accounts: Vec<ForeignAccount>) -> Self {
         let native_foreign_accounts: Vec<NativeForeignAccount> =
             foreign_accounts.into_iter().map(Into::into).collect();
-        self.0 = self.0.clone().with_foreign_accounts(native_foreign_accounts);
+        self.0 = self.0.clone().foreign_accounts(native_foreign_accounts);
         self
     }
 

--- a/tests/src/custom_transactions_tests.rs
+++ b/tests/src/custom_transactions_tests.rs
@@ -95,7 +95,7 @@ async fn transaction_request() {
     // FAILURE ATTEMPT
     let transaction_request = TransactionRequestBuilder::new()
         .authenticated_input_notes(note_args_map.clone())
-        .custom_script(tx_script)
+        .custom_script(tx_script.clone())
         .script_arg([ZERO, ZERO, ZERO, ZERO])
         .extend_advice_map(advice_map.clone())
         .build()

--- a/tests/src/custom_transactions_tests.rs
+++ b/tests/src/custom_transactions_tests.rs
@@ -96,8 +96,8 @@ async fn transaction_request() {
     let tx_script = client.compile_tx_script(&failure_code).unwrap();
 
     let transaction_request = TransactionRequestBuilder::new()
-        .with_authenticated_input_notes(note_args_map.clone())
-        .with_custom_script(tx_script)
+        .authenticated_input_notes(note_args_map.clone())
+        .custom_script(tx_script)
         .extend_advice_map(advice_map.clone())
         .build()
         .unwrap();
@@ -112,8 +112,8 @@ async fn transaction_request() {
     let tx_script = client.compile_tx_script(&success_code).unwrap();
 
     let transaction_request = TransactionRequestBuilder::new()
-        .with_authenticated_input_notes(note_args_map)
-        .with_custom_script(tx_script)
+        .authenticated_input_notes(note_args_map)
+        .custom_script(tx_script)
         .extend_advice_map(advice_map)
         .build()
         .unwrap();
@@ -209,8 +209,8 @@ async fn merkle_store() {
     let tx_script = client.compile_tx_script(&code).unwrap();
 
     let transaction_request = TransactionRequestBuilder::new()
-        .with_authenticated_input_notes(note_args_map)
-        .with_custom_script(tx_script)
+        .authenticated_input_notes(note_args_map)
+        .custom_script(tx_script)
         .extend_advice_map(advice_map)
         .extend_merkle_store(merkle_store.inner_nodes())
         .build()
@@ -271,7 +271,7 @@ async fn onchain_notes_sync_with_tag() {
 
     // Send transaction and wait for it to be committed
     let tx_request = TransactionRequestBuilder::new()
-        .with_own_output_notes(vec![OutputNote::Full(note.clone())])
+        .own_output_notes(vec![OutputNote::Full(note.clone())])
         .build()
         .unwrap();
 
@@ -306,7 +306,7 @@ async fn mint_custom_note(
     let note = create_custom_note(client, faucet_account_id, target_account_id, &mut random_coin);
 
     let transaction_request = TransactionRequestBuilder::new()
-        .with_own_output_notes(vec![OutputNote::Full(note.clone())])
+        .own_output_notes(vec![OutputNote::Full(note.clone())])
         .build()
         .unwrap();
 

--- a/tests/src/fpi_tests.rs
+++ b/tests/src/fpi_tests.rs
@@ -199,7 +199,7 @@ async fn nested_fpi_calls() {
     wait_for_blocks(&mut client, 2).await;
 
     // Create transaction request with FPI
-    let builder = TransactionRequestBuilder::new().with_custom_script(tx_script);
+    let builder = TransactionRequestBuilder::new().custom_script(tx_script);
 
     // We will require slot 0, key `MAP_KEY` as well as account proof
     let storage_requirements =
@@ -210,7 +210,7 @@ async fn nested_fpi_calls() {
         ForeignAccount::public(outer_foreign_account_id, storage_requirements).unwrap(),
     ];
 
-    let tx_request = builder.with_foreign_accounts(foreign_accounts).build().unwrap();
+    let tx_request = builder.foreign_accounts(foreign_accounts).build().unwrap();
     let tx_result = client.new_transaction(native_account.id(), tx_request).await.unwrap();
 
     client.submit_transaction(tx_result).await.unwrap();
@@ -292,7 +292,7 @@ async fn standard_fpi(storage_mode: AccountStorageMode) {
     assert!(foreign_accounts.is_empty());
 
     // Create transaction request with FPI
-    let builder = TransactionRequestBuilder::new().with_custom_script(tx_script);
+    let builder = TransactionRequestBuilder::new().custom_script(tx_script);
 
     // We will require slot 0, key `MAP_KEY` as well as account proof
     let storage_requirements =
@@ -307,7 +307,7 @@ async fn standard_fpi(storage_mode: AccountStorageMode) {
         ForeignAccount::private(foreign_account)
     };
 
-    let tx_request = builder.with_foreign_accounts([foreign_account.unwrap()]).build().unwrap();
+    let tx_request = builder.foreign_accounts([foreign_account.unwrap()]).build().unwrap();
     let tx_result = client.new_transaction(native_account.id(), tx_request).await.unwrap();
 
     client.submit_transaction(tx_result).await.unwrap();
@@ -396,7 +396,7 @@ async fn deploy_foreign_account(
         .new_transaction(
             foreign_account_id,
             TransactionRequestBuilder::new()
-                .with_custom_script(deployment_tx_script)
+                .custom_script(deployment_tx_script)
                 .build()
                 .unwrap(),
         )

--- a/tests/src/main_tests.rs
+++ b/tests/src/main_tests.rs
@@ -30,9 +30,9 @@ async fn client_builder_initializes_client_with_endpoint() -> Result<(), ClientE
     let (_, _, store_config, auth_path) = get_client_config();
 
     let mut client = ClientBuilder::new()
-        .with_tonic_rpc_client(&Endpoint::default(), Some(10_000))
-        .with_filesystem_keystore(auth_path.to_str().unwrap())
-        .with_sqlite_store(store_config.to_str().unwrap())
+        .tonic_rpc_client(&Endpoint::default(), Some(10_000))
+        .filesystem_keystore(auth_path.to_str().unwrap())
+        .sqlite_store(store_config.to_str().unwrap())
         .in_debug_mode(true)
         .build()
         .await?;
@@ -50,8 +50,8 @@ async fn client_builder_initializes_client_with_endpoint() -> Result<(), ClientE
 async fn client_builder_fails_without_keystore() {
     let (_, _, store_config, _) = get_client_config();
     let result = ClientBuilder::new()
-        .with_tonic_rpc_client(&Endpoint::default(), Some(10_000))
-        .with_sqlite_store(store_config.to_str().unwrap())
+        .tonic_rpc_client(&Endpoint::default(), Some(10_000))
+        .sqlite_store(store_config.to_str().unwrap())
         .in_debug_mode(true)
         .build()
         .await;
@@ -616,14 +616,12 @@ async fn consume_multiple_expected_notes() {
 
     // Create and execute transactions
     let tx_request_1 = TransactionRequestBuilder::new()
-        .with_authenticated_input_notes(client_owned_notes.iter().map(|note| (note.id(), None)))
+        .authenticated_input_notes(client_owned_notes.iter().map(|note| (note.id(), None)))
         .build_consume_notes(client_owned_notes.iter().map(|note| note.id()).collect())
         .unwrap();
 
     let tx_request_2 = TransactionRequestBuilder::new()
-        .with_unauthenticated_input_notes(
-            unauth_owned_notes.iter().map(|note| ((*note).clone(), None)),
-        )
+        .unauthenticated_input_notes(unauth_owned_notes.iter().map(|note| ((*note).clone(), None)))
         .build_consume_notes(unauth_owned_notes.iter().map(|note| note.id()).collect())
         .unwrap();
 
@@ -1087,7 +1085,7 @@ async fn expired_transaction_fails() {
     let fungible_asset = FungibleAsset::new(faucet_account_id, MINT_AMOUNT).unwrap();
     println!("Minting Asset");
     let tx_request = TransactionRequestBuilder::new()
-        .with_expiration_delta(expiration_delta)
+        .expiration_delta(expiration_delta)
         .build_mint_fungible_asset(fungible_asset, from_account_id, NoteType::Public, client.rng())
         .unwrap();
 

--- a/tests/src/network_transaction_tests.rs
+++ b/tests/src/network_transaction_tests.rs
@@ -79,7 +79,7 @@ async fn deploy_counter_contract(
 
     // Build a transaction request with the custom script
     let tx_increment_request =
-        TransactionRequestBuilder::new().with_custom_script(tx_script).build().unwrap();
+        TransactionRequestBuilder::new().custom_script(tx_script).build().unwrap();
 
     // Execute the transaction locally
     let tx_result = client.new_transaction(acc.id(), tx_increment_request).await.unwrap();
@@ -184,7 +184,7 @@ async fn counter_contract_ntx() {
     }
 
     let tx_request = TransactionRequestBuilder::new()
-        .with_own_output_notes(network_notes)
+        .own_output_notes(network_notes)
         .build()
         .unwrap();
 
@@ -243,7 +243,7 @@ async fn recall_note_before_ntx_consumes_it() {
 
     // Prepare both transactions
     let tx_request = TransactionRequestBuilder::new()
-        .with_own_output_notes(vec![OutputNote::Full(network_note.clone())])
+        .own_output_notes(vec![OutputNote::Full(network_note.clone())])
         .build()
         .unwrap();
 
@@ -251,7 +251,7 @@ async fn recall_note_before_ntx_consumes_it() {
     client.testing_apply_transaction(bump_transaction.clone()).await.unwrap();
 
     let tx_request = TransactionRequestBuilder::new()
-        .with_unauthenticated_input_notes(vec![(network_note, None)])
+        .unauthenticated_input_notes(vec![(network_note, None)])
         .build()
         .unwrap();
 


### PR DESCRIPTION
stemming from https://github.com/0xMiden/miden-client/pull/1017#discussion_r2190629555

This PR removes the `with_` prefix from builders to better follow rust naming conventions and to simplify function names.