### PR TITLE
chore: update `init` cmd docs

### DIFF
--- a/bin/miden-cli/README.md
+++ b/bin/miden-cli/README.md
@@ -29,7 +29,7 @@ These actions can also be executed when inside the repository via the Makefile w
 To have a fully-functional client CLI, you would need to set it up first. You can accomplish that with:
 
 ```shell
-miden-client init
+miden-client init --network {localhost/devnet/testnet/custom_rpc_endpoint}
 ```
 
 This would generate the `miden-client.toml` file, which contains useful information for the client like RPC provider's URL and database path.

--- a/bin/miden-cli/src/commands/init.rs
+++ b/bin/miden-cli/src/commands/init.rs
@@ -39,7 +39,7 @@ directory"
 )]
 pub struct InitCmd {
     /// Network configuration to use. Options are `devnet`, `testnet`, `localhost` or a custom RPC
-    /// endpoint. Defaults to the testnet network.
+    /// endpoint.
     #[clap(long, short)]
     network: Network,
 


### PR DESCRIPTION
Docs were out of date, with https://github.com/0xMiden/miden-client/issues/877 the `--network` argument is mandatory.