### PR TITLE
feat(web-client): expose TransactionFilter.Ids in web-client

### DIFF
--- a/crates/web-client/src/models/transaction_filter.rs
+++ b/crates/web-client/src/models/transaction_filter.rs
@@ -1,5 +1,10 @@
-use miden_client::store::TransactionFilter as NativeTransactionFilter;
+use miden_client::{
+    store::TransactionFilter as NativeTransactionFilter,
+    transaction::TransactionId as NativeTransactionId,
+};
 use wasm_bindgen::prelude::*;
+
+use super::transaction_id::TransactionId;
 
 #[derive(Clone)]
 #[wasm_bindgen]
@@ -9,6 +14,12 @@ pub struct TransactionFilter(NativeTransactionFilter);
 impl TransactionFilter {
     pub fn all() -> TransactionFilter {
         TransactionFilter(NativeTransactionFilter::All)
+    }
+
+    pub fn ids(ids: Vec<TransactionId>) -> TransactionFilter {
+        let native_transaction_ids: Vec<NativeTransactionId> =
+            ids.into_iter().map(Into::into).collect();
+        TransactionFilter(NativeTransactionFilter::Ids(native_transaction_ids))
     }
 
     pub fn uncommitted() -> TransactionFilter {

--- a/crates/web-client/src/models/transaction_id.rs
+++ b/crates/web-client/src/models/transaction_id.rs
@@ -43,3 +43,9 @@ impl From<&NativeTransactionId> for TransactionId {
         TransactionId(*native_id)
     }
 }
+
+impl From<TransactionId> for NativeTransactionId {
+    fn from(transaction_id: TransactionId) -> Self {
+        transaction_id.0
+    }
+}


### PR DESCRIPTION
This PR exposes the `TransactionFilter.Ids` filter type from `rust-client` to `web-client`, besides existing `All` and `Uncommitted` variants.

This is needed to be able to fetch transactions having a particular set of ids in a dApp.
