### PR TITLE
feat(web-client): add read_note_script_from_bytes method

### DIFF
--- a/crates/web-client/src/notes.rs
+++ b/crates/web-client/src/notes.rs
@@ -1,5 +1,9 @@
 use miden_client::{Word, store::OutputNoteRecord};
-use miden_objects::note::{NoteId, NoteScript as NativeNoteScript};
+use miden_objects::{
+    note::{NoteId, NoteScript as NativeNoteScript},
+    utils::Deserializable,
+    vm::Program,
+};
 use wasm_bindgen::prelude::*;
 
 use super::models::note_script::NoteScript;
@@ -113,5 +117,13 @@ impl WebClient {
         } else {
             Err(JsValue::from_str("Client not initialized"))
         }
+    }
+
+    #[wasm_bindgen(js_name = "readNoteScriptFromBytes")]
+    pub fn read_note_script_from_bytes(script_bytes: &[u8]) -> Result<NoteScript, JsValue> {
+        let program = Program::read_from_bytes(script_bytes)
+            .map_err(|err| js_error_with_context(err, "failed to deserialize masb bytes"))?;
+
+        Ok(NativeNoteScript::new(program).into())
     }
 }

--- a/docs/src/web-client/api/classes/WebClient.md
+++ b/docs/src/web-client/api/classes/WebClient.md
@@ -687,3 +687,19 @@ Meant to be used in conjunction with the force_import_store method
 #### Returns
 
 [`NoteTag`](NoteTag.md)
+
+***
+
+### readNoteScriptFromBytes()
+
+> `static` **readNoteScriptFromBytes**(`script_bytes`): [`NoteScript`](NoteScript.md)
+
+#### Parameters
+
+##### script\_bytes
+
+`Uint8Array`
+
+#### Returns
+
+[`NoteScript`](NoteScript.md)


### PR DESCRIPTION
This PR adds a web client method `read_note_script_from_bytes`/`readNoteScriptFromBytes` for deserialization of arbitrary note script from MASB files to use it with our frontend, [example](https://github.com/arcane-finance-defi/miden-mixer-frontend/blob/274d7d0946871d5e35163c20c03beeedd41748fe/ui/src/shared/miden/service.ts#L56).

fyi @slon2015

Pre-PR check list:
- [x] Check tools `make check-tools` and `make install-tools`
- [x] Lint code
- [x] Re-generate docs for web-client