### PR TITLE
refactor: change error in callback

### DIFF
--- a/crates/rust-client/src/errors.rs
+++ b/crates/rust-client/src/errors.rs
@@ -1,4 +1,5 @@
 use alloc::{
+    boxed::Box,
     string::{String, ToString},
     vec::Vec,
 };
@@ -70,6 +71,8 @@ pub enum ClientError {
     NoteRecordConversionError(#[from] NoteRecordError),
     #[error("no consumable note for account {0}")]
     NoConsumableNoteForAccount(AccountId),
+    #[error("on note received failure: {0}")]
+    OnNoteReceivedFailure(String, #[source] Option<Box<dyn core::error::Error + Send + Sync>>),
     #[error("rpc api error")]
     RpcError(#[from] RpcError),
     #[error("recency condition error: {0}")]


### PR DESCRIPTION
Based on [this comment](https://github.com/0xMiden/miden-client/pull/1080#discussion_r2240498932).

This PR changes the error in the `OnNoteReceived` trait callback to be generic.