### PR TITLE
Fix P2ID and P2IDE Note Creation in Web Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 0.10.3 (2025-08-07)
+
+### Fixes
+
+* Fixes createP2IDNote and createP2IDENote Convenience Functions in Web Client (#1138).
+
 ## 0.10.2 (2025-08-04)
 
 ### Fixes

--- a/crates/web-client/package.json
+++ b/crates/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demox-labs/miden-sdk",
-  "version": "0.10.0-next.11",
+  "version": "0.10.2",
   "description": "Miden Wasm SDK",
   "collaborators": [
     "Miden",

--- a/crates/web-client/src/models/note.rs
+++ b/crates/web-client/src/models/note.rs
@@ -1,9 +1,11 @@
-use miden_client::note::{
-    NoteMetadata as NativeNoteMetadata,
-    NoteTag as NativeNoteTag,
-};
+use miden_client::note::{NoteMetadata as NativeNoteMetadata, NoteTag as NativeNoteTag};
 use miden_lib::note::utils;
-use miden_objects::{block::BlockNumber as NativeBlockNumber, crypto::rand::{FeltRng, RpoRandomCoin}, Felt as NativeFelt, note::{Note as NativeNote, NoteExecutionHint as NativeNoteExecutionHint}};
+use miden_objects::{
+    Felt as NativeFelt,
+    block::BlockNumber as NativeBlockNumber,
+    crypto::rand::{FeltRng, RpoRandomCoin},
+    note::{Note as NativeNote, NoteExecutionHint as NativeNoteExecutionHint},
+};
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use wasm_bindgen::prelude::*;
 
@@ -87,10 +89,10 @@ impl Note {
 
         let serial_num = rng.draw_word();
         let recipient = utils::build_p2ide_recipient(
-            target.into(), 
-            reclaim_height.map(NativeBlockNumber::from), 
-            timelock_height.map(NativeBlockNumber::from), 
-            serial_num
+            target.into(),
+            reclaim_height.map(NativeBlockNumber::from),
+            timelock_height.map(NativeBlockNumber::from),
+            serial_num,
         )
         .unwrap();
 

--- a/crates/web-client/src/models/note.rs
+++ b/crates/web-client/src/models/note.rs
@@ -3,13 +3,13 @@ use miden_client::note::{
     NoteTag as NativeNoteTag,
 };
 use miden_lib::note::utils;
-use miden_objects::{block::BlockNumber as NativeBlockNumber, crypto::rand::{FeltRng, RpoRandomCoin}, note::{Note as NativeNote, NoteExecutionHint as NativeNoteExecutionHint}};
+use miden_objects::{block::BlockNumber as NativeBlockNumber, crypto::rand::{FeltRng, RpoRandomCoin}, Felt as NativeFelt, note::{Note as NativeNote, NoteExecutionHint as NativeNoteExecutionHint}};
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use wasm_bindgen::prelude::*;
 
 use super::{
     account_id::AccountId, felt::Felt, note_assets::NoteAssets, note_id::NoteId,
-    note_metadata::NoteMetadata, note_recipient::NoteRecipient, note_type::NoteType, word::Word,
+    note_metadata::NoteMetadata, note_recipient::NoteRecipient, note_type::NoteType,
 };
 
 #[wasm_bindgen]
@@ -53,7 +53,7 @@ impl Note {
     ) -> Self {
         let mut rng = StdRng::from_os_rng();
         let coin_seed: [u64; 4] = rng.random();
-        let rng = RpoRandomCoin::new(coin_seed.map(Felt::new));
+        let mut rng = RpoRandomCoin::new(coin_seed.map(NativeFelt::new));
 
         let serial_num = rng.draw_word();
         let recipient = utils::build_p2id_recipient(target.into(), serial_num).unwrap();
@@ -83,7 +83,7 @@ impl Note {
     ) -> Self {
         let mut rng = StdRng::from_os_rng();
         let coin_seed: [u64; 4] = rng.random();
-        let rng = RpoRandomCoin::new(coin_seed.map(Felt::new));
+        let mut rng = RpoRandomCoin::new(coin_seed.map(NativeFelt::new));
 
         let serial_num = rng.draw_word();
         let recipient = utils::build_p2ide_recipient(

--- a/crates/web-client/test/notes.test.ts
+++ b/crates/web-client/test/notes.test.ts
@@ -160,152 +160,193 @@ describe("get_consumable_notes", () => {
 });
 
 describe("createP2IDNote and createP2IDENote", () => {
-  it("should create a proper consumable p2id note from the createP2IDNote function", async ()=> {
+  it("should create a proper consumable p2id note from the createP2IDNote function", async () => {
     const { accountId: senderId, faucetId } = await setupWalletAndFaucet();
     const { accountId: targetId } = await setupWalletAndFaucet();
 
-    const { createdNoteId } = await mintTransaction(senderId, faucetId, false, true);
+    const { createdNoteId } = await mintTransaction(
+      senderId,
+      faucetId,
+      false,
+      true
+    );
 
     await consumeTransaction(senderId, faucetId, createdNoteId, false);
 
-    const result = await testingPage.evaluate(async(
-      _senderId: string,
-      _targetId: string,
-      _faucetId: string
-    ) => {
-      let client = window.client;
+    const result = await testingPage.evaluate(
+      async (_senderId: string, _targetId: string, _faucetId: string) => {
+        let client = window.client;
 
-      let senderAccountId = window.AccountId.fromHex(_senderId);
-      let targetAccountId = window.AccountId.fromHex(_targetId);
-      let faucetAccountId = window.AccountId.fromHex(_faucetId);
+        let senderAccountId = window.AccountId.fromHex(_senderId);
+        let targetAccountId = window.AccountId.fromHex(_targetId);
+        let faucetAccountId = window.AccountId.fromHex(_faucetId);
 
-      let fungibleAsset = new window.FungibleAsset(faucetAccountId, BigInt(10));
-      let noteAssets = new window.NoteAssets([fungibleAsset]);
-      let p2IdNote = window.Note.createP2IDNote(senderAccountId, targetAccountId, noteAssets, window.NoteType.Public, new window.Felt(0n));
+        let fungibleAsset = new window.FungibleAsset(
+          faucetAccountId,
+          BigInt(10)
+        );
+        let noteAssets = new window.NoteAssets([fungibleAsset]);
+        let p2IdNote = window.Note.createP2IDNote(
+          senderAccountId,
+          targetAccountId,
+          noteAssets,
+          window.NoteType.Public,
+          new window.Felt(0n)
+        );
 
-      let outputNote = window.OutputNote.full(p2IdNote);
+        let outputNote = window.OutputNote.full(p2IdNote);
 
-      let transactionRequest = new window.TransactionRequestBuilder()
-        .withOwnOutputNotes(new window.OutputNotesArray([outputNote]))
-        .build();
+        let transactionRequest = new window.TransactionRequestBuilder()
+          .withOwnOutputNotes(new window.OutputNotesArray([outputNote]))
+          .build();
 
-      let transactionResult = await client.newTransaction(
-        senderAccountId, 
-        transactionRequest
-      )
+        let transactionResult = await client.newTransaction(
+          senderAccountId,
+          transactionRequest
+        );
 
-      await client.submitTransaction(transactionResult);
+        await client.submitTransaction(transactionResult);
 
-      await window.helpers.waitForTransaction(
-        transactionResult.executedTransaction().id().toHex()
-      );
+        await window.helpers.waitForTransaction(
+          transactionResult.executedTransaction().id().toHex()
+        );
 
-      let createdNoteId = transactionResult.createdNotes()
+        let createdNoteId = transactionResult
+          .createdNotes()
           .notes()[0]
           .id()
-          .toString()
+          .toString();
 
-      let consumeTransactionRequest = client.newConsumeTransactionRequest([createdNoteId])
+        let consumeTransactionRequest = client.newConsumeTransactionRequest([
+          createdNoteId,
+        ]);
 
-      let consumeTransactionResult = await client.newTransaction(
-        targetAccountId,
-        consumeTransactionRequest
-      );
+        let consumeTransactionResult = await client.newTransaction(
+          targetAccountId,
+          consumeTransactionRequest
+        );
 
-      await client.submitTransaction(consumeTransactionResult);
+        await client.submitTransaction(consumeTransactionResult);
 
-      await window.helpers.waitForTransaction(
-        consumeTransactionResult.executedTransaction().id().toHex()
-      );
+        await window.helpers.waitForTransaction(
+          consumeTransactionResult.executedTransaction().id().toHex()
+        );
 
-      let senderAccountBalance = (await client.getAccount(senderAccountId))?.vault().getBalance(faucetAccountId).toString();
-      let targetAccountBalance = (await client.getAccount(targetAccountId))?.vault().getBalance(faucetAccountId).toString();
+        let senderAccountBalance = (await client.getAccount(senderAccountId))
+          ?.vault()
+          .getBalance(faucetAccountId)
+          .toString();
+        let targetAccountBalance = (await client.getAccount(targetAccountId))
+          ?.vault()
+          .getBalance(faucetAccountId)
+          .toString();
 
-      return {
-        senderAccountBalance: senderAccountBalance,
-        targetAccountBalance: targetAccountBalance
-      }
-    },
-    senderId,
-    targetId,
-    faucetId
+        return {
+          senderAccountBalance: senderAccountBalance,
+          targetAccountBalance: targetAccountBalance,
+        };
+      },
+      senderId,
+      targetId,
+      faucetId
     );
 
     expect(result.senderAccountBalance).to.equal("990");
     expect(result.targetAccountBalance).to.equal("10");
   });
 
-  it.only("should create a proper consumable p2ide note from the createP2IDENote function", async ()=> {
+  it.only("should create a proper consumable p2ide note from the createP2IDENote function", async () => {
     const { accountId: senderId, faucetId } = await setupWalletAndFaucet();
     const { accountId: targetId } = await setupWalletAndFaucet();
 
-    const { createdNoteId } = await mintTransaction(senderId, faucetId, false, true);
+    const { createdNoteId } = await mintTransaction(
+      senderId,
+      faucetId,
+      false,
+      true
+    );
 
     await consumeTransaction(senderId, faucetId, createdNoteId, false);
 
-    const result = await testingPage.evaluate(async(
-      _senderId: string,
-      _targetId: string,
-      _faucetId: string
-    ) => {
-      let client = window.client;
+    const result = await testingPage.evaluate(
+      async (_senderId: string, _targetId: string, _faucetId: string) => {
+        let client = window.client;
 
-      console.log(_senderId, _targetId, _faucetId);
-      let senderAccountId = window.AccountId.fromHex(_senderId);
-      let targetAccountId = window.AccountId.fromHex(_targetId);
-      let faucetAccountId = window.AccountId.fromHex(_faucetId);
+        console.log(_senderId, _targetId, _faucetId);
+        let senderAccountId = window.AccountId.fromHex(_senderId);
+        let targetAccountId = window.AccountId.fromHex(_targetId);
+        let faucetAccountId = window.AccountId.fromHex(_faucetId);
 
-      let fungibleAsset = new window.FungibleAsset(faucetAccountId, BigInt(10));
-      let noteAssets = new window.NoteAssets([fungibleAsset]);
-      let p2IdeNote = window.Note.createP2IDENote(
-        senderAccountId, targetAccountId, noteAssets, null, null, window.NoteType.Public, new window.Felt(0n));
+        let fungibleAsset = new window.FungibleAsset(
+          faucetAccountId,
+          BigInt(10)
+        );
+        let noteAssets = new window.NoteAssets([fungibleAsset]);
+        let p2IdeNote = window.Note.createP2IDENote(
+          senderAccountId,
+          targetAccountId,
+          noteAssets,
+          null,
+          null,
+          window.NoteType.Public,
+          new window.Felt(0n)
+        );
 
-      let outputNote = window.OutputNote.full(p2IdeNote);
+        let outputNote = window.OutputNote.full(p2IdeNote);
 
-      let transactionRequest = new window.TransactionRequestBuilder()
-        .withOwnOutputNotes(new window.OutputNotesArray([outputNote]))
-        .build();
+        let transactionRequest = new window.TransactionRequestBuilder()
+          .withOwnOutputNotes(new window.OutputNotesArray([outputNote]))
+          .build();
 
-      let transactionResult = await client.newTransaction(
-        senderAccountId, 
-        transactionRequest
-      )
+        let transactionResult = await client.newTransaction(
+          senderAccountId,
+          transactionRequest
+        );
 
-      await client.submitTransaction(transactionResult);
+        await client.submitTransaction(transactionResult);
 
-      await window.helpers.waitForTransaction(
-        transactionResult.executedTransaction().id().toHex()
-      );
+        await window.helpers.waitForTransaction(
+          transactionResult.executedTransaction().id().toHex()
+        );
 
-      let createdNoteId = transactionResult.createdNotes()
+        let createdNoteId = transactionResult
+          .createdNotes()
           .notes()[0]
           .id()
-          .toString()
+          .toString();
 
-      let consumeTransactionRequest = client.newConsumeTransactionRequest([createdNoteId])
+        let consumeTransactionRequest = client.newConsumeTransactionRequest([
+          createdNoteId,
+        ]);
 
-      let consumeTransactionResult = await client.newTransaction(
-        targetAccountId,
-        consumeTransactionRequest
-      );
+        let consumeTransactionResult = await client.newTransaction(
+          targetAccountId,
+          consumeTransactionRequest
+        );
 
-      await client.submitTransaction(consumeTransactionResult);
+        await client.submitTransaction(consumeTransactionResult);
 
-      await window.helpers.waitForTransaction(
-        consumeTransactionResult.executedTransaction().id().toHex()
-      );
+        await window.helpers.waitForTransaction(
+          consumeTransactionResult.executedTransaction().id().toHex()
+        );
 
-      let senderAccountBalance = (await client.getAccount(senderAccountId))?.vault().getBalance(faucetAccountId).toString();
-      let targetAccountBalance = (await client.getAccount(targetAccountId))?.vault().getBalance(faucetAccountId).toString();
+        let senderAccountBalance = (await client.getAccount(senderAccountId))
+          ?.vault()
+          .getBalance(faucetAccountId)
+          .toString();
+        let targetAccountBalance = (await client.getAccount(targetAccountId))
+          ?.vault()
+          .getBalance(faucetAccountId)
+          .toString();
 
-      return {
-        senderAccountBalance: senderAccountBalance,
-        targetAccountBalance: targetAccountBalance
-      }
-    },
-    senderId,
-    targetId,
-    faucetId
+        return {
+          senderAccountBalance: senderAccountBalance,
+          targetAccountBalance: targetAccountBalance,
+        };
+      },
+      senderId,
+      targetId,
+      faucetId
     );
 
     expect(result.senderAccountBalance).to.equal("990");

--- a/crates/web-client/test/notes.test.ts
+++ b/crates/web-client/test/notes.test.ts
@@ -159,12 +159,12 @@ describe("get_consumable_notes", () => {
   });
 });
 
-describe.only("standalone p2Id note", () => {
+describe("createP2IDNote and createP2IDENote", () => {
   it("should create a proper consumable p2id note from the createP2IDNote function", async ()=> {
     const { accountId: senderId, faucetId } = await setupWalletAndFaucet();
     const { accountId: targetId } = await setupWalletAndFaucet();
 
-    const { createdNoteId } = await mintTransaction(senderId, faucetId, false, false);
+    const { createdNoteId } = await mintTransaction(senderId, faucetId, false, true);
 
     await consumeTransaction(senderId, faucetId, createdNoteId, false);
 
@@ -173,6 +173,8 @@ describe.only("standalone p2Id note", () => {
       _targetId: string,
       _faucetId: string
     ) => {
+      let client = window.client;
+
       let senderAccountId = window.AccountId.fromHex(_senderId);
       let targetAccountId = window.AccountId.fromHex(_targetId);
       let faucetAccountId = window.AccountId.fromHex(_faucetId);
@@ -187,7 +189,6 @@ describe.only("standalone p2Id note", () => {
         .withOwnOutputNotes(new window.OutputNotesArray([outputNote]))
         .build();
 
-      let client = window.client;
       let transactionResult = await client.newTransaction(
         senderAccountId, 
         transactionRequest
@@ -199,8 +200,29 @@ describe.only("standalone p2Id note", () => {
         transactionResult.executedTransaction().id().toHex()
       );
 
+      let createdNoteId = transactionResult.createdNotes()
+          .notes()[0]
+          .id()
+          .toString()
+
+      let consumeTransactionRequest = client.newConsumeTransactionRequest([createdNoteId])
+
+      let consumeTransactionResult = await client.newTransaction(
+        targetAccountId,
+        consumeTransactionRequest
+      );
+
+      await client.submitTransaction(consumeTransactionResult);
+
+      await window.helpers.waitForTransaction(
+        consumeTransactionResult.executedTransaction().id().toHex()
+      );
+
+      let senderAccountBalance = (await client.getAccount(senderAccountId))?.vault().getBalance(faucetAccountId).toString();
       let targetAccountBalance = (await client.getAccount(targetAccountId))?.vault().getBalance(faucetAccountId).toString();
+
       return {
+        senderAccountBalance: senderAccountBalance,
         targetAccountBalance: targetAccountBalance
       }
     },
@@ -209,6 +231,84 @@ describe.only("standalone p2Id note", () => {
     faucetId
     );
 
+    expect(result.senderAccountBalance).to.equal("990");
+    expect(result.targetAccountBalance).to.equal("10");
+  });
+
+  it.only("should create a proper consumable p2ide note from the createP2IDENote function", async ()=> {
+    const { accountId: senderId, faucetId } = await setupWalletAndFaucet();
+    const { accountId: targetId } = await setupWalletAndFaucet();
+
+    const { createdNoteId } = await mintTransaction(senderId, faucetId, false, true);
+
+    await consumeTransaction(senderId, faucetId, createdNoteId, false);
+
+    const result = await testingPage.evaluate(async(
+      _senderId: string,
+      _targetId: string,
+      _faucetId: string
+    ) => {
+      let client = window.client;
+
+      console.log(_senderId, _targetId, _faucetId);
+      let senderAccountId = window.AccountId.fromHex(_senderId);
+      let targetAccountId = window.AccountId.fromHex(_targetId);
+      let faucetAccountId = window.AccountId.fromHex(_faucetId);
+
+      let fungibleAsset = new window.FungibleAsset(faucetAccountId, BigInt(10));
+      let noteAssets = new window.NoteAssets([fungibleAsset]);
+      let p2IdeNote = window.Note.createP2IDENote(
+        senderAccountId, targetAccountId, noteAssets, null, null, window.NoteType.Public, new window.Felt(0n));
+
+      let outputNote = window.OutputNote.full(p2IdeNote);
+
+      let transactionRequest = new window.TransactionRequestBuilder()
+        .withOwnOutputNotes(new window.OutputNotesArray([outputNote]))
+        .build();
+
+      let transactionResult = await client.newTransaction(
+        senderAccountId, 
+        transactionRequest
+      )
+
+      await client.submitTransaction(transactionResult);
+
+      await window.helpers.waitForTransaction(
+        transactionResult.executedTransaction().id().toHex()
+      );
+
+      let createdNoteId = transactionResult.createdNotes()
+          .notes()[0]
+          .id()
+          .toString()
+
+      let consumeTransactionRequest = client.newConsumeTransactionRequest([createdNoteId])
+
+      let consumeTransactionResult = await client.newTransaction(
+        targetAccountId,
+        consumeTransactionRequest
+      );
+
+      await client.submitTransaction(consumeTransactionResult);
+
+      await window.helpers.waitForTransaction(
+        consumeTransactionResult.executedTransaction().id().toHex()
+      );
+
+      let senderAccountBalance = (await client.getAccount(senderAccountId))?.vault().getBalance(faucetAccountId).toString();
+      let targetAccountBalance = (await client.getAccount(targetAccountId))?.vault().getBalance(faucetAccountId).toString();
+
+      return {
+        senderAccountBalance: senderAccountBalance,
+        targetAccountBalance: targetAccountBalance
+      }
+    },
+    senderId,
+    targetId,
+    faucetId
+    );
+
+    expect(result.senderAccountBalance).to.equal("990");
     expect(result.targetAccountBalance).to.equal("10");
   });
 });

--- a/docs/src/web-client/api/classes/Note.md
+++ b/docs/src/web-client/api/classes/Note.md
@@ -84,7 +84,7 @@
 
 ### createP2IDENote()
 
-> `static` **createP2IDENote**(`sender`, `target`, `assets`, `note_type`, `serial_num`, `recall_height`, `aux`): `Note`
+> `static` **createP2IDENote**(`sender`, `target`, `assets`, `reclaim_height`, `timelock_height`, `note_type`, `aux`): `Note`
 
 #### Parameters
 
@@ -100,17 +100,17 @@
 
 [`NoteAssets`](NoteAssets.md)
 
+##### reclaim\_height
+
+`number`
+
+##### timelock\_height
+
+`number`
+
 ##### note\_type
 
 [`NoteType`](../enumerations/NoteType.md)
-
-##### serial\_num
-
-[`Word`](Word.md)
-
-##### recall\_height
-
-`number`
 
 ##### aux
 
@@ -124,7 +124,7 @@
 
 ### createP2IDNote()
 
-> `static` **createP2IDNote**(`sender`, `target`, `assets`, `note_type`, `serial_num`, `aux`): `Note`
+> `static` **createP2IDNote**(`sender`, `target`, `assets`, `note_type`, `aux`): `Note`
 
 #### Parameters
 
@@ -143,10 +143,6 @@
 ##### note\_type
 
 [`NoteType`](../enumerations/NoteType.md)
-
-##### serial\_num
-
-[`Word`](Word.md)
 
 ##### aux
 


### PR DESCRIPTION
Addresses https://github.com/0xMiden/miden-client/issues/1070

Note: before, I was having users pass in their own serial number to both of these functions, but I realized that it's better to instantiate a `FeltRng` instance myself and generate a random value for them to ensure the randomness falls on a valid field element. This was already done in Rust, but updated the web side to do the same. 