### PR TITLE
feat: remove duplicate error trace

### DIFF
--- a/crates/rust-client/src/errors.rs
+++ b/crates/rust-client/src/errors.rs
@@ -6,13 +6,8 @@ use miden_objects::account::AccountId;
 use miden_objects::crypto::merkle::MerkleError;
 use miden_objects::note::NoteId;
 use miden_objects::{
-    AccountError,
-    AssetError,
-    NoteError,
-    PartialBlockchainError,
-    TransactionInputError,
-    TransactionScriptError,
-    Word,
+    AccountError, AssetError, NoteError, PartialBlockchainError, TransactionInputError,
+    TransactionScriptError, Word,
 };
 // RE-EXPORTS
 // ================================================================================================
@@ -80,7 +75,7 @@ pub enum ClientError {
     NoteScreenerError(#[from] NoteScreenerError),
     #[error("store error")]
     StoreError(#[from] StoreError),
-    #[error("transaction executor error: {0}")]
+    #[error("transaction executor error")]
     TransactionExecutorError(#[from] TransactionExecutorError),
     #[error("transaction input error")]
     TransactionInputError(#[source] TransactionInputError),

--- a/crates/rust-client/src/errors.rs
+++ b/crates/rust-client/src/errors.rs
@@ -6,8 +6,13 @@ use miden_objects::account::AccountId;
 use miden_objects::crypto::merkle::MerkleError;
 use miden_objects::note::NoteId;
 use miden_objects::{
-    AccountError, AssetError, NoteError, PartialBlockchainError, TransactionInputError,
-    TransactionScriptError, Word,
+    AccountError,
+    AssetError,
+    NoteError,
+    PartialBlockchainError,
+    TransactionInputError,
+    TransactionScriptError,
+    Word,
 };
 // RE-EXPORTS
 // ================================================================================================


### PR DESCRIPTION
When `TransactionExecutorError` is displayed in a trace, the error is showed twice. For example:

```
Caused by:
    0: transaction executor error: failed to execute transaction kernel program:
         × error during processing of event in on_event handler
         ╰─▶ public note with metadata NoteMetadata { sender: V0(AccountIdV0 { prefix: 11226098615840309536, suffix: 9029612700626841344 }), note_type: Public, tag: LocalAny(3874619392), aux: 0,
             execution_hint: Always } and recipient digest 0x0000000000000000000000000000000000000000000000003b1cfd38897a99ba is missing details in the advice provider

    1: failed to execute transaction kernel program:
         × error during processing of event in on_event handler
         ╰─▶ public note with metadata NoteMetadata { sender: V0(AccountIdV0 { prefix: 11226098615840309536, suffix: 9029612700626841344 }), note_type: Public, tag: LocalAny(3874619392), aux: 0,
             execution_hint: Always } and recipient digest 0x0000000000000000000000000000000000000000000000003b1cfd38897a99ba is missing details in the advice provider
```

This PR removes the error display on the error wrapper so it's only displayed once.