### PR TITLE
feat: Add RPC version mismatch error handling

### DIFF
--- a/crates/rust-client/src/rpc/errors.rs
+++ b/crates/rust-client/src/rpc/errors.rs
@@ -29,6 +29,13 @@ pub enum RpcError {
     NoteNotFound(NoteId),
     #[error("rpc request failed for {0}: {1}")]
     RequestError(String, String),
+    #[error(
+        "rpc version mismatch: client version '{client_version}' is incompatible with server. Please update your client or use a compatible server version"
+    )]
+    RpcVersionMismatch {
+        client_version: String,
+        server_version: Option<String>,
+    },
 }
 
 impl From<DeserializationError> for RpcError {

--- a/crates/rust-client/src/rpc/mod.rs
+++ b/crates/rust-client/src/rpc/mod.rs
@@ -118,17 +118,17 @@ pub trait NodeRpcClient: Send + Sync {
     /// the `/GetBlockByNumber` RPC endpoint.
     async fn get_block_by_number(&self, block_num: BlockNumber) -> Result<ProvenBlock, RpcError>;
 
-    /// Fetches note-related data for a list of [NoteId] using the `/GetNotesById` rpc endpoint.
+    /// Fetches note-related data for a list of [`NoteId`] using the `/GetNotesById` rpc endpoint.
     ///
-    /// For any NoteType::Private note, the return data is only the
-    /// [miden_objects::note::NoteMetadata], whereas for NoteType::Onchain notes, the return
+    /// For any `NoteType::Private` note, the return data is only the
+    /// [`miden_objects::note::NoteMetadata`], whereas for `NoteType::Onchain` notes, the return
     /// data includes all details.
     async fn get_notes_by_id(&self, note_ids: &[NoteId]) -> Result<Vec<FetchedNote>, RpcError>;
 
     /// Fetches info from the node necessary to perform a state sync using the
     /// `/SyncState` RPC endpoint.
     ///
-    /// - `block_num` is the last block number known by the client. The returned [StateSyncInfo]
+    /// - `block_num` is the last block number known by the client. The returned [`StateSyncInfo`]
     ///   should contain data starting from the next block, until the first block which contains a
     ///   note of matching the requested tag, or the chain tip if there are no notes.
     /// - `account_ids` is a list of account IDs and determines the accounts the client is
@@ -201,7 +201,7 @@ pub trait NodeRpcClient: Send + Sync {
     /// then `None` is returned.
     /// The `block_num` parameter is the block number to start the search from.
     ///
-    /// The default implementation of this method uses [NodeRpcClient::check_nullifiers_by_prefix].
+    /// The default implementation of this method uses [`NodeRpcClient::check_nullifiers_by_prefix`].
     async fn get_nullifier_commit_height(
         &self,
         nullifier: &Nullifier,
@@ -215,7 +215,7 @@ pub trait NodeRpcClient: Send + Sync {
             .map(|update| update.block_num))
     }
 
-    /// Fetches public note-related data for a list of [NoteId] and builds [InputNoteRecord]s with
+    /// Fetches public note-related data for a list of [`NoteId`] and builds [`InputNoteRecord`]s with
     /// it. If a note is not found or it's private, it is ignored and will not be included in the
     /// returned list.
     ///
@@ -308,6 +308,7 @@ pub enum NodeRpcClientEndpoint {
     GetAccountProofs,
     GetBlockByNumber,
     GetBlockHeaderByNumber,
+    GetNotesById,
     SyncState,
     SubmitProvenTx,
     SyncNotes,
@@ -327,6 +328,7 @@ impl fmt::Display for NodeRpcClientEndpoint {
             NodeRpcClientEndpoint::GetBlockHeaderByNumber => {
                 write!(f, "get_block_header_by_number")
             },
+            NodeRpcClientEndpoint::GetNotesById => write!(f, "get_notes_by_id"),
             NodeRpcClientEndpoint::SyncState => write!(f, "sync_state"),
             NodeRpcClientEndpoint::SubmitProvenTx => write!(f, "submit_proven_transaction"),
             NodeRpcClientEndpoint::SyncNotes => write!(f, "sync_notes"),

--- a/crates/web-client/src/lib.rs
+++ b/crates/web-client/src/lib.rs
@@ -4,9 +4,11 @@ use std::fmt::Write;
 
 use miden_client::{
     Client, ExecutionOptions,
+    builder::ClientBuilder,
     keystore::WebKeyStore,
     rpc::{Endpoint, TonicRpcClient},
     store::web_store::WebStore,
+    sync::SyncSummary,
 };
 use miden_objects::{
     Felt, MAX_TX_EXECUTION_CYCLES, MIN_TX_EXECUTION_CYCLES, crypto::rand::RpoRandomCoin,
@@ -85,25 +87,51 @@ impl WebClient {
 
         let web_rpc_client = Arc::new(TonicRpcClient::new(&endpoint, 0));
 
-        self.inner = Some(Client::new(
-            web_rpc_client,
-            Box::new(rng),
-            web_store.clone(),
-            Arc::new(keystore.clone()),
-            ExecutionOptions::new(
-                Some(MAX_TX_EXECUTION_CYCLES),
-                MIN_TX_EXECUTION_CYCLES,
-                false,
-                false,
-            )
-            .expect("Default executor's options should always be valid"),
-            None,
-            None,
-        ));
+        let mut client_builder = ClientBuilder::new()
+            .rpc(web_rpc_client)
+            .store(web_store.clone())
+            .authenticator(Arc::new(keystore.clone()));
+
+        // Try to build the client, handling version mismatch errors specially
+        let client = match client_builder.build().await {
+            Ok(client) => client,
+            Err(client_error) => {
+                use miden_client::{ClientError, rpc::RpcError};
+
+                match &client_error {
+                    ClientError::RpcError(RpcError::RpcVersionMismatch {
+                        client_version,
+                        server_version,
+                    }) => {
+                        let server_info = match server_version {
+                            Some(version) => format!("server version '{}'", version),
+                            None => "an incompatible server version".to_string(),
+                        };
+
+                        let error_message = format!(
+                            "RPC version mismatch: Your client (version '{}') is incompatible with {}. \
+                            Please update your client or connect to a compatible server.",
+                            client_version, server_info
+                        );
+
+                        return Err(JsValue::from_str(&error_message));
+                    },
+                    _ => {
+                        return Err(JsValue::from_str(&format!(
+                            "Failed to initialize client: {}",
+                            client_error
+                        )));
+                    },
+                }
+            },
+        };
+
+        self.inner = Some(client);
         self.store = Some(web_store);
         self.keystore = Some(keystore);
 
-        Ok(JsValue::from_str("Client created successfully"))
+        let summary = SyncSummary::default();
+        Ok(summary.into())
     }
 }
 


### PR DESCRIPTION
- Add `RpcVersionMismatch` error variant for better error identification
- Implement smart error detection in `convert_tonic_error` function
- Apply version mismatch detection to all RPC method calls
- Add user-friendly CLI error messages with actionable guidance
- Support version mismatch errors in web client (WASM)
- Add comprehensive unit tests for error handling logic
- Add missing GetNotesById endpoint variant

closes: #935 