### PR TITLE
Add ability to mint from public faucets on webclient

### DIFF
--- a/crates/web-client/test/mocha.global.setup.mjs
+++ b/crates/web-client/test/mocha.global.setup.mjs
@@ -26,7 +26,7 @@ const REMOTE_TX_PROVER_PORT = 50051;
 
 before(async () => {
   console.log("Starting test server...");
-  serverProcess = spawn("http-server", ["./dist", "-p", TEST_SERVER_PORT], {
+  serverProcess = spawn("npx", ["http-server", "./dist", "-p", TEST_SERVER_PORT], {
     stdio: "inherit",
     shell: process.platform == "win32",
   });

--- a/crates/web-client/test/mocha.global.setup.mjs
+++ b/crates/web-client/test/mocha.global.setup.mjs
@@ -28,7 +28,34 @@ before(async () => {
   console.log("Starting test server...");
   serverProcess = spawn("npx", ["http-server", "./dist", "-p", TEST_SERVER_PORT], {
     stdio: "inherit",
-    shell: process.platform == "win32",
+    shell: true,
+  });
+
+  // Wait for server to start
+  console.log("Waiting for server to start...");
+  await new Promise((resolve, reject) => {
+    const checkServer = async () => {
+      try {
+        const response = await fetch(TEST_SERVER);
+        if (response.ok) {
+          console.log("Server is ready!");
+          resolve();
+        } else {
+          throw new Error(`Server responded with status: ${response.status}`);
+        }
+      } catch (error) {
+        // Server not ready yet, wait and try again
+        setTimeout(checkServer, 500);
+      }
+    };
+    
+    // Start checking after a brief delay
+    setTimeout(checkServer, 1000);
+    
+    // Timeout after 30 seconds
+    setTimeout(() => {
+      reject(new Error("Timeout waiting for server to start"));
+    }, 30000);
   });
 
   try {


### PR DESCRIPTION
This PR adds a test for the following scenario:

A user knows some public faucet id. The user imports the public faucet id then calls mint. The problem currently is that when trying to do this, the webclient gives the error:  `Error: Account auth not found in cache.`

This is likely due to the fact that webclient is not importing the faucet with the authentication component. 

Having this feature would be useful for frontend applications that allow users to test mint small amount of some asset id for testing purposes.

Currently this PR is in draft mode, and only adds the test which fails. 