### PR TITLE
chore: add dependency categories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,14 @@ rust-version = "1.87"
 [workspace.dependencies]
 # Miden dependencies
 miden-lib                  = { default-features = false, version = "0.10" }
+miden-node-block-producer  = { version = "0.10" }
+miden-node-ntx-builder     = { version = "0.10" }
+miden-node-proto-build     = { default-features = false, version = "0.10" }
+miden-node-rpc             = { version = "0.10" }
+miden-node-store           = { version = "0.10" }
+miden-node-utils           = { version = "0.10" }
 miden-objects              = { default-features = false, version = "0.10" }
+miden-remote-prover        = { features = ["concurrent"], version = "0.10" }
 miden-remote-prover-client = { default-features = false, features = ["tx-prover"], version = "0.10" }
 miden-testing              = { default-features = false, features = ["async"], version = "0.10" }
 miden-tx                   = { default-features = false, features = ["async"], version = "0.10" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,18 +20,21 @@ repository   = "https://github.com/0xMiden/miden-client"
 rust-version = "1.87"
 
 [workspace.dependencies]
-async-trait                = "0.1"
+# Miden dependencies
 miden-lib                  = { default-features = false, version = "0.10" }
 miden-objects              = { default-features = false, version = "0.10" }
 miden-remote-prover-client = { default-features = false, features = ["tx-prover"], version = "0.10" }
 miden-testing              = { default-features = false, features = ["async"], version = "0.10" }
 miden-tx                   = { default-features = false, features = ["async"], version = "0.10" }
-miette                     = { features = ["fancy"], version = "7.2" }
-rand                       = { version = "0.9" }
-serde                      = { features = ["derive"], version = "1.0" }
-thiserror                  = { default-features = false, version = "2.0" }
-tokio                      = { features = ["macros", "net", "rt-multi-thread"], version = "1.40" }
-tracing                    = { version = "0.1" }
+
+# External dependencies
+async-trait = "0.1"
+miette      = { features = ["fancy"], version = "7.2" }
+rand        = { version = "0.9" }
+serde       = { features = ["derive"], version = "1.0" }
+thiserror   = { default-features = false, version = "2.0" }
+tokio       = { features = ["macros", "net", "rt-multi-thread"], version = "1.40" }
+tracing     = { version = "0.1" }
 
 # Lints are set to warn for development, which are promoted to errors in CI.
 [workspace.lints.clippy]

--- a/bin/miden-cli/Cargo.toml
+++ b/bin/miden-cli/Cargo.toml
@@ -16,20 +16,8 @@ version                = "0.10.0"
 name = "miden-client"
 path = "src/main.rs"
 
-[lints]
-workspace = true
-
 [features]
 default = []
-
-[[test]]
-name = "integration"
-path = "tests/cli.rs"
-
-[dev-dependencies]
-assert_cmd = { version = "2.0" }
-predicates = { version = "3.0" }
-uuid       = { features = ["serde", "v4"], version = "1.10" }
 
 [dependencies]
 clap               = { features = ["derive"], version = "4.5" }
@@ -51,3 +39,15 @@ tracing-subscriber = { version = "0.3" }
 miden-client  = { path = "../../crates/rust-client", version = "0.10" }
 miden-lib     = { workspace = true }
 miden-objects = { workspace = true }
+
+[dev-dependencies]
+assert_cmd = { version = "2.0" }
+predicates = { version = "3.0" }
+uuid       = { features = ["serde", "v4"], version = "1.10" }
+
+[lints]
+workspace = true
+
+[[test]]
+name = "integration"
+path = "tests/cli.rs"

--- a/bin/miden-cli/Cargo.toml
+++ b/bin/miden-cli/Cargo.toml
@@ -20,12 +20,17 @@ path = "src/main.rs"
 default = []
 
 [dependencies]
+# Workspace dependencies
+miden-client = { features = ["sqlite", "tonic"], path = "../../crates/rust-client", version = "0.10" }
+
+# Miden dependencies
+miden-lib     = { workspace = true }
+miden-objects = { workspace = true }
+
+# External dependencies
 clap               = { features = ["derive"], version = "4.5" }
 comfy-table        = { version = "7.1" }
 figment            = { features = ["env", "toml"], version = "0.10" }
-miden-client       = { features = ["sqlite", "tonic"], path = "../../crates/rust-client", version = "0.10" }
-miden-lib          = { workspace = true }
-miden-objects      = { workspace = true }
 miette             = { workspace = true }
 rand               = { workspace = true }
 serde              = { features = ["derive"], version = "1.0" }

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -12,11 +12,11 @@ repository.workspace   = true
 rust-version.workspace = true
 version                = "0.10.0"
 
+[package.metadata.cargo-machete]
+ignored = ["getrandom"]
+
 [lib]
 crate-type = ["lib"]
-
-[lints]
-workspace = true
 
 [features]
 default = ["std", "tonic/channel"]
@@ -69,19 +69,8 @@ uuid                       = { features = ["js", "serde", "v4"], optional = true
 wasm-bindgen               = { features = ["serde-serialize"], optional = true, version = "0.2" }
 wasm-bindgen-futures       = { optional = true, version = "0.4" }
 
-[package.metadata.cargo-machete]
-ignored = ["getrandom"]
-
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { features = ["Storage", "Window", "console"], version = "0.3" }
-
-[dev-dependencies]
-miden-client  = { features = ["sqlite", "testing", "tonic"], path = "." }
-miden-lib     = { features = ["testing"], workspace = true }
-miden-objects = { default-features = false, features = ["testing"], workspace = true }
-miden-testing = { default-features = false, features = ["async"], workspace = true }
-tokio         = { workspace = true }
-web-sys       = { features = ["console"], version = "0.3" }
 
 [build-dependencies]
 miden-lib              = { workspace = true }
@@ -92,3 +81,14 @@ prost                  = { default-features = false, features = ["derive"], vers
 prost-build            = { default-features = false, version = "0.13" }
 protox                 = { version = "0.7" }
 tonic-build            = { version = "0.13" }
+
+[dev-dependencies]
+miden-client  = { features = ["sqlite", "testing", "tonic"], path = "." }
+miden-lib     = { features = ["testing"], workspace = true }
+miden-objects = { default-features = false, features = ["testing"], workspace = true }
+miden-testing = { default-features = false, features = ["async"], workspace = true }
+tokio         = { workspace = true }
+web-sys       = { features = ["console"], version = "0.3" }
+
+[lints]
+workspace = true

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -42,32 +42,35 @@ tonic = ["std", "tonic/tls-native-roots", "tonic/tls-ring", "tonic/transport"]
 web-tonic = ["dep:getrandom", "dep:tonic-web-wasm-client"]
 
 [dependencies]
-async-trait                = { workspace = true }
-base64                     = { optional = true, version = "0.22" }
-chrono                     = { optional = false, version = "0.4" }
-deadpool                   = { default-features = false, features = ["managed", "rt_tokio_1"], optional = true, version = "0.12" }
-deadpool-sync              = { optional = true, version = "0.1" }
-getrandom                  = { features = ["wasm_js"], optional = true, version = "0.3" }
-hex                        = { version = "0.4" }
+# Miden dependencies
 miden-lib                  = { workspace = true }
 miden-objects              = { workspace = true }
 miden-remote-prover-client = { default-features = false, features = ["tx-prover"], workspace = true }
 miden-testing              = { optional = true, workspace = true }
 miden-tx                   = { features = ["async"], workspace = true }
-prost                      = { default-features = false, features = ["derive"], version = "0.13" }
-rand                       = { workspace = true }
-rusqlite                   = { features = ["array", "bundled", "vtab"], optional = true, version = "0.36" }
-rusqlite_migration         = { optional = true, version = "2.1" }
-serde                      = { optional = true, workspace = true }
-serde-wasm-bindgen         = { optional = true, version = "0.6" }
-thiserror                  = { workspace = true }
-toml                       = { optional = true, version = "0.8" }
-tonic                      = { default-features = false, features = ["codegen", "prost"], version = "0.13" }
-tonic-web-wasm-client      = { default-features = false, optional = true, version = "0.7" }
-tracing                    = { workspace = true }
-uuid                       = { features = ["js", "serde", "v4"], optional = true, version = "1.10" }
-wasm-bindgen               = { features = ["serde-serialize"], optional = true, version = "0.2" }
-wasm-bindgen-futures       = { optional = true, version = "0.4" }
+
+# External dependencies
+async-trait           = { workspace = true }
+base64                = { optional = true, version = "0.22" }
+chrono                = { optional = false, version = "0.4" }
+deadpool              = { default-features = false, features = ["managed", "rt_tokio_1"], optional = true, version = "0.12" }
+deadpool-sync         = { optional = true, version = "0.1" }
+getrandom             = { features = ["wasm_js"], optional = true, version = "0.3" }
+hex                   = { version = "0.4" }
+prost                 = { default-features = false, features = ["derive"], version = "0.13" }
+rand                  = { workspace = true }
+rusqlite              = { features = ["array", "bundled", "vtab"], optional = true, version = "0.36" }
+rusqlite_migration    = { optional = true, version = "2.1" }
+serde                 = { optional = true, workspace = true }
+serde-wasm-bindgen    = { optional = true, version = "0.6" }
+thiserror             = { workspace = true }
+toml                  = { optional = true, version = "0.8" }
+tonic                 = { default-features = false, features = ["codegen", "prost"], version = "0.13" }
+tonic-web-wasm-client = { default-features = false, optional = true, version = "0.7" }
+tracing               = { workspace = true }
+uuid                  = { features = ["js", "serde", "v4"], optional = true, version = "1.10" }
+wasm-bindgen          = { features = ["serde-serialize"], optional = true, version = "0.2" }
+wasm-bindgen-futures  = { optional = true, version = "0.4" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { features = ["Storage", "Window", "console"], version = "0.3" }

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -77,7 +77,7 @@ web-sys = { features = ["Storage", "Window", "console"], version = "0.3" }
 
 [build-dependencies]
 miden-lib              = { workspace = true }
-miden-node-proto-build = { default-features = false, version = "0.10" }
+miden-node-proto-build = { workspace = true }
 miden-objects          = { workspace = true }
 miette                 = { workspace = true }
 prost                  = { default-features = false, features = ["derive"], version = "0.13" }

--- a/crates/testing/node-builder/Cargo.toml
+++ b/crates/testing/node-builder/Cargo.toml
@@ -17,11 +17,11 @@ path = "src/main.rs"
 [dependencies]
 # Miden dependencies
 miden-lib                 = { workspace = true }
-miden-node-block-producer = { version = "0.10" }
-miden-node-ntx-builder    = { version = "0.10" }
-miden-node-rpc            = { version = "0.10" }
-miden-node-store          = { version = "0.10" }
-miden-node-utils          = { version = "0.10" }
+miden-node-block-producer = { workspace = true }
+miden-node-ntx-builder    = { workspace = true }
+miden-node-rpc            = { workspace = true }
+miden-node-store          = { workspace = true }
+miden-node-utils          = { workspace = true }
 miden-objects             = { workspace = true }
 
 # External dependencies

--- a/crates/testing/node-builder/Cargo.toml
+++ b/crates/testing/node-builder/Cargo.toml
@@ -15,7 +15,7 @@ name = "testing-node-builder"
 path = "src/main.rs"
 
 [dependencies]
-anyhow                    = "1.0"
+# Miden dependencies
 miden-lib                 = { workspace = true }
 miden-node-block-producer = { version = "0.10" }
 miden-node-ntx-builder    = { version = "0.10" }
@@ -23,10 +23,13 @@ miden-node-rpc            = { version = "0.10" }
 miden-node-store          = { version = "0.10" }
 miden-node-utils          = { version = "0.10" }
 miden-objects             = { workspace = true }
-rand                      = { workspace = true }
-rand_chacha               = { version = "0.9" }
-tokio                     = { features = ["full"], version = "1.0" }
-url                       = { features = ["serde"], version = "2.5" }
+
+# External dependencies
+anyhow      = "1.0"
+rand        = { workspace = true }
+rand_chacha = { version = "0.9" }
+tokio       = { features = ["full"], version = "1.0" }
+url         = { features = ["serde"], version = "2.5" }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/crates/testing/node-builder/Cargo.toml
+++ b/crates/testing/node-builder/Cargo.toml
@@ -14,9 +14,6 @@ version                = "0.10.0"
 name = "testing-node-builder"
 path = "src/main.rs"
 
-[lints]
-workspace = true
-
 [dependencies]
 anyhow                    = "1.0"
 miden-lib                 = { workspace = true }
@@ -33,3 +30,6 @@ url                       = { features = ["serde"], version = "2.5" }
 
 [dev-dependencies]
 tempfile = "3.0"
+
+[lints]
+workspace = true

--- a/crates/testing/prover/Cargo.toml
+++ b/crates/testing/prover/Cargo.toml
@@ -8,15 +8,18 @@ rust-version.workspace = true
 version                = "0.1.0"
 
 [dependencies]
-anyhow              = "1.0"
+# Miden dependencies
 miden-node-utils    = { version = "0.10" }
 miden-remote-prover = { features = ["concurrent"], version = "0.10" }
-tokio               = { features = ["full"], version = "1.0" }
-tokio-stream        = { features = ["net"], version = "0.1" }
-tonic               = { default-features = false, features = ["transport"], version = "0.13" }
-tonic-web           = { version = "0.13" }
-tracing             = { version = "0.1" }
-tracing-subscriber  = { features = ["env-filter", "fmt", "json"], version = "0.3" }
+
+# External dependencies
+anyhow             = "1.0"
+tokio              = { features = ["full"], version = "1.0" }
+tokio-stream       = { features = ["net"], version = "0.1" }
+tonic              = { default-features = false, features = ["transport"], version = "0.13" }
+tonic-web          = { version = "0.13" }
+tracing            = { version = "0.1" }
+tracing-subscriber = { features = ["env-filter", "fmt", "json"], version = "0.3" }
 
 [lints]
 workspace = true

--- a/crates/testing/prover/Cargo.toml
+++ b/crates/testing/prover/Cargo.toml
@@ -9,8 +9,8 @@ version                = "0.1.0"
 
 [dependencies]
 # Miden dependencies
-miden-node-utils    = { version = "0.10" }
-miden-remote-prover = { features = ["concurrent"], version = "0.10" }
+miden-node-utils    = { workspace = true }
+miden-remote-prover = { features = ["concurrent"], workspace = true }
 
 # External dependencies
 anyhow             = "1.0"

--- a/crates/web-client/Cargo.toml
+++ b/crates/web-client/Cargo.toml
@@ -12,11 +12,11 @@ repository.workspace   = true
 rust-version.workspace = true
 version                = "0.10.0"
 
+[package.metadata.cargo-machete]
+ignored = ["wasm-bindgen-futures"]
+
 [lib]
 crate-type = ["cdylib"]
-
-[lints]
-workspace = true
 
 [features]
 testing = ["miden-client/testing"]
@@ -39,5 +39,5 @@ miden-lib     = { default-features = false, features = ["testing"], workspace = 
 miden-objects = { default-features = false, features = ["testing"], workspace = true }
 web-sys       = { features = ["console"], version = "0.3" }
 
-[package.metadata.cargo-machete]
-ignored = ["wasm-bindgen-futures"]
+[lints]
+workspace = true

--- a/crates/web-client/Cargo.toml
+++ b/crates/web-client/Cargo.toml
@@ -22,15 +22,20 @@ crate-type = ["cdylib"]
 testing = ["miden-client/testing"]
 
 [dependencies]
+# Workspace dependencies
 miden-client = { default-features = false, features = [
   "idxdb",
   "web-tonic",
 ], path = "../rust-client", version = "0.10" }
-miden-lib = { workspace = true }
+
+# Miden dependencies
+miden-lib     = { workspace = true }
 miden-objects = { workspace = true }
-rand = { workspace = true }
-serde-wasm-bindgen = { version = "0.6" }
-wasm-bindgen = { features = ["serde-serialize"], version = "0.2" }
+
+# External dependencies
+rand                 = { workspace = true }
+serde-wasm-bindgen   = { version = "0.6" }
+wasm-bindgen         = { features = ["serde-serialize"], version = "0.2" }
 wasm-bindgen-futures = { version = "0.4" }
 
 [dev-dependencies]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -11,9 +11,14 @@ rust-version.workspace = true
 version                = "0.10.0"
 
 [dependencies]
-miden-client  = { features = ["sqlite", "std", "testing", "tonic"], path = "../crates/rust-client" }
+# Workspace dependencies
+miden-client = { features = ["sqlite", "std", "testing", "tonic"], path = "../crates/rust-client" }
+
+# Miden dependencies
 miden-objects = { default-features = false, features = ["testing"], workspace = true }
-rand          = { workspace = true }
+
+# External dependencies
+rand = { workspace = true }
 
 [dev-dependencies]
 async-trait        = { version = "0.1" }


### PR DESCRIPTION
closes #988 

In this PR I ran `cargo sort --grouped --workspace` to do a general workspace modification but I belive most of the ordering issues were already fixed by `make toml` using `taplo`. I also created sections inside each dependency section.