### PR TITLE
feat(web-client, rust-client): add get_note_inclusion_proof method for web-client and from_hex for note_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Added bindings for retrieving storage `AccountDelta` in the web client ([#1098](https://github.com/0xMiden/miden-client/pull/1098)).
 * Added `multicall` support for the CLI ([#1141](https://github.com/0xMiden/miden-client/pull/1141))
 * Added `TransactionSummary`, `AccountDelta`, and `BasicFungibleFaucet` types to Web Client ([#1115](https://github.com/0xMiden/miden-client/pull/1115))
+* Added ability to fetch `NoteInclusionProof` in Web Client ([#1110](https://github.com/0xMiden/miden-client/pull/1110)).
 
 ## 0.10.1 (2025-07-26)
 

--- a/crates/rust-client/src/note/mod.rs
+++ b/crates/rust-client/src/note/mod.rs
@@ -63,6 +63,8 @@ use alloc::vec::Vec;
 use miden_objects::account::AccountId;
 use miden_tx::auth::TransactionAuthenticator;
 
+use crate::rpc::RpcError;
+use crate::rpc::domain::note::FetchedNote;
 use crate::store::{InputNoteRecord, NoteFilter, OutputNoteRecord};
 use crate::{Client, ClientError, IdPrefixFetchError};
 
@@ -171,6 +173,20 @@ where
             .check_relevance(&note.clone().try_into()?)
             .await
             .map_err(Into::into)
+    }
+
+    /// Returns `FetchedNote` for given [`NoteId`]. Returns `None` if the note is not found.
+    pub async fn get_fetched_note(
+        &self,
+        note_id: NoteId,
+    ) -> Result<Option<FetchedNote>, ClientError> {
+        let result = self.rpc_api.get_note_by_id(note_id).await;
+
+        match result {
+            Ok(fetched_note) => Ok(Some(fetched_note)),
+            Err(RpcError::NoteNotFound(_)) => Ok(None),
+            Err(err) => Err(ClientError::RpcError(err)),
+        }
     }
 
     /// Retrieves the input note given a [`NoteId`]. Returns `None` if the note is not found.

--- a/crates/web-client/package.json
+++ b/crates/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demox-labs/miden-sdk",
-  "version": "0.11.0-next.20",
+  "version": "0.11.0-next.21",
   "description": "Miden Wasm SDK",
   "collaborators": [
     "Miden",

--- a/crates/web-client/src/models/note_id.rs
+++ b/crates/web-client/src/models/note_id.rs
@@ -2,6 +2,7 @@ use miden_objects::note::NoteId as NativeNoteId;
 use wasm_bindgen::prelude::*;
 
 use super::word::Word;
+use crate::js_error_with_context;
 
 #[derive(Clone)]
 #[wasm_bindgen]
@@ -12,6 +13,13 @@ impl NoteId {
     #[wasm_bindgen(constructor)]
     pub fn new(recipient_digest: &Word, asset_commitment_digest: &Word) -> NoteId {
         NoteId(NativeNoteId::new(recipient_digest.into(), asset_commitment_digest.into()))
+    }
+
+    #[wasm_bindgen(js_name = "fromHex")]
+    pub fn from_hex(hex: &str) -> Result<NoteId, JsValue> {
+        NativeNoteId::try_from_hex(hex)
+            .map_err(|err| js_error_with_context(err, "cannot convert hex to note id"))
+            .map(NoteId::from)
     }
 
     #[wasm_bindgen(js_name = "toString")]

--- a/docs/src/web-client/api/classes/NoteId.md
+++ b/docs/src/web-client/api/classes/NoteId.md
@@ -45,3 +45,19 @@
 #### Returns
 
 `string`
+
+***
+
+### fromHex()
+
+> `static` **fromHex**(`hex`): `NoteId`
+
+#### Parameters
+
+##### hex
+
+`string`
+
+#### Returns
+
+`NoteId`

--- a/docs/src/web-client/api/classes/WebClient.md
+++ b/docs/src/web-client/api/classes/WebClient.md
@@ -262,6 +262,22 @@ Meant to be used in conjunction with the `force_import_store` method
 
 ***
 
+### getNoteInclusionProof()
+
+> **getNoteInclusionProof**(`note_id`): `Promise`\<[`NoteInclusionProof`](NoteInclusionProof.md)\>
+
+#### Parameters
+
+##### note\_id
+
+[`NoteId`](NoteId.md)
+
+#### Returns
+
+`Promise`\<[`NoteInclusionProof`](NoteInclusionProof.md)\>
+
+***
+
 ### getOutputNote()
 
 > **getOutputNote**(`note_id`): `Promise`\<`any`\>


### PR DESCRIPTION
This PR adds a rust-client method and web-client wrapper for it, both called `get_note_inclusion_proof`, which searches for a note in the blockchain (online), and includes approval to use it with Arcane's frontend (https://github.com/arcane-finance-defi/miden-mixer-frontend).
I also added `from_hex` method for `NoteId` model to the PR.

PR check list:
- [x]  Check tools `make check-tools` and `make install-tools`
- [x]  Lint code `make lint`
- [x]  Re-generate docs for web-client `make