### PR TITLE
feat: add `hex_to_bytes` utils reexport

### DIFF
--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -184,8 +184,8 @@ pub use miden_tx::ExecutionOptions;
 /// client library.
 pub mod utils {
     pub use miden_tx::utils::{
-        ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
-        bytes_to_hex_string,
+        ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable, ToHex,
+        bytes_to_hex_string, hex_to_bytes,
         sync::{LazyLock, RwLock, RwLockReadGuard, RwLockWriteGuard},
     };
 }


### PR DESCRIPTION
This PR reexports `hex_to_bytes` and `ToHex` from `miden_tx::utils`. This is needed in https://github.com/0xMiden/miden-faucet/pull/11