### PR TITLE
Export `ScriptBuilder` from miden-base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [BREAKING] Renamed P2IDR to P2IDE (#1016).
 * Replaced deprecated #[clap(...)] with #[command(...)] and #[arg(...)] (#897).
 * [BREAKING] Removed `with_` prefix from builder functions (#1018).
+* Added a way to instantiate a `ScriptBuilder` from `Client` (#1022).
 
 ### Features
 

--- a/bin/miden-cli/src/commands/exec.rs
+++ b/bin/miden-cli/src/commands/exec.rs
@@ -79,7 +79,7 @@ impl ExecCmd {
         let mut advice_inputs = AdviceInputs::default();
         advice_inputs.extend_map(inputs);
 
-        let tx_script = client.compile_tx_script(&program)?;
+        let tx_script = client.script_builder().compile_tx_script(&program)?;
 
         let result = client
             .execute_program(account_id, tx_script, advice_inputs, BTreeSet::new())

--- a/bin/miden-cli/src/errors.rs
+++ b/bin/miden-cli/src/errors.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 
 use miden_client::{ClientError, keystore::KeyStoreError};
+use miden_lib::utils::ScriptBuilderError;
 use miden_objects::{AccountError, AccountIdError, AssetError, NetworkIdError};
 use miette::Diagnostic;
 use thiserror::Error;
@@ -63,6 +64,9 @@ pub enum CliError {
     #[error("parse error: {1}")]
     #[diagnostic(code(cli::parse_error), help("Check the inputs."))]
     Parse(#[source] SourceError, String),
+    #[error("script builder error")]
+    #[diagnostic(code(cli::script_builder_error))]
+    ScriptBuilder(#[from] ScriptBuilderError),
     #[error("transaction error: {1}")]
     #[diagnostic(code(cli::transaction_error))]
     Transaction(#[source] SourceError, String),

--- a/bin/miden-cli/tests/cli.rs
+++ b/bin/miden-cli/tests/cli.rs
@@ -463,7 +463,7 @@ async fn debug_mode_outputs_logs() {
                 assert_eq
             end
             ";
-    let note_script = client.compile_note_script(note_script).unwrap();
+    let note_script = client.script_builder().compile_note_script(note_script).unwrap();
     let inputs = NoteInputs::new(vec![]).unwrap();
     let serial_num = client.rng().draw_word();
     let note_metadata = NoteMetadata::new(

--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -206,6 +206,7 @@ pub mod testing {
 
 use alloc::sync::Arc;
 
+use miden_lib::utils::ScriptBuilder;
 use miden_objects::crypto::rand::FeltRng;
 use miden_tx::{LocalTransactionProver, auth::TransactionAuthenticator};
 use rand::RngCore;
@@ -300,6 +301,11 @@ impl Client {
     /// Returns true if the client is in debug mode.
     pub fn in_debug_mode(&self) -> bool {
         self.exec_options.enable_debugging()
+    }
+
+    /// Returns an instance of the `ScriptBuilder`
+    pub fn script_builder(&self) -> ScriptBuilder {
+        ScriptBuilder::new(self.in_debug_mode())
     }
 
     /// Returns a reference to the client's random number generator. This can be used to generate

--- a/crates/rust-client/src/note/mod.rs
+++ b/crates/rust-client/src/note/mod.rs
@@ -46,7 +46,7 @@
 //!
 //! // Compile the note script
 //! let script_src = "begin push.9 push.12 add end";
-//! let note_script = client.compile_note_script(script_src)?;
+//! let note_script = client.script_builder().compile_note_script(script_src)?;
 //! println!("Compiled note script successfully.");
 //!
 //! # Ok(())
@@ -58,7 +58,6 @@
 
 use alloc::{string::ToString, vec::Vec};
 
-use miden_lib::transaction::TransactionKernel;
 use miden_objects::account::AccountId;
 
 use crate::{
@@ -185,14 +184,6 @@ impl Client {
         note_id: NoteId,
     ) -> Result<Option<OutputNoteRecord>, ClientError> {
         Ok(self.store.get_output_notes(NoteFilter::Unique(note_id)).await?.pop())
-    }
-
-    /// Compiles the provided program into a [`NoteScript`].
-    ///
-    /// The assembler uses the debug mode if the client was instantiated with debug mode on.
-    pub fn compile_note_script(&self, note_script: &str) -> Result<NoteScript, ClientError> {
-        let assembler = TransactionKernel::assembler().with_debug_mode(self.in_debug_mode());
-        NoteScript::compile(note_script, assembler).map_err(ClientError::NoteError)
     }
 }
 

--- a/crates/rust-client/src/tests.rs
+++ b/crates/rust-client/src/tests.rs
@@ -811,7 +811,7 @@ async fn execute_program() {
         end
         ";
 
-    let tx_script = client.compile_tx_script(code).unwrap();
+    let tx_script = client.script_builder().compile_tx_script(code).unwrap();
 
     let output_stack = client
         .execute_program(wallet.id(), tx_script, AdviceInputs::default(), BTreeSet::new())

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -769,12 +769,6 @@ impl Client {
         Ok(())
     }
 
-    /// Compiles the provided transaction script source and inputs into a [`TransactionScript`].
-    pub fn compile_tx_script(&self, program: &str) -> Result<TransactionScript, ClientError> {
-        let assembler = TransactionKernel::assembler().with_debug_mode(self.in_debug_mode());
-        TransactionScript::compile(program, assembler).map_err(ClientError::TransactionScriptError)
-    }
-
     // HELPERS
     // --------------------------------------------------------------------------------------------
 

--- a/crates/web-client/src/notes.rs
+++ b/crates/web-client/src/notes.rs
@@ -90,6 +90,7 @@ impl WebClient {
     pub fn compile_note_script(&mut self, script: &str) -> Result<NoteScript, JsValue> {
         if let Some(client) = self.get_mut_inner() {
             let native_note_script: NativeNoteScript = client
+                .script_builder()
                 .compile_note_script(script)
                 .map_err(|err| js_error_with_context(err, "failed to compile note script"))?;
 

--- a/crates/web-client/src/transactions.rs
+++ b/crates/web-client/src/transactions.rs
@@ -32,7 +32,7 @@ impl WebClient {
     pub fn compile_tx_script(&mut self, script: &str) -> Result<TransactionScript, JsValue> {
         if let Some(client) = self.get_mut_inner() {
             let native_tx_script: NativeTransactionScript =
-                client.compile_tx_script(script).map_err(|err| {
+                client.script_builder().compile_tx_script(script).map_err(|err| {
                     js_error_with_context(err, "failed to compile transaction script")
                 })?;
             Ok(native_tx_script.into())

--- a/tests/src/custom_transactions_tests.rs
+++ b/tests/src/custom_transactions_tests.rs
@@ -90,7 +90,7 @@ async fn transaction_request() {
             call.auth_tx::auth__tx_rpo_falcon512
         end
         ";
-    let tx_script = client.compile_tx_script(code).unwrap();
+    let tx_script = client.script_builder().compile_tx_script(code).unwrap();
 
     // FAILURE ATTEMPT
     let transaction_request = TransactionRequestBuilder::new()
@@ -217,7 +217,7 @@ async fn merkle_store() {
     code += "call.auth_tx::auth__tx_rpo_falcon512 end";
 
     // Build the transaction
-    let tx_script = client.compile_tx_script(&code).unwrap();
+    let tx_script = client.script_builder().compile_tx_script(&code).unwrap();
 
     let transaction_request = TransactionRequestBuilder::new()
         .unauthenticated_input_notes(note_args_map)
@@ -265,7 +265,7 @@ async fn onchain_notes_sync_with_tag() {
                 assert_eq
             end
             ";
-    let note_script = client_1.compile_note_script(note_script).unwrap();
+    let note_script = client_1.script_builder().compile_note_script(note_script).unwrap();
     let inputs = NoteInputs::new(vec![]).unwrap();
     let serial_num = client_1.rng().draw_word();
     let note_metadata = NoteMetadata::new(
@@ -340,7 +340,7 @@ fn create_custom_note(
         .replace("{expected_note_arg_2}", &expected_note_args[4..=7].join("."))
         .replace("{mem_address}", &mem_addr.to_string())
         .replace("{mem_address_2}", &(mem_addr + 4).to_string());
-    let note_script = client.compile_note_script(&note_script).unwrap();
+    let note_script = client.script_builder().compile_note_script(&note_script).unwrap();
 
     let inputs =
         NoteInputs::new(vec![target_account_id.prefix().as_felt(), target_account_id.suffix()])

--- a/tests/src/fpi_tests.rs
+++ b/tests/src/fpi_tests.rs
@@ -80,7 +80,7 @@ async fn fpi_execute_program() {
         account_id_suffix = foreign_account_id.suffix(),
     );
 
-    let tx_script = client.compile_tx_script(&code).unwrap();
+    let tx_script = client.script_builder().compile_tx_script(&code).unwrap();
     _ = client.sync_state().await.unwrap();
 
     // Wait for a couple of blocks so that the account gets committed


### PR DESCRIPTION
This small PR exports the newly added `ScriptBuilder` from miden-base. This PR will close #944 since the functionality is now in the `ScriptBuilder`.

This PR also changes `.nonce_increment()` to `.nonce_delta()` since this method changed in miden-base.

