### PR TITLE
chore: add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union


### PR DESCRIPTION
Copying changes from https://github.com/0xMiden/miden-node/pull/1101 to the client. This configuration should reduce the number of times that the `CHANGELOG` file is the only conflict.

As @SantiagoPittella brought up, we should be careful when merging changes between merges as these are the times when the conflicts sometimes require a closer look.