### PR TITLE
feat: reexport `NetworkId`, `NetworkIdError`, `AccountIdError`

### DIFF
--- a/crates/rust-client/src/account/mod.rs
+++ b/crates/rust-client/src/account/mod.rs
@@ -52,9 +52,12 @@ pub mod procedure_roots;
 // RE-EXPORTS
 // ================================================================================================
 
-pub use miden_objects::account::{
-    Account, AccountBuilder, AccountCode, AccountDelta, AccountFile, AccountHeader, AccountId,
-    AccountStorage, AccountStorageMode, AccountType, StorageMap, StorageSlot,
+pub use miden_objects::{
+    AccountIdError, NetworkIdError,
+    account::{
+        Account, AccountBuilder, AccountCode, AccountDelta, AccountFile, AccountHeader, AccountId,
+        AccountStorage, AccountStorageMode, AccountType, NetworkId, StorageMap, StorageSlot,
+    },
 };
 
 pub mod component {

--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -176,9 +176,7 @@ pub mod crypto {
 }
 
 pub use errors::{AuthenticationError, ClientError, IdPrefixFetchError};
-pub use miden_objects::{
-    AccountIdError, Felt, NetworkIdError, ONE, StarkField, Word, ZERO, account::NetworkId,
-};
+pub use miden_objects::{Felt, ONE, StarkField, Word, ZERO};
 pub use miden_remote_prover_client::remote_prover::tx_prover::RemoteTransactionProver;
 pub use miden_tx::ExecutionOptions;
 


### PR DESCRIPTION
This PR adds missing reexports that are needed for https://github.com/0xMiden/miden-faucet/pull/11