### PR TITLE
feat(web-client): expose more note getters in the web-client

### DIFF
--- a/crates/web-client/src/models/note_inputs.rs
+++ b/crates/web-client/src/models/note_inputs.rs
@@ -1,7 +1,7 @@
 use miden_objects::note::NoteInputs as NativeNoteInputs;
 use wasm_bindgen::prelude::*;
 
-use super::felt::FeltArray;
+use super::felt::{Felt, FeltArray};
 
 #[derive(Clone)]
 #[wasm_bindgen]
@@ -15,10 +15,26 @@ impl NoteInputs {
         let native_note_inputs = NativeNoteInputs::new(native_felts).unwrap();
         NoteInputs(native_note_inputs)
     }
+
+    pub fn values(&self) -> Vec<Felt> {
+        self.0.values().iter().map(Into::into).collect()
+    }
 }
 
 // CONVERSIONS
 // ================================================================================================
+
+impl From<NativeNoteInputs> for NoteInputs {
+    fn from(native_note_inputs: NativeNoteInputs) -> Self {
+        NoteInputs(native_note_inputs)
+    }
+}
+
+impl From<&NativeNoteInputs> for NoteInputs {
+    fn from(native_note_inputs: &NativeNoteInputs) -> Self {
+        NoteInputs(native_note_inputs.clone())
+    }
+}
 
 impl From<NoteInputs> for NativeNoteInputs {
     fn from(note_inputs: NoteInputs) -> Self {

--- a/crates/web-client/src/models/note_recipient.rs
+++ b/crates/web-client/src/models/note_recipient.rs
@@ -29,6 +29,19 @@ impl NoteRecipient {
     pub fn digest(&self) -> Word {
         self.0.digest().into()
     }
+
+    #[wasm_bindgen(js_name = "serialNum")]
+    pub fn serial_num(&self) -> Word {
+        self.0.serial_num().into()
+    }
+
+    pub fn script(&self) -> NoteScript {
+        self.0.script().into()
+    }
+
+    pub fn inputs(&self) -> NoteInputs {
+        self.0.inputs().into()
+    }
 }
 
 // CONVERSIONS

--- a/crates/web-client/src/models/note_script.rs
+++ b/crates/web-client/src/models/note_script.rs
@@ -2,6 +2,8 @@ use miden_client::note::{NoteScript as NativeNoteScript, WellKnownNote};
 use miden_objects::PrettyPrint;
 use wasm_bindgen::prelude::*;
 
+use super::word::Word;
+
 #[derive(Clone)]
 #[wasm_bindgen]
 pub struct NoteScript(NativeNoteScript);
@@ -25,6 +27,10 @@ impl NoteScript {
 
     pub fn swap() -> Self {
         WellKnownNote::SWAP.script().into()
+    }
+
+    pub fn root(&self) -> Word {
+        self.0.root().into()
     }
 }
 // CONVERSIONS


### PR DESCRIPTION
This PR adds more note getters available in `rust-client` that were not yet available in the `web-client`.

This is needed to show eg. note inputs (raw and decoded in case of well-known notes), note scripts roots, etc in the context of a dApp.