### PR TITLE
chore: update client to use generics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,9 +470,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.29"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "jobserver",
  "libc",
@@ -1955,9 +1955,9 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f8a250a0d54c41e7ba9c7c3206c85de37ed891340b79c8f645b05cc4938c2d"
+checksum = "77e07b5ea75948306dd6aaf341c7865a927a3fc2135bb261571435f315793bd5"
 dependencies = [
  "miden-core",
  "thiserror 2.0.12",
@@ -1967,9 +1967,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5453d77fc1a7e4642e1fd8855e1d5904087ac1ec53b02549a11af4697df2713"
+checksum = "fd3ed10cf5894fea966161ef42e5a366779ff2ae5ea35fd45e12236115083851"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -1981,9 +1981,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822b0c69f22346ddcaba307dbcb69d2e881fd4d074511da8f1b51c6d2a03d384"
+checksum = "c2319962222c27ea6d8eba4e0ed59c847f816bfc51c9539b4e2a12bfd901c524"
 dependencies = [
  "aho-corasick",
  "lalrpop",
@@ -2002,7 +2002,7 @@ dependencies = [
 [[package]]
 name = "miden-block-prover"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#9bb5110b174c293df02df0e05126b2943aa1d205"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#c90f0ccbae881fe21faa6c0ad6e129f124bbcacc"
 dependencies = [
  "miden-lib",
  "miden-objects",
@@ -2031,7 +2031,7 @@ dependencies = [
  "prost",
  "prost-build",
  "protox 0.7.2",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rusqlite",
  "rusqlite_migration",
  "serde",
@@ -2062,7 +2062,7 @@ dependencies = [
  "miden-objects",
  "miette",
  "predicates",
- "rand 0.9.1",
+ "rand 0.9.2",
  "serde",
  "thiserror 2.0.12",
  "tokio",
@@ -2080,7 +2080,7 @@ dependencies = [
  "miden-client",
  "miden-lib",
  "miden-objects",
- "rand 0.9.1",
+ "rand 0.9.2",
  "tokio",
  "winter-maybe-async 0.12.0",
 ]
@@ -2092,7 +2092,7 @@ dependencies = [
  "miden-client",
  "miden-lib",
  "miden-objects",
- "rand 0.9.1",
+ "rand 0.9.2",
  "serde-wasm-bindgen",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2101,9 +2101,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dee966d664e92903bd9d20e846179395c50941e608c975970c20c034a32ab64"
+checksum = "d432f414f3029470619f41f741c67551d14e282dd0ad19cd276b14eeefdd34b6"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
@@ -2117,16 +2117,16 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.15.5"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab02236b6dd41d54c733f5551adf93cc66c710ea1e4e4d80e0fba9b233acdf93"
+checksum = "9d8d6fde5681ffcae64b32153280476b992578b35842ba62c751fd17b1e5c3c6"
 dependencies = [
  "blake3",
  "cc",
  "glob",
  "num",
  "num-complex",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rand_core 0.9.3",
  "sha3",
  "thiserror 2.0.12",
@@ -2137,9 +2137,9 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22a9b5fb8ef50eba125dba5ab15af1cefb801dc2ec02d54901166358ff3201c"
+checksum = "703e80e02f1f14fdcf154cb947bfaff999da58db13b7e450dcf24808794910f8"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -2164,7 +2164,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#9bb5110b174c293df02df0e05126b2943aa1d205"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#c90f0ccbae881fe21faa6c0ad6e129f124bbcacc"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -2176,9 +2176,9 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a16c81f550d17454769ffb51b3788cdf2f8cb56bf4b3bf7dc90957ba234dcc"
+checksum = "04924185b8561234b891c87920c50c14f15bbcee32334855d0bc7dd0141bd75c"
 dependencies = [
  "derive_more",
  "miden-assembly-syntax",
@@ -2244,7 +2244,7 @@ dependencies = [
  "miden-remote-prover-client",
  "miden-tx",
  "miden-tx-batch-prover",
- "rand 0.9.1",
+ "rand 0.9.2",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
@@ -2268,7 +2268,7 @@ dependencies = [
  "miden-objects",
  "miden-remote-prover-client",
  "miden-tx",
- "rand 0.9.1",
+ "rand 0.9.2",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
@@ -2347,7 +2347,7 @@ dependencies = [
  "miden-node-proto-build",
  "miden-node-utils",
  "miden-objects",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rusqlite",
  "rusqlite_migration",
@@ -2375,7 +2375,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "rand 0.9.1",
+ "rand 0.9.2",
  "serde",
  "thiserror 2.0.12",
  "tokio",
@@ -2390,7 +2390,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#9bb5110b174c293df02df0e05126b2943aa1d205"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#c90f0ccbae881fe21faa6c0ad6e129f124bbcacc"
 dependencies = [
  "bech32",
  "getrandom 0.3.3",
@@ -2400,7 +2400,7 @@ dependencies = [
  "miden-processor",
  "miden-utils-sync",
  "miden-verifier",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rand_xoshiro",
  "semver 1.0.26",
  "serde",
@@ -2411,9 +2411,9 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31fe7dd289f73562936b6810ed370d64e78129926c7f0f20860f8d263dfcb566"
+checksum = "ec8e112548b2d316598c2258326b5f8d8d018f37df8a190d2cd7f9d2e11a4921"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -2427,15 +2427,15 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ae8ccd743e679dccca400cb748eedc3d26c3ebd93a9ea6cb47ef50ed0555eb"
+checksum = "79553c02f2e1de9c1d5a0f956a609f12c99b9590d31787fb0c5b865018290412"
 dependencies = [
  "miden-air",
  "miden-debug-types",
  "miden-processor",
  "tracing",
- "winter-maybe-async 0.13.0",
+ "winter-maybe-async 0.13.1",
  "winter-prover",
 ]
 
@@ -2505,9 +2505,9 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d090c8a83966282b5fcd96bc2c9c1b1f5f7569c6b85a086ff693b12213990"
+checksum = "1a124c7b77b395ca04a94b3d4a2bae04bfc422831e364279743395fb7b95e70f"
 dependencies = [
  "env_logger",
  "miden-assembly",
@@ -2518,26 +2518,27 @@ dependencies = [
 [[package]]
 name = "miden-testing"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#9bb5110b174c293df02df0e05126b2943aa1d205"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#c90f0ccbae881fe21faa6c0ad6e129f124bbcacc"
 dependencies = [
  "anyhow",
  "async-trait",
+ "itertools 0.14.0",
  "miden-block-prover",
  "miden-lib",
  "miden-objects",
  "miden-processor",
  "miden-tx",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "thiserror 2.0.12",
- "winter-maybe-async 0.13.0",
+ "winter-maybe-async 0.13.1",
  "winterfell",
 ]
 
 [[package]]
 name = "miden-tx"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#9bb5110b174c293df02df0e05126b2943aa1d205"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#c90f0ccbae881fe21faa6c0ad6e129f124bbcacc"
 dependencies = [
  "async-trait",
  "miden-lib",
@@ -2545,7 +2546,7 @@ dependencies = [
  "miden-processor",
  "miden-prover",
  "miden-verifier",
- "rand 0.9.1",
+ "rand 0.9.2",
  "thiserror 2.0.12",
  "winter-maybe-async 0.12.0",
 ]
@@ -2553,7 +2554,7 @@ dependencies = [
 [[package]]
 name = "miden-tx-batch-prover"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#9bb5110b174c293df02df0e05126b2943aa1d205"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#c90f0ccbae881fe21faa6c0ad6e129f124bbcacc"
 dependencies = [
  "miden-objects",
  "miden-tx",
@@ -2561,9 +2562,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af06bd6a4f215ce646b6ee57a481e1c083600e109d50d5e8fd782884acb0f07a"
+checksum = "2cf0aa85171045c0c081ee2b2a05665f4cc06157a1ad899734d8389006a659a8"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
@@ -2574,9 +2575,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1771d84e358da9957786a7058b7431e2d5d5934e37de128b927b9e520ec0d2e"
+checksum = "6d5fb22ce7af59baae7dafe3c68ddaacb738108d3bb5ecb6738088daa87be825"
 dependencies = [
  "lock_api",
  "loom",
@@ -2585,9 +2586,9 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "253fb17aee78a1d9b0d2030fc1a14e7559590a43a7d2d00e7cce0bd23f61fbb6"
+checksum = "c4995ea8f48bf30ec02cec53019d1345c5c7cb0655290459e3e750295df95fa3"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -2736,7 +2737,7 @@ dependencies = [
  "miden-node-store",
  "miden-node-utils",
  "miden-objects",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "tempfile",
  "tokio",
@@ -2991,7 +2992,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.1",
+ "rand 0.9.2",
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
@@ -3714,9 +3715,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -3791,9 +3792,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -4190,9 +4191,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",
@@ -5793,9 +5794,9 @@ dependencies = [
 
 [[package]]
 name = "winter-air"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473277f696e5359c00059118f3b4b26c1056591dfcf159175e4cd9f7f2f9aa13"
+checksum = "ef01227f23c7c331710f43b877a8333f5f8d539631eea763600f1a74bf018c7c"
 dependencies = [
  "libm",
  "winter-crypto",
@@ -5806,9 +5807,9 @@ dependencies = [
 
 [[package]]
 name = "winter-crypto"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef01ae983f420aee0943c3bd6a413df43a151c12d1851daf384e0a4c6e0563ec"
+checksum = "1cdb247bc142438798edb04067ab72a22cf815f57abbd7b78a6fa986fc101db8"
 dependencies = [
  "blake3",
  "sha3",
@@ -5818,9 +5819,9 @@ dependencies = [
 
 [[package]]
 name = "winter-fri"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10954644f1fcb79374801f458a66c9e5a3b771950e4816c5db36aaea8637422f"
+checksum = "fd592b943f9d65545683868aaf1b601eb66e52bfd67175347362efff09101d3a"
 dependencies = [
  "winter-crypto",
  "winter-math",
@@ -5829,9 +5830,9 @@ dependencies = [
 
 [[package]]
 name = "winter-math"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147699a1350037b39c3fbbb993d944532e461fe3e46537ef7c36742ffc1a3498"
+checksum = "7aecfb48ee6a8b4746392c8ff31e33e62df8528a3b5628c5af27b92b14aef1ea"
 dependencies = [
  "winter-utils",
 ]
@@ -5848,9 +5849,9 @@ dependencies = [
 
 [[package]]
 name = "winter-maybe-async"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3253cf551b6e481f6ebeee986e8a5eaa3fbe9e79b129824320765a6efe90cb8"
+checksum = "6d31a19dae58475d019850e25b0170e94b16d382fbf6afee9c0e80fdc935e73e"
 dependencies = [
  "quote",
  "syn 2.0.104",
@@ -5858,43 +5859,43 @@ dependencies = [
 
 [[package]]
 name = "winter-prover"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee69201ecac6cf077571130ad5aa43f8a4c7de19b35245e1f00ba8294ffd18b"
+checksum = "84cc631ed56cd39b78ef932c1ec4060cc6a44d114474291216c32f56655b3048"
 dependencies = [
  "tracing",
  "winter-air",
  "winter-crypto",
  "winter-fri",
  "winter-math",
- "winter-maybe-async 0.13.0",
+ "winter-maybe-async 0.13.1",
  "winter-utils",
 ]
 
 [[package]]
 name = "winter-rand-utils"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ff50bd9ffaf905154d96e967f863246378dd5600997db07575bd1e1fa22260"
+checksum = "a4ff3b651754a7bd216f959764d0a5ab6f4b551c9a3a08fb9ccecbed594b614a"
 dependencies = [
- "rand 0.9.1",
+ "rand 0.9.2",
  "winter-utils",
 ]
 
 [[package]]
 name = "winter-utils"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c14bedf485c77b8a6ce76b0afbd86038d12bf441c2ede64ea9e573e3ff9658f"
+checksum = "9951263ef5317740cd0f49e618db00c72fabb70b75756ea26c4d5efe462c04dd"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
 name = "winter-verifier"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6ae1f01494541059a874286dbdb4ef52357ac28980fc4c4ebb2e6bda7fb718"
+checksum = "0425ea81f8f703a1021810216da12003175c7974a584660856224df04b2e2fdb"
 dependencies = [
  "winter-air",
  "winter-crypto",
@@ -5905,9 +5906,9 @@ dependencies = [
 
 [[package]]
 name = "winterfell"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60be62bd793cae134656ab770236b471fee3a4c68b9c260a12c73ef294ca61"
+checksum = "43f824ddd5aec8ca6a54307f20c115485a8a919ea94dd26d496d856ca6185f4f"
 dependencies = [
  "winter-air",
  "winter-prover",

--- a/bin/miden-cli/src/commands/account.rs
+++ b/bin/miden-cli/src/commands/account.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use comfy_table::{Cell, ContentArrangement, presets};
 use miden_client::{
-    Client, ZERO,
+    ZERO,
     account::{Account, AccountId, AccountType, StorageSlot},
     asset::Asset,
     rpc::{NodeRpcClient, TonicRpcClient},
@@ -9,7 +9,7 @@ use miden_client::{
 use miden_objects::PrettyPrint;
 
 use crate::{
-    CLIENT_BINARY_NAME,
+    CLIENT_BINARY_NAME, CliClient,
     config::CliConfig,
     create_dynamic_table,
     errors::CliError,
@@ -42,7 +42,7 @@ pub struct AccountCmd {
 }
 
 impl AccountCmd {
-    pub async fn execute(&self, client: Client) -> Result<(), CliError> {
+    pub async fn execute(&self, client: CliClient) -> Result<(), CliError> {
         let (cli_config, _) = load_config_file()?;
         match self {
             AccountCmd {
@@ -98,7 +98,7 @@ impl AccountCmd {
 // LIST ACCOUNTS
 // ================================================================================================
 
-async fn list_accounts(client: Client, cli_config: &CliConfig) -> Result<(), CliError> {
+async fn list_accounts(client: CliClient, cli_config: &CliConfig) -> Result<(), CliError> {
     let accounts = client.get_account_headers().await?;
 
     let mut table =
@@ -129,7 +129,7 @@ async fn list_accounts(client: Client, cli_config: &CliConfig) -> Result<(), Cli
 // ================================================================================================
 
 pub async fn show_account(
-    client: Client,
+    client: CliClient,
     account_id: AccountId,
     cli_config: &CliConfig,
     with_code: bool,

--- a/bin/miden-cli/src/commands/exec.rs
+++ b/bin/miden-cli/src/commands/exec.rs
@@ -1,11 +1,11 @@
 use std::{collections::BTreeSet, path::PathBuf};
 
 use clap::Parser;
-use miden_client::{Client, Felt, Word};
+use miden_client::{Felt, Word};
 use miden_objects::vm::AdviceInputs;
 use serde::{Deserialize, Deserializer, Serialize, de};
 
-use crate::{errors::CliError, utils::get_input_acc_id_by_prefix_or_default};
+use crate::{CliClient, errors::CliError, utils::get_input_acc_id_by_prefix_or_default};
 
 // EXEC COMMAND
 // ================================================================================================
@@ -46,7 +46,7 @@ pub struct ExecCmd {
 }
 
 impl ExecCmd {
-    pub async fn execute(&self, mut client: Client) -> Result<(), CliError> {
+    pub async fn execute(&self, mut client: CliClient) -> Result<(), CliError> {
         let script_path = PathBuf::from(&self.script_path);
         if !script_path.exists() {
             return Err(CliError::Exec(

--- a/bin/miden-cli/src/commands/export.rs
+++ b/bin/miden-cli/src/commands/export.rs
@@ -1,7 +1,7 @@
 use std::{fs::File, io::Write, path::PathBuf};
 
 use miden_client::{
-    Client, Word,
+    Word,
     account::{Account, AccountFile},
     store::NoteExportType,
     transaction::AccountInterface,
@@ -11,7 +11,8 @@ use miden_lib::AuthScheme;
 use tracing::info;
 
 use crate::{
-    CliKeyStore, Parser, errors::CliError, get_output_note_with_id_prefix, utils::parse_account_id,
+    CliClient, CliKeyStore, Parser, errors::CliError, get_output_note_with_id_prefix,
+    utils::parse_account_id,
 };
 
 #[derive(Debug, Parser, Clone)]
@@ -56,7 +57,11 @@ impl From<&ExportType> for NoteExportType {
 }
 
 impl ExportCmd {
-    pub async fn execute(&self, mut client: Client, keystore: CliKeyStore) -> Result<(), CliError> {
+    pub async fn execute(
+        &self,
+        mut client: CliClient,
+        keystore: CliKeyStore,
+    ) -> Result<(), CliError> {
         if self.account {
             export_account(&client, &keystore, self.id.as_str(), self.filename.clone()).await?;
         } else if let Some(export_type) = &self.export_type {
@@ -74,7 +79,7 @@ impl ExportCmd {
 // ================================================================================================
 
 async fn export_account(
-    client: &Client,
+    client: &CliClient,
     keystore: &CliKeyStore,
     account_id: &str,
     filename: Option<PathBuf>,
@@ -121,7 +126,7 @@ async fn export_account(
 // ================================================================================================
 
 async fn export_note(
-    client: &mut Client,
+    client: &mut CliClient,
     note_id: &str,
     filename: Option<PathBuf>,
     export_type: &ExportType,

--- a/bin/miden-cli/src/commands/import.rs
+++ b/bin/miden-cli/src/commands/import.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use miden_client::{
-    Client, ClientError,
+    ClientError,
     account::{AccountFile, AccountId},
     note::NoteFile,
     utils::Deserializable,
@@ -13,7 +13,7 @@ use miden_client::{
 use tracing::info;
 
 use crate::{
-    CliKeyStore, Parser, commands::account::maybe_set_default_account, errors::CliError,
+    CliClient, CliKeyStore, Parser, commands::account::maybe_set_default_account, errors::CliError,
     utils::load_config_file,
 };
 
@@ -29,7 +29,11 @@ pub struct ImportCmd {
 }
 
 impl ImportCmd {
-    pub async fn execute(&self, mut client: Client, keystore: CliKeyStore) -> Result<(), CliError> {
+    pub async fn execute(
+        &self,
+        mut client: CliClient,
+        keystore: CliKeyStore,
+    ) -> Result<(), CliError> {
         validate_paths(&self.filenames)?;
         let (mut current_config, _) = load_config_file()?;
         for filename in &self.filenames {
@@ -68,7 +72,7 @@ impl ImportCmd {
 // ================================================================================================
 
 async fn import_account(
-    client: &mut Client,
+    client: &mut CliClient,
     keystore: &CliKeyStore,
     account_data_file_contents: &[u8],
     overwrite: bool,

--- a/bin/miden-cli/src/commands/new_account.rs
+++ b/bin/miden-cli/src/commands/new_account.rs
@@ -8,7 +8,6 @@ use std::{
 
 use clap::{Parser, ValueEnum};
 use miden_client::{
-    Client,
     account::{
         Account, AccountBuilder, AccountStorageMode, AccountType,
         component::COMPONENT_TEMPLATE_EXTENSION,
@@ -26,7 +25,7 @@ use rand::RngCore;
 use tracing::debug;
 
 use crate::{
-    CLIENT_BINARY_NAME, CliKeyStore, commands::account::maybe_set_default_account,
+    CLIENT_BINARY_NAME, CliClient, CliKeyStore, commands::account::maybe_set_default_account,
     errors::CliError, utils::load_config_file,
 };
 
@@ -101,7 +100,11 @@ pub struct NewWalletCmd {
 }
 
 impl NewWalletCmd {
-    pub async fn execute(&self, mut client: Client, keystore: CliKeyStore) -> Result<(), CliError> {
+    pub async fn execute(
+        &self,
+        mut client: CliClient,
+        keystore: CliKeyStore,
+    ) -> Result<(), CliError> {
         let mut component_template_paths = vec![PathBuf::from("basic-wallet")];
         component_template_paths.extend(self.extra_components.iter().cloned());
 
@@ -170,7 +173,11 @@ pub struct NewAccountCmd {
 }
 
 impl NewAccountCmd {
-    pub async fn execute(&self, mut client: Client, keystore: CliKeyStore) -> Result<(), CliError> {
+    pub async fn execute(
+        &self,
+        mut client: CliClient,
+        keystore: CliKeyStore,
+    ) -> Result<(), CliError> {
         let new_account = create_client_account(
             &mut client,
             &keystore,
@@ -241,7 +248,7 @@ fn load_init_storage_data(path: Option<PathBuf>) -> Result<InitStorageData, CliE
 /// The created account will have a Falcon-based auth component, additional to any specified
 /// component.
 async fn create_client_account(
-    client: &mut Client,
+    client: &mut CliClient,
     keystore: &CliKeyStore,
     account_type: AccountType,
     storage_mode: AccountStorageMode,
@@ -297,7 +304,7 @@ async fn create_client_account(
 }
 
 /// Submits a deploy transaction to the node for the specified account.
-async fn deploy_account(client: &mut Client, account: &Account) -> Result<(), CliError> {
+async fn deploy_account(client: &mut CliClient, account: &Account) -> Result<(), CliError> {
     // Retrieve the auth procedure mast root pointer and call it in the transaction script.
     // We only use RpoFalcon512 for the auth component so this may be overkill but it lets us
     // use different auth components in the future.

--- a/bin/miden-cli/src/commands/new_transactions.rs
+++ b/bin/miden-cli/src/commands/new_transactions.rs
@@ -2,7 +2,7 @@ use std::{io, sync::Arc};
 
 use clap::{Parser, ValueEnum};
 use miden_client::{
-    Client, RemoteTransactionProver,
+    RemoteTransactionProver,
     account::AccountId,
     asset::{FungibleAsset, NonFungibleDeltaAction},
     note::{BlockNumber, NoteType as MidenNoteType, build_swap_tag, get_input_note_with_id_prefix},
@@ -15,7 +15,7 @@ use miden_client::{
 use tracing::info;
 
 use crate::{
-    create_dynamic_table,
+    CliClient, create_dynamic_table,
     errors::CliError,
     utils::{
         SHARED_TOKEN_DOCUMENTATION, get_input_acc_id_by_prefix_or_default, load_config_file,
@@ -61,7 +61,7 @@ pub struct MintCmd {
 }
 
 impl MintCmd {
-    pub async fn execute(&self, mut client: Client) -> Result<(), CliError> {
+    pub async fn execute(&self, mut client: CliClient) -> Result<(), CliError> {
         let force = self.force;
         let faucet_details_map = load_faucet_details_map()?;
 
@@ -129,7 +129,7 @@ pub struct SendCmd {
 }
 
 impl SendCmd {
-    pub async fn execute(&self, mut client: Client) -> Result<(), CliError> {
+    pub async fn execute(&self, mut client: CliClient) -> Result<(), CliError> {
         let force = self.force;
 
         let faucet_details_map = load_faucet_details_map()?;
@@ -202,7 +202,7 @@ pub struct SwapCmd {
 }
 
 impl SwapCmd {
-    pub async fn execute(&self, mut client: Client) -> Result<(), CliError> {
+    pub async fn execute(&self, mut client: CliClient) -> Result<(), CliError> {
         let force = self.force;
 
         let faucet_details_map = load_faucet_details_map()?;
@@ -273,7 +273,7 @@ pub struct ConsumeNotesCmd {
 }
 
 impl ConsumeNotesCmd {
-    pub async fn execute(&self, mut client: Client) -> Result<(), CliError> {
+    pub async fn execute(&self, mut client: CliClient) -> Result<(), CliError> {
         let force = self.force;
 
         let mut authenticated_notes = Vec::new();
@@ -342,7 +342,7 @@ impl ConsumeNotesCmd {
 // ================================================================================================
 
 async fn execute_transaction(
-    client: &mut Client,
+    client: &mut CliClient,
     account_id: AccountId,
     transaction_request: TransactionRequest,
     force: bool,

--- a/bin/miden-cli/src/commands/notes.rs
+++ b/bin/miden-cli/src/commands/notes.rs
@@ -1,7 +1,7 @@
 use clap::ValueEnum;
 use comfy_table::{Attribute, Cell, ContentArrangement, Table, presets};
 use miden_client::{
-    Client, ClientError, IdPrefixFetchError,
+    ClientError, IdPrefixFetchError,
     asset::Asset,
     note::{
         NoteConsumability, NoteInputs, NoteMetadata, WellKnownNote, get_input_note_with_id_prefix,
@@ -11,7 +11,7 @@ use miden_client::{
 use miden_objects::PrettyPrint;
 
 use crate::{
-    Parser, create_dynamic_table,
+    CliClient, Parser, create_dynamic_table,
     errors::CliError,
     get_output_note_with_id_prefix,
     utils::{load_faucet_details_map, parse_account_id},
@@ -61,7 +61,7 @@ pub struct NotesCmd {
 }
 
 impl NotesCmd {
-    pub async fn execute(&self, client: Client) -> Result<(), CliError> {
+    pub async fn execute(&self, client: CliClient) -> Result<(), CliError> {
         match self {
             NotesCmd { list: Some(NoteFilter::Consumable), .. } => {
                 list_consumable_notes(client, None).await?;
@@ -99,7 +99,7 @@ struct CliNoteSummary {
 
 // LIST NOTES
 // ================================================================================================
-async fn list_notes(client: Client, filter: ClientNoteFilter) -> Result<(), CliError> {
+async fn list_notes(client: CliClient, filter: ClientNoteFilter) -> Result<(), CliError> {
     let input_notes = client
         .get_input_notes(filter.clone())
         .await?
@@ -122,7 +122,7 @@ async fn list_notes(client: Client, filter: ClientNoteFilter) -> Result<(), CliE
 // SHOW NOTE
 // ================================================================================================
 #[allow(clippy::too_many_lines)]
-async fn show_note(client: Client, note_id: String, with_code: bool) -> Result<(), CliError> {
+async fn show_note(client: CliClient, note_id: String, with_code: bool) -> Result<(), CliError> {
     let input_note_record = get_input_note_with_id_prefix(&client, &note_id).await;
     let output_note_record = get_output_note_with_id_prefix(&client, &note_id).await;
 
@@ -290,7 +290,7 @@ async fn show_note(client: Client, note_id: String, with_code: bool) -> Result<(
 // LIST CONSUMABLE INPUT NOTES
 // ================================================================================================
 async fn list_consumable_notes(
-    client: Client,
+    client: CliClient,
     account_id: Option<&String>,
 ) -> Result<(), CliError> {
     let account_id = match account_id {

--- a/bin/miden-cli/src/commands/sync.rs
+++ b/bin/miden-cli/src/commands/sync.rs
@@ -1,14 +1,13 @@
 use clap::Parser;
-use miden_client::Client;
 
-use crate::errors::CliError;
+use crate::{CliClient, errors::CliError};
 
 #[derive(Debug, Parser, Clone)]
 #[command(about = "Sync this client with the latest state of the Miden network")]
 pub struct SyncCmd {}
 
 impl SyncCmd {
-    pub async fn execute(&self, mut client: Client) -> Result<(), CliError> {
+    pub async fn execute(&self, mut client: CliClient) -> Result<(), CliError> {
         let new_details = client.sync_state().await?;
 
         println!("State synced to block {}", new_details.block_num);

--- a/bin/miden-cli/src/commands/tags.rs
+++ b/bin/miden-cli/src/commands/tags.rs
@@ -1,10 +1,7 @@
-use miden_client::{
-    Client,
-    note::{NoteExecutionMode, NoteTag},
-};
+use miden_client::note::{NoteExecutionMode, NoteTag};
 use tracing::info;
 
-use crate::{Parser, create_dynamic_table, errors::CliError, load_config_file};
+use crate::{CliClient, Parser, create_dynamic_table, errors::CliError, load_config_file};
 
 #[derive(Default, Debug, Parser, Clone)]
 #[command(about = "View and manage tags. Defaults to `list` command")]
@@ -23,7 +20,7 @@ pub struct TagsCmd {
 }
 
 impl TagsCmd {
-    pub async fn execute(&self, client: Client) -> Result<(), CliError> {
+    pub async fn execute(&self, client: CliClient) -> Result<(), CliError> {
         match self {
             TagsCmd { add: Some(tag), .. } => {
                 add_tag(client, *tag).await?;
@@ -41,7 +38,7 @@ impl TagsCmd {
 
 // HELPERS
 // ================================================================================================
-async fn list_tags(client: Client) -> Result<(), CliError> {
+async fn list_tags(client: CliClient) -> Result<(), CliError> {
     let (cli_config, _) = load_config_file()?;
     let mut table = create_dynamic_table(&["Tag", "Source"]);
 
@@ -65,7 +62,7 @@ async fn list_tags(client: Client) -> Result<(), CliError> {
     Ok(())
 }
 
-async fn add_tag(mut client: Client, tag: u32) -> Result<(), CliError> {
+async fn add_tag(mut client: CliClient, tag: u32) -> Result<(), CliError> {
     let tag: NoteTag = tag.into();
     let execution_mode = match tag.execution_mode() {
         NoteExecutionMode::Local => "Local",
@@ -81,7 +78,7 @@ async fn add_tag(mut client: Client, tag: u32) -> Result<(), CliError> {
     Ok(())
 }
 
-async fn remove_tag(mut client: Client, tag: u32) -> Result<(), CliError> {
+async fn remove_tag(mut client: CliClient, tag: u32) -> Result<(), CliError> {
     client.remove_note_tag(tag.into()).await?;
     println!("Tag {tag} removed");
     Ok(())

--- a/bin/miden-cli/src/commands/transactions.rs
+++ b/bin/miden-cli/src/commands/transactions.rs
@@ -1,6 +1,6 @@
-use miden_client::{Client, store::TransactionFilter, transaction::TransactionRecord};
+use miden_client::{store::TransactionFilter, transaction::TransactionRecord};
 
-use crate::{Parser, create_dynamic_table, errors::CliError};
+use crate::{CliClient, Parser, create_dynamic_table, errors::CliError};
 
 #[derive(Default, Debug, Parser, Clone)]
 #[command(about = "Manage and view transactions. Defaults to `list` command")]
@@ -11,7 +11,7 @@ pub struct TransactionCmd {
 }
 
 impl TransactionCmd {
-    pub async fn execute(&self, client: Client) -> Result<(), CliError> {
+    pub async fn execute(&self, client: CliClient) -> Result<(), CliError> {
         list_transactions(client).await?;
         Ok(())
     }
@@ -19,7 +19,7 @@ impl TransactionCmd {
 
 // LIST TRANSACTIONS
 // ================================================================================================
-async fn list_transactions(client: Client) -> Result<(), CliError> {
+async fn list_transactions(client: CliClient) -> Result<(), CliError> {
     let transactions = client.get_transactions(TransactionFilter::All).await?;
     print_transactions_summary(&transactions);
     Ok(())

--- a/bin/miden-cli/src/faucet_details_map.rs
+++ b/bin/miden-cli/src/faucet_details_map.rs
@@ -3,11 +3,11 @@ use std::{
     path::PathBuf,
 };
 
-use miden_client::{Client, account::AccountId, asset::FungibleAsset};
+use miden_client::{account::AccountId, asset::FungibleAsset};
 use miden_lib::account::faucets::BasicFungibleFaucet;
 use serde::{Deserialize, Serialize};
 
-use crate::{errors::CliError, load_config_file, utils::parse_account_id};
+use crate::{CliClient, errors::CliError, load_config_file, utils::parse_account_id};
 
 /// Stores the detail information of a faucet to be stored in the token symbol map file.
 #[derive(Debug, Serialize, Deserialize)]
@@ -94,7 +94,7 @@ impl FaucetDetailsMap {
     /// - The token symbol isn't present in the token symbol map file.
     pub async fn parse_fungible_asset(
         &self,
-        client: &Client,
+        client: &CliClient,
         arg: &str,
     ) -> Result<FungibleAsset, CliError> {
         let (amount, asset) = arg.split_once("::").ok_or(CliError::Parse(

--- a/bin/miden-cli/src/info.rs
+++ b/bin/miden-cli/src/info.rs
@@ -1,11 +1,11 @@
 use std::fs;
 
-use miden_client::{Client, store::NoteFilter};
+use miden_client::store::NoteFilter;
 
 use super::config::CliConfig;
-use crate::{errors::CliError, load_config_file};
+use crate::{CliClient, errors::CliError, load_config_file};
 
-pub async fn print_client_info(client: &Client) -> Result<(), CliError> {
+pub async fn print_client_info(client: &CliClient) -> Result<(), CliError> {
     let (config, _) = load_config_file()?;
 
     println!("Client version: {}", env!("CARGO_PKG_VERSION"));
@@ -15,7 +15,7 @@ pub async fn print_client_info(client: &Client) -> Result<(), CliError> {
 
 // HELPERS
 // ================================================================================================
-async fn print_client_stats(client: &Client) -> Result<(), CliError> {
+async fn print_client_stats(client: &CliClient) -> Result<(), CliError> {
     println!("Block number: {}", client.get_sync_height().await?);
     println!("Tracked accounts: {}", client.get_account_headers().await?.len());
     println!("Expected notes: {}", client.get_input_notes(NoteFilter::Expected).await?.len());

--- a/bin/miden-cli/src/lib.rs
+++ b/bin/miden-cli/src/lib.rs
@@ -8,7 +8,7 @@ use miden_client::{
     account::AccountHeader,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
-    store::{NoteFilter as ClientNoteFilter, OutputNoteRecord},
+    store::{NoteFilter as ClientNoteFilter, OutputNoteRecord, sqlite_store::SqliteStore},
 };
 use rand::rngs::StdRng;
 mod commands;
@@ -29,6 +29,7 @@ use commands::{
 use self::utils::load_config_file;
 
 pub type CliKeyStore = FilesystemKeyStore<StdRng>;
+pub type CliClient = Client<SqliteStore, CliKeyStore>;
 
 mod config;
 mod errors;
@@ -178,7 +179,7 @@ pub fn create_dynamic_table(headers: &[&str]) -> Table {
 /// - Returns [`IdPrefixFetchError::MultipleMatches`] if there were more than one note found where
 ///   `note_id_prefix` is a prefix of its ID.
 pub(crate) async fn get_output_note_with_id_prefix(
-    client: &Client,
+    client: &CliClient,
     note_id_prefix: &str,
 ) -> Result<OutputNoteRecord, IdPrefixFetchError> {
     let mut output_note_records = client
@@ -224,7 +225,7 @@ pub(crate) async fn get_output_note_with_id_prefix(
 /// - Returns [`IdPrefixFetchError::MultipleMatches`] if there were more than one account found
 ///   where `account_id_prefix` is a prefix of its ID.
 async fn get_account_with_id_prefix(
-    client: &Client,
+    client: &CliClient,
     account_id_prefix: &str,
 ) -> Result<AccountHeader, IdPrefixFetchError> {
     let mut accounts = client

--- a/bin/miden-cli/src/utils.rs
+++ b/bin/miden-cli/src/utils.rs
@@ -8,11 +8,11 @@ use figment::{
     Figment,
     providers::{Format, Toml},
 };
-use miden_client::{Client, account::AccountId};
+use miden_client::account::AccountId;
 use tracing::info;
 
 use super::{CLIENT_CONFIG_FILE_NAME, config::CliConfig, get_account_with_id_prefix};
-use crate::{errors::CliError, faucet_details_map::FaucetDetailsMap};
+use crate::{CliClient, errors::CliError, faucet_details_map::FaucetDetailsMap};
 
 pub(crate) const SHARED_TOKEN_DOCUMENTATION: &str = "There are two accepted formats for the asset:
 - `<AMOUNT>::<FAUCET_ID>` where `<AMOUNT>` is in the faucet base units.
@@ -25,7 +25,7 @@ For example, `100::0xabcdef0123456789` or `1.23::TST`";
 /// Returns a tracked Account ID matching a hex string or the default one defined in the Client
 /// config.
 pub(crate) async fn get_input_acc_id_by_prefix_or_default(
-    client: &Client,
+    client: &CliClient,
     account_id: Option<String>,
 ) -> Result<AccountId, CliError> {
     let account_id_str = if let Some(account_id_prefix) = account_id {
@@ -54,7 +54,7 @@ pub(crate) async fn get_input_acc_id_by_prefix_or_default(
 /// - Will return a `IdPrefixFetchError` if the provided account ID string can't be parsed as an
 ///   `AccountId` and doesn't correspond to an account tracked by the client either.
 pub(crate) async fn parse_account_id(
-    client: &Client,
+    client: &CliClient,
     account_id: &str,
 ) -> Result<AccountId, CliError> {
     if account_id.starts_with("0x") {

--- a/crates/rust-client/src/account/mod.rs
+++ b/crates/rust-client/src/account/mod.rs
@@ -88,7 +88,7 @@ pub mod component {
 ///   with the network.
 ///
 /// - **Data retrieval:** The module also provides methods to fetch account-related data.
-impl<STORE: Store, AUTH: TransactionAuthenticator> Client<STORE, AUTH> {
+impl<STORE: Store + 'static, AUTH: TransactionAuthenticator + 'static> Client<STORE, AUTH> {
     // ACCOUNT CREATION
     // --------------------------------------------------------------------------------------------
 

--- a/crates/rust-client/src/account/mod.rs
+++ b/crates/rust-client/src/account/mod.rs
@@ -39,12 +39,13 @@ use alloc::vec::Vec;
 
 use miden_lib::account::{auth::RpoFalcon512, wallets::BasicWallet};
 use miden_objects::{Word, crypto::dsa::rpo_falcon512::PublicKey};
+use miden_tx::auth::TransactionAuthenticator;
 
 use super::Client;
 use crate::{
     errors::ClientError,
     rpc::domain::account::FetchedAccount,
-    store::{AccountRecord, AccountStatus},
+    store::{AccountRecord, AccountStatus, Store},
 };
 
 pub mod procedure_roots;
@@ -87,7 +88,7 @@ pub mod component {
 ///   with the network.
 ///
 /// - **Data retrieval:** The module also provides methods to fetch account-related data.
-impl Client {
+impl<STORE: Store + 'static, AUTH: TransactionAuthenticator + 'static> Client<STORE, AUTH> {
     // ACCOUNT CREATION
     // --------------------------------------------------------------------------------------------
 

--- a/crates/rust-client/src/account/mod.rs
+++ b/crates/rust-client/src/account/mod.rs
@@ -88,7 +88,7 @@ pub mod component {
 ///   with the network.
 ///
 /// - **Data retrieval:** The module also provides methods to fetch account-related data.
-impl<STORE: Store + 'static, AUTH: TransactionAuthenticator + 'static> Client<STORE, AUTH> {
+impl<STORE: Store, AUTH: TransactionAuthenticator> Client<STORE, AUTH> {
     // ACCOUNT CREATION
     // --------------------------------------------------------------------------------------------
 

--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -245,7 +245,7 @@ pub struct Client<STORE: Store, AUTH: TransactionAuthenticator> {
 }
 
 /// Construction and access methods.
-impl<STORE: Store, AUTH: TransactionAuthenticator> Client<STORE, AUTH> {
+impl<STORE: Store + 'static, AUTH: TransactionAuthenticator + 'static> Client<STORE, AUTH> {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
 

--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -245,7 +245,7 @@ pub struct Client<STORE: Store, AUTH: TransactionAuthenticator> {
 }
 
 /// Construction and access methods.
-impl<STORE: Store + 'static, AUTH: TransactionAuthenticator + 'static> Client<STORE, AUTH> {
+impl<STORE: Store, AUTH: TransactionAuthenticator> Client<STORE, AUTH> {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
 

--- a/crates/rust-client/src/note/import.rs
+++ b/crates/rust-client/src/note/import.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 
 /// Note importing methods.
-impl<STORE: Store + 'static, AUTH: TransactionAuthenticator + 'static> Client<STORE, AUTH> {
+impl<STORE: Store, AUTH: TransactionAuthenticator> Client<STORE, AUTH> {
     // INPUT NOTE CREATION
     // --------------------------------------------------------------------------------------------
 

--- a/crates/rust-client/src/note/import.rs
+++ b/crates/rust-client/src/note/import.rs
@@ -14,16 +14,17 @@ use miden_objects::{
     block::BlockNumber,
     note::{Note, NoteDetails, NoteFile, NoteId, NoteInclusionProof, NoteMetadata, NoteTag},
 };
+use miden_tx::auth::TransactionAuthenticator;
 
 use crate::{
     Client, ClientError,
     rpc::{RpcError, domain::note::FetchedNote},
-    store::{InputNoteRecord, InputNoteState, input_note_states::ExpectedNoteState},
+    store::{InputNoteRecord, InputNoteState, Store, input_note_states::ExpectedNoteState},
     sync::NoteTagRecord,
 };
 
 /// Note importing methods.
-impl Client {
+impl<STORE: Store + 'static, AUTH: TransactionAuthenticator + 'static> Client<STORE, AUTH> {
     // INPUT NOTE CREATION
     // --------------------------------------------------------------------------------------------
 

--- a/crates/rust-client/src/note/import.rs
+++ b/crates/rust-client/src/note/import.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 
 /// Note importing methods.
-impl<STORE: Store, AUTH: TransactionAuthenticator> Client<STORE, AUTH> {
+impl<STORE: Store + 'static, AUTH: TransactionAuthenticator + 'static> Client<STORE, AUTH> {
     // INPUT NOTE CREATION
     // --------------------------------------------------------------------------------------------
 

--- a/crates/rust-client/src/note/mod.rs
+++ b/crates/rust-client/src/note/mod.rs
@@ -59,10 +59,11 @@
 use alloc::{string::ToString, vec::Vec};
 
 use miden_objects::account::AccountId;
+use miden_tx::auth::TransactionAuthenticator;
 
 use crate::{
     Client, ClientError, IdPrefixFetchError,
-    store::{InputNoteRecord, NoteFilter, OutputNoteRecord},
+    store::{InputNoteRecord, NoteFilter, OutputNoteRecord, Store},
 };
 
 mod import;
@@ -92,7 +93,7 @@ pub use note_update_tracker::{
 };
 
 /// Note retrieval methods.
-impl Client {
+impl<STORE: Store + 'static, AUTH: TransactionAuthenticator + 'static> Client<STORE, AUTH> {
     // INPUT NOTE DATA RETRIEVAL
     // --------------------------------------------------------------------------------------------
 
@@ -195,8 +196,11 @@ impl Client {
 ///   `note_id_prefix` is a prefix of its ID.
 /// - Returns [`IdPrefixFetchError::MultipleMatches`] if there were more than one note found where
 ///   `note_id_prefix` is a prefix of its ID.
-pub async fn get_input_note_with_id_prefix(
-    client: &Client,
+pub async fn get_input_note_with_id_prefix<
+    STORE: Store + 'static,
+    AUTH: TransactionAuthenticator + 'static,
+>(
+    client: &Client<STORE, AUTH>,
     note_id_prefix: &str,
 ) -> Result<InputNoteRecord, IdPrefixFetchError> {
     let mut input_note_records = client

--- a/crates/rust-client/src/note/mod.rs
+++ b/crates/rust-client/src/note/mod.rs
@@ -93,7 +93,7 @@ pub use note_update_tracker::{
 };
 
 /// Note retrieval methods.
-impl<STORE: Store + 'static, AUTH: TransactionAuthenticator + 'static> Client<STORE, AUTH> {
+impl<STORE: Store, AUTH: TransactionAuthenticator> Client<STORE, AUTH> {
     // INPUT NOTE DATA RETRIEVAL
     // --------------------------------------------------------------------------------------------
 
@@ -196,10 +196,7 @@ impl<STORE: Store + 'static, AUTH: TransactionAuthenticator + 'static> Client<ST
 ///   `note_id_prefix` is a prefix of its ID.
 /// - Returns [`IdPrefixFetchError::MultipleMatches`] if there were more than one note found where
 ///   `note_id_prefix` is a prefix of its ID.
-pub async fn get_input_note_with_id_prefix<
-    STORE: Store + 'static,
-    AUTH: TransactionAuthenticator + 'static,
->(
+pub async fn get_input_note_with_id_prefix<STORE: Store, AUTH: TransactionAuthenticator>(
     client: &Client<STORE, AUTH>,
     note_id_prefix: &str,
 ) -> Result<InputNoteRecord, IdPrefixFetchError> {

--- a/crates/rust-client/src/note/mod.rs
+++ b/crates/rust-client/src/note/mod.rs
@@ -93,7 +93,7 @@ pub use note_update_tracker::{
 };
 
 /// Note retrieval methods.
-impl<STORE: Store, AUTH: TransactionAuthenticator> Client<STORE, AUTH> {
+impl<STORE: Store + 'static, AUTH: TransactionAuthenticator + 'static> Client<STORE, AUTH> {
     // INPUT NOTE DATA RETRIEVAL
     // --------------------------------------------------------------------------------------------
 
@@ -196,7 +196,10 @@ impl<STORE: Store, AUTH: TransactionAuthenticator> Client<STORE, AUTH> {
 ///   `note_id_prefix` is a prefix of its ID.
 /// - Returns [`IdPrefixFetchError::MultipleMatches`] if there were more than one note found where
 ///   `note_id_prefix` is a prefix of its ID.
-pub async fn get_input_note_with_id_prefix<STORE: Store, AUTH: TransactionAuthenticator>(
+pub async fn get_input_note_with_id_prefix<
+    STORE: Store + 'static,
+    AUTH: TransactionAuthenticator + 'static,
+>(
     client: &Client<STORE, AUTH>,
     note_id_prefix: &str,
 ) -> Result<InputNoteRecord, IdPrefixFetchError> {

--- a/crates/rust-client/src/note/note_screener.rs
+++ b/crates/rust-client/src/note/note_screener.rs
@@ -14,6 +14,7 @@ use miden_tx::{
     auth::TransactionAuthenticator,
 };
 use thiserror::Error;
+use tonic::async_trait;
 
 use crate::{
     store::{Store, StoreError, data_store::ClientDataStore},
@@ -127,8 +128,10 @@ impl<STORE: Store, AUTH: TransactionAuthenticator> NoteScreener<STORE, AUTH> {
             .expect("Single note should be valid");
 
         let data_store = ClientDataStore::new(self.store.clone());
-        let transaction_executor =
-            TransactionExecutor::new(&data_store, self.authenticator.as_deref());
+        let transaction_executor = TransactionExecutor::new(
+            &data_store,
+            self.authenticator.as_deref().map(|a| a as &dyn TransactionAuthenticator),
+        );
         let consumption_checker = NoteConsumptionChecker::new(&transaction_executor);
 
         data_store.mast_store().load_account_code(account.code());
@@ -171,6 +174,52 @@ impl<STORE: Store, AUTH: TransactionAuthenticator> NoteScreener<STORE, AUTH> {
             Ok(Some(NoteRelevance::After(recall_height)))
         } else {
             Ok(None)
+        }
+    }
+}
+
+// DEFAULT ON NOTE RECEIVED IMPLEMENTATION
+// ================================================================================================
+
+#[async_trait(?Send)]
+impl OnNoteReceived<STORE, AUTH> for NoteScreener<STORE, AUTH> {
+    /// Default implementation of the [`OnNoteReceived`] callback. It queries the store for the
+    /// committed note to check if it's relevant. If the note wasn't being tracked but it came in
+    /// the sync response it may be a new public note, in that case we use the [`NoteScreener`]
+    /// to check its relevance.
+    async fn on_note_received(
+        &self,
+        committed_note: CommittedNote,
+        public_note: Option<InputNoteRecord>,
+    ) -> Result<bool, ClientError> {
+        let note_id = *committed_note.note_id();
+
+        if !self.store.get_input_notes(NoteFilter::Unique(note_id)).await?.is_empty()
+            || !self.store.get_output_notes(NoteFilter::Unique(note_id)).await?.is_empty()
+        {
+            // The note is being tracked by the client so it is relevant
+            Ok(true)
+        } else if let Some(public_note) = public_note {
+            // If tracked by the user, keep note regardless of inputs and extra checks
+            if let Some(metadata) = public_note.metadata()
+                && self.store.get_unique_note_tags().await?.contains(&metadata.tag())
+            {
+                return Ok(true);
+            }
+
+            // The note is not being tracked by the client and is public so we can screen it
+            let new_note_relevance = self
+                .check_relevance(
+                    &public_note.try_into().map_err(ClientError::NoteRecordConversionError)?,
+                )
+                .await?;
+
+            let is_relevant = !new_note_relevance.is_empty();
+            Ok(is_relevant)
+        } else {
+            // The note is not being tracked by the client and is private so we can't determine if
+            // it is relevant
+            Ok(false)
         }
     }
 }

--- a/crates/rust-client/src/note/note_screener.rs
+++ b/crates/rust-client/src/note/note_screener.rs
@@ -50,18 +50,15 @@ impl fmt::Display for NoteRelevance {
 /// tracked in the provided `store`. This can be derived in a number of ways, such as looking
 /// at the combination of script root and note inputs. For example, a P2ID note is relevant
 /// for a specific account ID if this ID is its first note input.
-pub struct NoteScreener {
+pub struct NoteScreener<STORE: Store, AUTH: TransactionAuthenticator> {
     /// A reference to the client's store, used to fetch necessary data to check consumability.
-    store: Arc<dyn Store>,
+    store: Arc<STORE>,
     /// A reference to the transaction authenticator
-    authenticator: Option<Arc<dyn TransactionAuthenticator>>,
+    authenticator: Option<Arc<AUTH>>,
 }
 
-impl NoteScreener {
-    pub fn new(
-        store: Arc<dyn Store>,
-        authenticator: Option<Arc<dyn TransactionAuthenticator>>,
-    ) -> Self {
+impl<STORE: Store, AUTH: TransactionAuthenticator> NoteScreener<STORE, AUTH> {
+    pub fn new(store: Arc<STORE>, authenticator: Option<Arc<AUTH>>) -> Self {
         Self { store, authenticator }
     }
 

--- a/crates/rust-client/src/sync/block_header.rs
+++ b/crates/rust-client/src/sync/block_header.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 /// Network information management methods.
-impl<STORE: Store + 'static, AUTH: TransactionAuthenticator + 'static> Client<STORE, AUTH> {
+impl<STORE: Store, AUTH: TransactionAuthenticator> Client<STORE, AUTH> {
     /// Attempts to retrieve the genesis block from the store. If not found,
     /// it requests it from the node and store it.
     pub async fn ensure_genesis_in_place(&mut self) -> Result<BlockHeader, ClientError> {

--- a/crates/rust-client/src/sync/block_header.rs
+++ b/crates/rust-client/src/sync/block_header.rs
@@ -9,16 +9,17 @@ use miden_objects::{
         merkle::{Forest, MerklePath},
     },
 };
+use miden_tx::auth::TransactionAuthenticator;
 use tracing::warn;
 
 use crate::{
     Client, ClientError,
     rpc::NodeRpcClient,
-    store::{BlockRelevance, PartialBlockchainFilter, StoreError},
+    store::{BlockRelevance, PartialBlockchainFilter, Store, StoreError},
 };
 
 /// Network information management methods.
-impl Client {
+impl<STORE: Store + 'static, AUTH: TransactionAuthenticator + 'static> Client<STORE, AUTH> {
     /// Attempts to retrieve the genesis block from the store. If not found,
     /// it requests it from the node and store it.
     pub async fn ensure_genesis_in_place(&mut self) -> Result<BlockHeader, ClientError> {

--- a/crates/rust-client/src/sync/block_header.rs
+++ b/crates/rust-client/src/sync/block_header.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 /// Network information management methods.
-impl<STORE: Store, AUTH: TransactionAuthenticator> Client<STORE, AUTH> {
+impl<STORE: Store + 'static, AUTH: TransactionAuthenticator + 'static> Client<STORE, AUTH> {
     /// Attempts to retrieve the genesis block from the store. If not found,
     /// it requests it from the node and store it.
     pub async fn ensure_genesis_in_place(&mut self) -> Result<BlockHeader, ClientError> {

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -71,7 +71,7 @@ use miden_tx::{
 use crate::{
     Client, ClientError,
     note::NoteScreener,
-    store::{NoteFilter, TransactionFilter},
+    store::{NoteFilter, Store, TransactionFilter},
 };
 mod block_header;
 
@@ -87,7 +87,7 @@ pub use state_sync_update::{
 };
 
 /// Client synchronization methods.
-impl<STORE: Store, AUTH: TransactionAuthenticator> Client<STORE, AUTH> {
+impl<STORE: Store + 'static, AUTH: TransactionAuthenticator + 'static> Client<STORE, AUTH> {
     // SYNC STATE
     // --------------------------------------------------------------------------------------------
 

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -63,12 +63,15 @@ use miden_objects::{
     note::{NoteId, NoteTag},
     transaction::{PartialBlockchain, TransactionId},
 };
-use miden_tx::utils::{Deserializable, DeserializationError, Serializable};
+use miden_tx::{
+    auth::TransactionAuthenticator,
+    utils::{Deserializable, DeserializationError, Serializable},
+};
 
 use crate::{
     Client, ClientError,
     note::NoteScreener,
-    store::{NoteFilter, TransactionFilter},
+    store::{NoteFilter, Store, TransactionFilter},
 };
 mod block_header;
 
@@ -84,7 +87,7 @@ pub use state_sync_update::{
 };
 
 /// Client synchronization methods.
-impl Client {
+impl<STORE: Store + 'static, AUTH: TransactionAuthenticator + 'static> Client<STORE, AUTH> {
     // SYNC STATE
     // --------------------------------------------------------------------------------------------
 

--- a/crates/rust-client/src/sync/state_sync.rs
+++ b/crates/rust-client/src/sync/state_sync.rs
@@ -13,6 +13,7 @@ use miden_objects::{
     note::{NoteId, NoteTag},
     transaction::PartialBlockchain,
 };
+use miden_tx::auth::TransactionAuthenticator;
 use tonic::async_trait;
 use tracing::info;
 
@@ -21,12 +22,12 @@ use super::{
 };
 use crate::{
     ClientError,
-    note::{NoteScreener, NoteUpdateTracker},
+    note::NoteUpdateTracker,
     rpc::{
         NodeRpcClient,
         domain::{note::CommittedNote, transaction::TransactionInclusion},
     },
-    store::{InputNoteRecord, NoteFilter, OutputNoteRecord, Store, StoreError},
+    store::{InputNoteRecord, OutputNoteRecord, Store, StoreError},
     transaction::TransactionRecord,
 };
 
@@ -73,7 +74,7 @@ pub struct StateSync<STORE: Store, AUTH: TransactionAuthenticator> {
     tx_graceful_blocks: Option<u32>,
 }
 
-impl<STORE: Store, AUTH: TransactionAuthenticator> StateSync<STORE, AUTH> {
+impl<STORE: Store + 'static, AUTH: TransactionAuthenticator + 'static> StateSync<STORE, AUTH> {
     /// Creates a new instance of the state sync component.
     ///
     /// # Arguments

--- a/crates/rust-client/src/sync/state_sync.rs
+++ b/crates/rust-client/src/sync/state_sync.rs
@@ -14,6 +14,7 @@ use miden_objects::{
     note::{NoteId, NoteTag},
     transaction::PartialBlockchain,
 };
+use miden_tx::auth::TransactionAuthenticator;
 use tracing::info;
 
 use super::{
@@ -45,11 +46,11 @@ use crate::{
 ///
 /// It returns a boolean indicating if the received note update is relevant. If the return value
 /// is `false`, it gets discarded. If it is `true`, the update gets committed to the client's store.
-pub type OnNoteReceived = Box<
+pub type OnNoteReceived<STORE, AUTH> = Box<
     dyn Fn(
         CommittedNote,
         Option<InputNoteRecord>,
-        Arc<NoteScreener>,
+        Arc<NoteScreener<STORE, AUTH>>,
         Arc<BTreeSet<NoteTag>>,
     ) -> Pin<Box<dyn Future<Output = Result<bool, ClientError>>>>,
 >;
@@ -63,19 +64,19 @@ pub type OnNoteReceived = Box<
 ///
 /// When created it receives a callback that will be executed when a new note inclusion is received
 /// in the sync response.
-pub struct StateSync {
+pub struct StateSync<STORE: Store, AUTH: TransactionAuthenticator> {
     /// The RPC client used to communicate with the node.
     rpc_api: Arc<dyn NodeRpcClient + Send>,
     /// Callback to be executed when a new note inclusion is received.
-    on_note_received: OnNoteReceived,
+    on_note_received: OnNoteReceived<STORE, AUTH>,
     /// The number of blocks that are considered old enough to discard pending transactions. If
     /// `None`, there is no limit and transactions will be kept indefinitely.
     tx_graceful_blocks: Option<u32>,
     /// The note screener used to check the relevance of notes.
-    note_screener: Arc<NoteScreener>,
+    note_screener: Arc<NoteScreener<STORE, AUTH>>,
 }
 
-impl StateSync {
+impl<STORE: Store, AUTH: TransactionAuthenticator> StateSync<STORE, AUTH> {
     /// Creates a new instance of the state sync component.
     ///
     /// # Arguments
@@ -86,9 +87,9 @@ impl StateSync {
     /// * `note_screener` - The note screener used to check the relevance of notes.
     pub fn new(
         rpc_api: Arc<dyn NodeRpcClient + Send>,
-        on_note_received: OnNoteReceived,
+        on_note_received: OnNoteReceived<STORE, AUTH>,
         tx_graceful_blocks: Option<u32>,
-        note_screener: NoteScreener,
+        note_screener: NoteScreener<STORE, AUTH>,
     ) -> Self {
         Self {
             rpc_api,
@@ -478,11 +479,11 @@ fn apply_mmr_changes(
 /// committed note to check if it's relevant. If the note wasn't being tracked but it came in the
 /// sync response it may be a new public note, in that case we use the [`NoteScreener`] to check its
 /// relevance.
-pub async fn on_note_received(
+pub async fn on_note_received<STORE: Store, AUTH: TransactionAuthenticator>(
     store: Arc<dyn Store>,
     committed_note: CommittedNote,
     public_note: Option<InputNoteRecord>,
-    note_screener: Arc<NoteScreener>,
+    note_screener: Arc<NoteScreener<STORE, AUTH>>,
     note_tags: Arc<BTreeSet<NoteTag>>,
 ) -> Result<bool, ClientError> {
     let note_id = *committed_note.note_id();

--- a/crates/rust-client/src/sync/state_sync.rs
+++ b/crates/rust-client/src/sync/state_sync.rs
@@ -4,7 +4,6 @@ use alloc::{
     sync::Arc,
     vec::Vec,
 };
-use core::{future::Future, pin::Pin};
 
 use miden_objects::{
     Word,
@@ -14,7 +13,7 @@ use miden_objects::{
     note::{NoteId, NoteTag},
     transaction::PartialBlockchain,
 };
-use miden_tx::auth::TransactionAuthenticator;
+use tonic::async_trait;
 use tracing::info;
 
 use super::{
@@ -34,26 +33,26 @@ use crate::{
 // SYNC CALLBACKS
 // ================================================================================================
 
-/// Callback that gets executed when a new note is received as part of the sync response.
-///
-/// It receives:
-///
-/// - The committed note received from the network.
-/// - An optional note record that corresponds to the state of the note in the network (only if the
-///   note is public).
-/// - A note screener that can be used to test whether notes are consumable.
-/// - A set of [`NoteTag`]s that contains all tags tracked in the store.
-///
-/// It returns a boolean indicating if the received note update is relevant. If the return value
-/// is `false`, it gets discarded. If it is `true`, the update gets committed to the client's store.
-pub type OnNoteReceived<STORE, AUTH> = Box<
-    dyn Fn(
-        CommittedNote,
-        Option<InputNoteRecord>,
-        Arc<NoteScreener<STORE, AUTH>>,
-        Arc<BTreeSet<NoteTag>>,
-    ) -> Pin<Box<dyn Future<Output = Result<bool, ClientError>>>>,
->;
+#[async_trait(?Send)]
+pub trait OnNoteReceived<STORE: Store, AUTH: TransactionAuthenticator> {
+    /// Callback that gets executed when a new note is received as part of the sync response.
+    ///
+    /// It receives:
+    ///
+    /// - The committed note received from the network.
+    /// - An optional note record that corresponds to the state of the note in the network (only if
+    ///   the note is public).
+    /// - A note screener that can be used to test whether notes are consumable.
+    ///
+    /// It returns a boolean indicating if the received note update is relevant. If the return value
+    /// is `false`, it gets discarded. If it is `true`, the update gets committed to the client's
+    /// store.
+    async fn on_note_received(
+        &self,
+        committed_note: CommittedNote,
+        public_note: Option<InputNoteRecord>,
+    ) -> Result<bool, ClientError>;
+}
 
 // STATE SYNC
 // ================================================================================================
@@ -67,13 +66,11 @@ pub type OnNoteReceived<STORE, AUTH> = Box<
 pub struct StateSync<STORE: Store, AUTH: TransactionAuthenticator> {
     /// The RPC client used to communicate with the node.
     rpc_api: Arc<dyn NodeRpcClient + Send>,
-    /// Callback to be executed when a new note inclusion is received.
-    on_note_received: OnNoteReceived<STORE, AUTH>,
+    /// Note screener to be used when a new note inclusion is received.
+    note_screener: Arc<dyn OnNoteReceived<STORE, AUTH>>,
     /// The number of blocks that are considered old enough to discard pending transactions. If
     /// `None`, there is no limit and transactions will be kept indefinitely.
     tx_graceful_blocks: Option<u32>,
-    /// The note screener used to check the relevance of notes.
-    note_screener: Arc<NoteScreener<STORE, AUTH>>,
 }
 
 impl<STORE: Store, AUTH: TransactionAuthenticator> StateSync<STORE, AUTH> {
@@ -84,19 +81,15 @@ impl<STORE: Store, AUTH: TransactionAuthenticator> StateSync<STORE, AUTH> {
     /// * `rpc_api` - The RPC client used to communicate with the node.
     /// * `on_note_received` - A callback to be executed when a new note inclusion is received.
     /// * `tx_graceful_blocks` - The number of blocks that are considered old enough to discard.
-    /// * `note_screener` - The note screener used to check the relevance of notes.
     pub fn new(
         rpc_api: Arc<dyn NodeRpcClient + Send>,
-        on_note_received: OnNoteReceived<STORE, AUTH>,
+        on_note_received: Arc<dyn OnNoteReceived<STORE, AUTH>>,
         tx_graceful_blocks: Option<u32>,
-        note_screener: NoteScreener<STORE, AUTH>,
     ) -> Self {
         Self {
             rpc_api,
-            on_note_received,
+            note_screener: on_note_received,
             tx_graceful_blocks,
-            #[allow(clippy::arc_with_non_send_sync)]
-            note_screener: Arc::new(note_screener),
         }
     }
 
@@ -217,7 +210,6 @@ impl<STORE: Store, AUTH: TransactionAuthenticator> StateSync<STORE, AUTH> {
                 &mut state_sync_update.note_updates,
                 response.note_inclusions,
                 &response.block_header,
-                note_tags.clone(),
             )
             .await?;
 
@@ -328,7 +320,6 @@ impl<STORE: Store, AUTH: TransactionAuthenticator> StateSync<STORE, AUTH> {
         note_updates: &mut NoteUpdateTracker,
         note_inclusions: Vec<CommittedNote>,
         block_header: &BlockHeader,
-        note_tags: Arc<BTreeSet<NoteTag>>,
     ) -> Result<bool, ClientError> {
         let public_note_ids: Vec<NoteId> = note_inclusions
             .iter()
@@ -342,13 +333,10 @@ impl<STORE: Store, AUTH: TransactionAuthenticator> StateSync<STORE, AUTH> {
         for committed_note in note_inclusions {
             let public_note = new_public_notes.get(committed_note.note_id()).cloned();
 
-            if (self.on_note_received)(
-                committed_note.clone(),
-                public_note.clone(),
-                self.note_screener.clone(),
-                note_tags.clone(),
-            )
-            .await?
+            if self
+                .note_screener
+                .on_note_received(committed_note.clone(), public_note.clone())
+                .await?
             {
                 found_relevant_note = true;
 
@@ -470,49 +458,4 @@ fn apply_mmr_changes(
         .append(&mut current_partial_mmr.add(new_block.commitment(), new_block_has_relevant_notes));
 
     Ok((new_peaks, new_authentication_nodes))
-}
-
-// DEFAULT CALLBACK IMPLEMENTATIONS
-// ================================================================================================
-
-/// Default implementation of the [`OnNoteReceived`] callback. It queries the store for the
-/// committed note to check if it's relevant. If the note wasn't being tracked but it came in the
-/// sync response it may be a new public note, in that case we use the [`NoteScreener`] to check its
-/// relevance.
-pub async fn on_note_received<STORE: Store, AUTH: TransactionAuthenticator>(
-    store: Arc<dyn Store>,
-    committed_note: CommittedNote,
-    public_note: Option<InputNoteRecord>,
-    note_screener: Arc<NoteScreener<STORE, AUTH>>,
-    note_tags: Arc<BTreeSet<NoteTag>>,
-) -> Result<bool, ClientError> {
-    let note_id = *committed_note.note_id();
-
-    if !store.get_input_notes(NoteFilter::Unique(note_id)).await?.is_empty()
-        || !store.get_output_notes(NoteFilter::Unique(note_id)).await?.is_empty()
-    {
-        // The note is being tracked by the client so it is relevant
-        Ok(true)
-    } else if let Some(public_note) = public_note {
-        // If tracked by the user, keep note regardless of inputs and extra checks
-        if let Some(metadata) = public_note.metadata()
-            && note_tags.contains(&metadata.tag())
-        {
-            return Ok(true);
-        }
-
-        // The note is not being tracked by the client and is public so we can screen it
-        let new_note_relevance = note_screener
-            .check_relevance(
-                &public_note.try_into().map_err(ClientError::NoteRecordConversionError)?,
-            )
-            .await?;
-
-        let is_relevant = !new_note_relevance.is_empty();
-        Ok(is_relevant)
-    } else {
-        // The note is not being tracked by the client and is private so we can't determine if it
-        // is relevant
-        Ok(false)
-    }
 }

--- a/crates/rust-client/src/sync/tag.rs
+++ b/crates/rust-client/src/sync/tag.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 /// Tag management methods
-impl<STORE: Store + 'static, AUTH: TransactionAuthenticator + 'static> Client<STORE, AUTH> {
+impl<STORE: Store, AUTH: TransactionAuthenticator> Client<STORE, AUTH> {
     /// Returns the list of note tags tracked by the client along with their source.
     ///
     /// When syncing the state with the node, these tags will be added to the sync request and

--- a/crates/rust-client/src/sync/tag.rs
+++ b/crates/rust-client/src/sync/tag.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 /// Tag management methods
-impl<STORE: Store, AUTH: TransactionAuthenticator> Client<STORE, AUTH> {
+impl<STORE: Store + 'static, AUTH: TransactionAuthenticator + 'static> Client<STORE, AUTH> {
     /// Returns the list of note tags tracked by the client along with their source.
     ///
     /// When syncing the state with the node, these tags will be added to the sync request and

--- a/crates/rust-client/src/sync/tag.rs
+++ b/crates/rust-client/src/sync/tag.rs
@@ -4,17 +4,20 @@ use miden_objects::{
     account::{Account, AccountId},
     note::{NoteId, NoteTag},
 };
-use miden_tx::utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
+use miden_tx::{
+    auth::TransactionAuthenticator,
+    utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
+};
 use tracing::warn;
 
 use crate::{
     Client,
     errors::ClientError,
-    store::{InputNoteRecord, NoteRecordError},
+    store::{InputNoteRecord, NoteRecordError, Store},
 };
 
 /// Tag management methods
-impl Client {
+impl<STORE: Store + 'static, AUTH: TransactionAuthenticator + 'static> Client<STORE, AUTH> {
     /// Returns the list of note tags tracked by the client along with their source.
     ///
     /// When syncing the state with the node, these tags will be added to the sync request and

--- a/crates/rust-client/src/test_utils/common.rs
+++ b/crates/rust-client/src/test_utils/common.rs
@@ -44,7 +44,7 @@ use crate::{
     },
 };
 
-pub type TestClient = Client;
+pub type TestClient = Client<SqliteStore, TestClientKeyStore>;
 pub type TestClientKeyStore = FilesystemKeyStore<StdRng>;
 
 // CONSTANTS
@@ -143,7 +143,7 @@ pub fn create_test_store_path() -> std::path::PathBuf {
 
 /// Inserts a new wallet account into the client and into the keystore.
 pub async fn insert_new_wallet(
-    client: &mut Client,
+    client: &mut TestClient,
     storage_mode: AccountStorageMode,
     keystore: &TestClientKeyStore,
 ) -> Result<(Account, Word, SecretKey), ClientError> {
@@ -155,7 +155,7 @@ pub async fn insert_new_wallet(
 
 /// Inserts a new wallet account built with the provided seed into the client and into the keystore.
 pub async fn insert_new_wallet_with_seed(
-    client: &mut Client,
+    client: &mut TestClient,
     storage_mode: AccountStorageMode,
     keystore: &TestClientKeyStore,
     init_seed: [u8; 32],
@@ -180,7 +180,7 @@ pub async fn insert_new_wallet_with_seed(
 
 /// Inserts a new fungible faucet account into the client and into the keystore.
 pub async fn insert_new_fungible_faucet(
-    client: &mut Client,
+    client: &mut TestClient,
     storage_mode: AccountStorageMode,
     keystore: &TestClientKeyStore,
 ) -> Result<(Account, Word, SecretKey), ClientError> {

--- a/crates/rust-client/src/test_utils/mock.rs
+++ b/crates/rust-client/src/test_utils/mock.rs
@@ -17,7 +17,6 @@ use miden_testing::{MockChain, MockChainNote};
 use miden_tx::utils::sync::RwLock;
 
 use crate::{
-    Client,
     rpc::{
         NodeRpcClient, RpcError,
         domain::{
@@ -32,8 +31,6 @@ use crate::{
     },
     transaction::ForeignAccount,
 };
-
-pub type MockClient = Client;
 
 /// Mock RPC API
 ///

--- a/crates/rust-client/src/tests.rs
+++ b/crates/rust-client/src/tests.rs
@@ -43,24 +43,24 @@ use rand::{Rng, RngCore, rngs::StdRng};
 use uuid::Uuid;
 
 use crate::{
-    Client, ClientError, DebugMode,
+    ClientError, DebugMode,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
     note::NoteRelevance,
     rpc::NodeRpcClient,
     store::{
-        InputNoteRecord, InputNoteState, NoteFilter, TransactionFilter,
+        InputNoteRecord, InputNoteState, NoteFilter, Store, TransactionFilter,
         input_note_states::ConsumedAuthenticatedLocalNoteState, sqlite_store::SqliteStore,
     },
     sync::NoteTagSource,
     testing::{
         common::{
-            ACCOUNT_ID_REGULAR, MINT_AMOUNT, RECALL_HEIGHT_DELTA, TRANSFER_AMOUNT,
+            ACCOUNT_ID_REGULAR, MINT_AMOUNT, RECALL_HEIGHT_DELTA, TRANSFER_AMOUNT, TestClient,
             assert_account_has_single_asset, assert_note_cannot_be_consumed_twice, consume_notes,
             execute_failing_tx, execute_tx, execute_tx_and_sync, mint_and_consume, mint_note,
             setup_two_wallets_and_faucet, setup_wallet_and_faucet, wait_for_tx,
         },
-        mock::{MockClient, MockRpcApi},
+        mock::MockRpcApi,
     },
     transaction::{
         DiscardCause, PaymentNoteDescription, SwapTransactionData, TransactionRequestBuilder,
@@ -102,7 +102,7 @@ pub async fn create_test_client_builder() -> (ClientBuilder, MockRpcApi, Filesys
     (builder, rpc_api, keystore)
 }
 
-pub async fn create_test_client() -> (MockClient, MockRpcApi, FilesystemKeyStore<StdRng>) {
+pub async fn create_test_client() -> (TestClient, MockRpcApi, FilesystemKeyStore<StdRng>) {
     let (builder, rpc_api, keystore) = create_test_client_builder().await;
     let mut client = builder.build().await.unwrap();
     client.ensure_genesis_in_place().await.unwrap();
@@ -117,7 +117,7 @@ pub fn create_test_store_path() -> std::path::PathBuf {
 }
 
 async fn insert_new_wallet(
-    client: &mut Client,
+    client: &mut TestClient,
     storage_mode: AccountStorageMode,
     keystore: &FilesystemKeyStore<StdRng>,
 ) -> Result<(Account, Word), ClientError> {
@@ -143,7 +143,7 @@ async fn insert_new_wallet(
 }
 
 async fn insert_new_fungible_faucet(
-    client: &mut Client,
+    client: &mut TestClient,
     storage_mode: AccountStorageMode,
     keystore: &FilesystemKeyStore<StdRng>,
 ) -> Result<(Account, Word), ClientError> {

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -463,7 +463,7 @@ impl TransactionStoreUpdate {
 }
 
 /// Transaction management methods
-impl<STORE: Store, AUTH: TransactionAuthenticator> Client<STORE, AUTH> {
+impl<STORE: Store + 'static, AUTH: TransactionAuthenticator + 'static> Client<STORE, AUTH> {
     // TRANSACTION DATA RETRIEVAL
     // --------------------------------------------------------------------------------------------
 
@@ -1141,7 +1141,7 @@ impl<STORE: Store, AUTH: TransactionAuthenticator> Client<STORE, AUTH> {
 // ================================================================================================
 
 #[cfg(feature = "testing")]
-impl<STORE: Store, AUTH: TransactionAuthenticator> Client<STORE, AUTH> {
+impl<STORE: Store + 'static, AUTH: TransactionAuthenticator + 'static> Client<STORE, AUTH> {
     pub async fn testing_prove_transaction(
         &mut self,
         tx_result: &TransactionResult,

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -463,7 +463,7 @@ impl TransactionStoreUpdate {
 }
 
 /// Transaction management methods
-impl<STORE: Store + 'static, AUTH: TransactionAuthenticator + 'static> Client<STORE, AUTH> {
+impl<STORE: Store, AUTH: TransactionAuthenticator> Client<STORE, AUTH> {
     // TRANSACTION DATA RETRIEVAL
     // --------------------------------------------------------------------------------------------
 
@@ -1141,7 +1141,7 @@ impl<STORE: Store + 'static, AUTH: TransactionAuthenticator + 'static> Client<ST
 // ================================================================================================
 
 #[cfg(feature = "testing")]
-impl<STORE: Store + 'static, AUTH: TransactionAuthenticator + 'static> Client<STORE, AUTH> {
+impl<STORE: Store, AUTH: TransactionAuthenticator> Client<STORE, AUTH> {
     pub async fn testing_prove_transaction(
         &mut self,
         tx_result: &TransactionResult,

--- a/tests/src/fpi_tests.rs
+++ b/tests/src/fpi_tests.rs
@@ -3,6 +3,7 @@ use miden_client::{
     account::{Account, StorageSlot},
     auth::AuthSecretKey,
     rpc::domain::account::{AccountStorageRequirements, StorageMapKey},
+    store::Store,
     testing::common::*,
     transaction::{ForeignAccount, TransactionKernel, TransactionRequestBuilder},
 };


### PR DESCRIPTION
This draft PR is a PoC to update the client after the added generics in https://github.com/0xMiden/miden-base/pull/1580#discussion_r2214892321.

The `+ 'static` lifetime is mostly needed for the callback `OnNoteReceived`. We should look on alternatives that don't require this lifetime restriction on the generic.