### PR TITLE
fix: Avoid passing unneeded nodes to `PartialMmr::from_parts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.10.1 (2025-07-24)
+
+### Fixes
+
+* Avoid passing unneeded nodes to `PartialMmr::from_parts` (#1081).
+
 ## 0.10.0 (2025-07-12)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1978,7 +1978,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -2054,7 +2054,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-web"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "miden-client",
  "miden-lib",

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -2,7 +2,7 @@
 authors.workspace      = true
 categories             = ["no-std"]
 description            = "Client library that facilitates interaction with the Miden rollup"
-documentation          = "https://docs.rs/miden-client/0.10.0"
+documentation          = "https://docs.rs/miden-client/0.10.1"
 edition.workspace      = true
 keywords               = ["client", "miden"]
 license.workspace      = true
@@ -10,7 +10,7 @@ name                   = "miden-client"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version                = "0.10.0"
+version                = "0.10.1"
 
 [package.metadata.cargo-machete]
 ignored = ["getrandom"]

--- a/crates/rust-client/src/sync/block_header.rs
+++ b/crates/rust-client/src/sync/block_header.rs
@@ -47,9 +47,6 @@ impl Client {
     /// Builds the current view of the chain's [`PartialMmr`]. Because we want to add all new
     /// authentication nodes that could come from applying the MMR updates, we need to track all
     /// known leaves thus far.
-    ///
-    /// As part of the syncing process, we add the current block number so we don't need to
-    /// track it here.
     pub(crate) async fn build_current_partial_mmr(&self) -> Result<PartialMmr, ClientError> {
         let current_block_num = self.store.get_sync_height().await?;
 
@@ -58,21 +55,16 @@ impl Client {
         let current_peaks =
             self.store.get_partial_blockchain_peaks_by_block_num(current_block_num).await?;
 
-        let track_latest = if current_block_num.as_u32() != 0 {
-            match self
-                .store
-                .get_block_header_by_num(BlockNumber::from(current_block_num.as_u32() - 1))
-                .await?
-            {
-                Some((_, previous_block_had_notes)) => previous_block_had_notes,
-                None => false,
-            }
-        } else {
-            false
-        };
-
-        let mut current_partial_mmr =
-            PartialMmr::from_parts(current_peaks, tracked_nodes, track_latest);
+        // FIXME: Because each block stores the peaks for the MMR for the leaf of pos `block_num-1`,
+        // we can get an MMR based on those peaks, add the current block number and align it with 
+        // the set of all nodes in the store. 
+        // Otherwise, by doing `PartialMmr::from_parts` we would effectively have more nodes than
+        // we need for the passed peaks. The alternative here is to truncate the set of all nodes
+        // before calling `from_parts`
+        //
+        // This is a bit hacky but it works. One alternative would be to _just_ get nodes required
+        // for tracked blocks in the MMR. This would however block us from the convenience of
+        // just getting all nodes from the store.
 
         let (current_block, has_client_notes) = self
             .store
@@ -80,7 +72,11 @@ impl Client {
             .await?
             .expect("Current block should be in the store");
 
+        let mut current_partial_mmr = PartialMmr::from_peaks(current_peaks);
         current_partial_mmr.add(current_block.commitment(), has_client_notes);
+
+        let current_partial_mmr =
+            PartialMmr::from_parts(current_partial_mmr.peaks(), tracked_nodes, has_client_notes);
 
         Ok(current_partial_mmr)
     }

--- a/crates/rust-client/src/sync/block_header.rs
+++ b/crates/rust-client/src/sync/block_header.rs
@@ -56,8 +56,8 @@ impl Client {
             self.store.get_partial_blockchain_peaks_by_block_num(current_block_num).await?;
 
         // FIXME: Because each block stores the peaks for the MMR for the leaf of pos `block_num-1`,
-        // we can get an MMR based on those peaks, add the current block number and align it with 
-        // the set of all nodes in the store. 
+        // we can get an MMR based on those peaks, add the current block number and align it with
+        // the set of all nodes in the store.
         // Otherwise, by doing `PartialMmr::from_parts` we would effectively have more nodes than
         // we need for the passed peaks. The alternative here is to truncate the set of all nodes
         // before calling `from_parts`

--- a/crates/web-client/Cargo.toml
+++ b/crates/web-client/Cargo.toml
@@ -2,7 +2,7 @@
 authors.workspace      = true
 categories             = ["no-std"]
 description            = "Web Client library that facilitates interaction with the Miden rollup"
-documentation          = "https://docs.rs/miden-client-web/0.10.0"
+documentation          = "https://docs.rs/miden-client-web/0.10.1"
 edition.workspace      = true
 keywords               = ["client", "miden", "wasm", "web"]
 license.workspace      = true
@@ -10,7 +10,7 @@ name                   = "miden-client-web"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version                = "0.10.0"
+version                = "0.10.1"
 
 [package.metadata.cargo-machete]
 ignored = ["wasm-bindgen-futures"]


### PR DESCRIPTION
Closes #1073

The problem was that because of [the way that MMR changes are applied during the sync state](https://github.com/0xMiden/miden-client/blob/next/crates/rust-client/src/sync/state_sync.rs#L474), and the fact that block $N$ stores the peaks for block $N-1$, we were essentially passing more data than needed to the `PartialMmr::from_parts()` (which is unsafe and does not check inputs). Then, on later additions, `PartialMmr::add` had some sanity `debug_assertions` for making sure that nodes that are supposed to be new were not there before. I could not find a way to easily sanitize these inputs in a way that did not trigger the problem (and that did not forfeit the ability of just getting all MMR nodes from the store which is more convenient and performant), but found a workaround which also makes the code a bit simpler, but also is not very clean.

There were more tests than the referenced one triggering the same problem. Left a comment on the code explaining the solution.

Made a pass of all tests (unit, integration, web-client, etc.) with the `debug_assertion` that was causing the issue and everything worked correctly.