### PR TITLE
chore: update base and node versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 * [BREAKING] The WASM import has been changed into an async function to avoid issues with top-level awaits and some vite projects. ([#1172])(<https://github.com/0xMiden/miden-client/pull/1172>)
 * Added the `miden-client-integration-tests` binary for running integration tests against a remote node ([#1075](https://github.com/0xMiden/miden-client/pull/1075)).
 * Added a `exportAccount` method in Web Client ([#1111](https://github.com/0xMiden/miden-client/pull/1111))
+* Removed Account ID to bech32 conversions ([#1177](https://github.com/0xMiden/miden-client/pull/1177)).
+* Removed `get_account_state_delta` RPC endpoint  ([#1177](https://github.com/0xMiden/miden-client/pull/1177)).
 
 ### Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,17 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -1299,6 +1310,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1500,7 +1514,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2086,7 +2100,7 @@ dependencies = [
 [[package]]
 name = "miden-block-prover"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#4e946b770c9c39971503616a9316dbb41f229c89"
+source = "git+https://github.com/0xMiden/miden-base?branch=pgackst-remove-account-id-bech32#3206878fe5c4fa868ef429b8480978895a62bb3a"
 dependencies = [
  "miden-lib",
  "miden-objects",
@@ -2247,7 +2261,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#4e946b770c9c39971503616a9316dbb41f229c89"
+source = "git+https://github.com/0xMiden/miden-base?branch=pgackst-remove-account-id-bech32#3206878fe5c4fa868ef429b8480978895a62bb3a"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -2314,7 +2328,7 @@ dependencies = [
 [[package]]
 name = "miden-node-block-producer"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#5cc3d45be165c1048dfce24407f7f8a2b944703c"
+source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-base-address#6d393961a93637dd6ee5ac53dfaa8591fe8ec19e"
 dependencies = [
  "anyhow",
  "futures",
@@ -2342,7 +2356,7 @@ dependencies = [
 [[package]]
 name = "miden-node-ntx-builder"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#5cc3d45be165c1048dfce24407f7f8a2b944703c"
+source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-base-address#6d393961a93637dd6ee5ac53dfaa8591fe8ec19e"
 dependencies = [
  "anyhow",
  "futures",
@@ -2351,7 +2365,6 @@ dependencies = [
  "miden-objects",
  "miden-remote-prover-client",
  "miden-tx",
- "rand 0.9.2",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
@@ -2363,7 +2376,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#5cc3d45be165c1048dfce24407f7f8a2b944703c"
+source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-base-address#6d393961a93637dd6ee5ac53dfaa8591fe8ec19e"
 dependencies = [
  "anyhow",
  "hex",
@@ -2377,12 +2390,13 @@ dependencies = [
  "thiserror 2.0.12",
  "tonic",
  "tonic-build",
+ "url",
 ]
 
 [[package]]
 name = "miden-node-proto-build"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#5cc3d45be165c1048dfce24407f7f8a2b944703c"
+source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-base-address#6d393961a93637dd6ee5ac53dfaa8591fe8ec19e"
 dependencies = [
  "anyhow",
  "prost",
@@ -2393,7 +2407,7 @@ dependencies = [
 [[package]]
 name = "miden-node-rpc"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#5cc3d45be165c1048dfce24407f7f8a2b944703c"
+source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-base-address#6d393961a93637dd6ee5ac53dfaa8591fe8ec19e"
 dependencies = [
  "anyhow",
  "futures",
@@ -2420,16 +2434,16 @@ dependencies = [
 [[package]]
 name = "miden-node-store"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#5cc3d45be165c1048dfce24407f7f8a2b944703c"
+source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-base-address#6d393961a93637dd6ee5ac53dfaa8591fe8ec19e"
 dependencies = [
  "anyhow",
- "bigdecimal",
  "deadpool",
  "deadpool-diesel",
  "deadpool-sync",
  "diesel",
  "diesel_migrations",
  "hex",
+ "indexmap 2.10.0",
  "miden-lib",
  "miden-node-proto",
  "miden-node-proto-build",
@@ -2451,11 +2465,13 @@ dependencies = [
 [[package]]
 name = "miden-node-utils"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#5cc3d45be165c1048dfce24407f7f8a2b944703c"
+source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-base-address#6d393961a93637dd6ee5ac53dfaa8591fe8ec19e"
 dependencies = [
  "anyhow",
+ "bytes",
  "figment",
  "http",
+ "http-body-util",
  "itertools",
  "miden-objects",
  "opentelemetry",
@@ -2476,7 +2492,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#4e946b770c9c39971503616a9316dbb41f229c89"
+source = "git+https://github.com/0xMiden/miden-base?branch=pgackst-remove-account-id-bech32#3206878fe5c4fa868ef429b8480978895a62bb3a"
 dependencies = [
  "bech32",
  "getrandom 0.3.3",
@@ -2528,7 +2544,7 @@ dependencies = [
 [[package]]
 name = "miden-remote-prover"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#5cc3d45be165c1048dfce24407f7f8a2b944703c"
+source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-base-address#6d393961a93637dd6ee5ac53dfaa8591fe8ec19e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2571,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "miden-remote-prover-client"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#5cc3d45be165c1048dfce24407f7f8a2b944703c"
+source = "git+https://github.com/0xMiden/miden-node?branch=tomyrd-base-address#6d393961a93637dd6ee5ac53dfaa8591fe8ec19e"
 dependencies = [
  "getrandom 0.3.3",
  "miden-node-proto-build",
@@ -2605,7 +2621,7 @@ dependencies = [
 [[package]]
 name = "miden-testing"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#4e946b770c9c39971503616a9316dbb41f229c89"
+source = "git+https://github.com/0xMiden/miden-base?branch=pgackst-remove-account-id-bech32#3206878fe5c4fa868ef429b8480978895a62bb3a"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2624,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#4e946b770c9c39971503616a9316dbb41f229c89"
+source = "git+https://github.com/0xMiden/miden-base?branch=pgackst-remove-account-id-bech32#3206878fe5c4fa868ef429b8480978895a62bb3a"
 dependencies = [
  "miden-lib",
  "miden-objects",
@@ -2639,7 +2655,7 @@ dependencies = [
 [[package]]
 name = "miden-tx-batch-prover"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#4e946b770c9c39971503616a9316dbb41f229c89"
+source = "git+https://github.com/0xMiden/miden-base?branch=pgackst-remove-account-id-bech32#3206878fe5c4fa868ef429b8480978895a62bb3a"
 dependencies = [
  "miden-objects",
  "miden-tx",
@@ -3243,7 +3259,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb4b85ca73955092e7e2a6654304f6ee7868d38792f442733a197cbb3ac5f75"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "async-trait",
  "blake2",
  "bytes",
@@ -3278,7 +3294,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2298292e2dbd156294bcc8dd2ec34507277c78bab31bfe3aecc1cab9b1f91dff"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "async-trait",
  "brotli",
  "bytes",
@@ -3310,7 +3326,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "sfv",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "strum",
  "strum_macros",
  "tokio",
@@ -3368,7 +3384,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a719a8cb5558ca06bd6076c97b8905d500ea556da89e132ba53d4272844f95b9"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
 ]
 
 [[package]]
@@ -3400,7 +3416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32f1c33f6ce9ca9b8e81190796f7d4d543d1ab2a310097d884ebe48ce5d33c4d"
 dependencies = [
  "arrayvec",
- "hashbrown 0.15.5",
+ "hashbrown 0.12.3",
  "parking_lot",
  "rand 0.8.5",
 ]
@@ -5109,6 +5125,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,21 +22,23 @@ version      = "0.11.0"
 
 [workspace.dependencies]
 # Miden dependencies
-miden-lib = { branch = "next", default-features = false, git = "https://github.com/0xMiden/miden-base" }
-miden-node-block-producer = { branch = "next", git = "https://github.com/0xMiden/miden-node" }
-miden-node-ntx-builder = { branch = "next", git = "https://github.com/0xMiden/miden-node" }
-miden-node-proto-build = { branch = "next", default-features = false, git = "https://github.com/0xMiden/miden-node" }
-miden-node-rpc = { branch = "next", git = "https://github.com/0xMiden/miden-node" }
-miden-node-store = { branch = "next", git = "https://github.com/0xMiden/miden-node" }
-miden-node-utils = { branch = "next", git = "https://github.com/0xMiden/miden-node" }
-miden-objects = { branch = "next", default-features = false, git = "https://github.com/0xMiden/miden-base" }
-miden-remote-prover = { branch = "next", features = ["concurrent"], git = "https://github.com/0xMiden/miden-node" }
-miden-remote-prover-client = { branch = "next", default-features = false, features = [
+miden-lib = { branch = "pgackst-remove-account-id-bech32", default-features = false, git = "https://github.com/0xMiden/miden-base" }
+miden-node-block-producer = { branch = "tomyrd-base-address", git = "https://github.com/0xMiden/miden-node" }
+miden-node-ntx-builder = { branch = "tomyrd-base-address", git = "https://github.com/0xMiden/miden-node" }
+miden-node-proto-build = { branch = "tomyrd-base-address", default-features = false, git = "https://github.com/0xMiden/miden-node" }
+miden-node-rpc = { branch = "tomyrd-base-address", git = "https://github.com/0xMiden/miden-node" }
+miden-node-store = { branch = "tomyrd-base-address", git = "https://github.com/0xMiden/miden-node" }
+miden-node-utils = { branch = "tomyrd-base-address", git = "https://github.com/0xMiden/miden-node" }
+miden-objects = { branch = "pgackst-remove-account-id-bech32", default-features = false, git = "https://github.com/0xMiden/miden-base" }
+miden-remote-prover = { branch = "tomyrd-base-address", features = [
+  "concurrent",
+], git = "https://github.com/0xMiden/miden-node" }
+miden-remote-prover-client = { branch = "tomyrd-base-address", default-features = false, features = [
   "tx-prover",
 ], git = "https://github.com/0xMiden/miden-node" }
-miden-testing = { branch = "next", default-features = false, features = [
+miden-testing = { branch = "pgackst-remove-account-id-bech32", default-features = false, features = [
 ], git = "https://github.com/0xMiden/miden-base" }
-miden-tx = { branch = "next", default-features = false, git = "https://github.com/0xMiden/miden-base" }
+miden-tx = { branch = "pgackst-remove-account-id-bech32", default-features = false, git = "https://github.com/0xMiden/miden-base" }
 
 # External dependencies
 async-trait = "0.1"

--- a/bin/integration-tests/src/tests/client.rs
+++ b/bin/integration-tests/src/tests/client.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use miden_client::ClientError;
 use miden_client::account::{AccountId, AccountStorageMode};
 use miden_client::asset::{Asset, FungibleAsset};
 use miden_client::builder::ClientBuilder;
@@ -26,7 +27,6 @@ use miden_client::transaction::{
     TransactionStatus,
     TransactionWitness,
 };
-use miden_client::{ClientError, ONE};
 
 pub async fn client_builder_initializes_client_with_endpoint(client_config: ClientConfig) {
     let (endpoint, _, store_config, auth_path) = client_config.into_parts();
@@ -1172,8 +1172,6 @@ pub async fn unused_rpc_api(client_config: ClientConfig) {
 
     client.sync_state().await.unwrap();
 
-    let second_block_num = client.get_sync_height().await.unwrap();
-
     let nullifier = note.nullifier();
 
     let node_nullifier = client
@@ -1193,15 +1191,6 @@ pub async fn unused_rpc_api(client_config: ClientConfig) {
 
     assert_eq!(node_nullifier.nullifier, nullifier);
     assert_eq!(node_nullifier_proof.leaf().entries().pop().unwrap().0, nullifier.as_word());
-
-    let account_delta = client
-        .test_rpc_api()
-        .get_account_state_delta(first_basic_account.id(), first_block_num, second_block_num)
-        .await
-        .unwrap();
-
-    assert_eq!(account_delta.nonce_delta(), ONE);
-    assert_eq!(*account_delta.vault().fungible().iter().next().unwrap().1, MINT_AMOUNT as i64);
 }
 
 pub async fn ignore_invalid_notes(client_config: ClientConfig) {

--- a/bin/integration-tests/src/tests/fpi.rs
+++ b/bin/integration-tests/src/tests/fpi.rs
@@ -11,7 +11,6 @@ use miden_client::transaction::{
     TransactionKernel,
     TransactionRequestBuilder,
 };
-use miden_client::utils::word_to_masm_push_string;
 use miden_client::{Felt, ScriptBuilder, Word};
 
 // FPI TESTS
@@ -46,7 +45,7 @@ pub async fn fpi_execute_program(client_config: ClientConfig) {
                 exec.::miden::account::get_map_item
                 swapw dropw
             end",
-            map_key = word_to_masm_push_string(&MAP_KEY.into())
+            map_key = Word::from(MAP_KEY)
         ),
     )
     .await
@@ -121,7 +120,7 @@ pub async fn nested_fpi_calls(client_config: ClientConfig) {
                 exec.::miden::account::get_map_item
                 swapw dropw
             end",
-            map_key = word_to_masm_push_string(&MAP_KEY.into())
+            map_key = Word::from(MAP_KEY)
         ),
     )
     .await
@@ -180,7 +179,7 @@ pub async fn nested_fpi_calls(client_config: ClientConfig) {
             push.{fpi_value} add.1 assert_eqw
         end
         ",
-        fpi_value = word_to_masm_push_string(&FPI_STORAGE_VALUE.into()),
+        fpi_value = Word::from(FPI_STORAGE_VALUE),
         account_id_prefix = outer_foreign_account_id.prefix().as_u64(),
         account_id_suffix = outer_foreign_account_id.suffix(),
     );
@@ -232,7 +231,7 @@ async fn standard_fpi(storage_mode: AccountStorageMode, client_config: ClientCon
                 exec.::miden::account::get_map_item
                 swapw dropw
             end",
-            map_key = word_to_masm_push_string(&MAP_KEY.into())
+            map_key = Word::from(MAP_KEY)
         ),
     )
     .await
@@ -263,7 +262,7 @@ async fn standard_fpi(storage_mode: AccountStorageMode, client_config: ClientCon
             push.{fpi_value} assert_eqw
         end
         ",
-        fpi_value = word_to_masm_push_string(&FPI_STORAGE_VALUE.into()),
+        fpi_value = Word::from(FPI_STORAGE_VALUE),
         account_id_prefix = foreign_account_id.prefix().as_u64(),
         account_id_suffix = foreign_account_id.suffix(),
     );

--- a/bin/miden-cli/src/commands/new_account.rs
+++ b/bin/miden-cli/src/commands/new_account.rs
@@ -24,7 +24,7 @@ use tracing::debug;
 
 use crate::commands::account::maybe_set_default_account;
 use crate::errors::CliError;
-use crate::utils::load_config_file;
+use crate::utils::{account_id_to_address, load_config_file};
 use crate::{CliKeyStore, client_binary_name};
 
 // CLI TYPES
@@ -125,8 +125,7 @@ impl NewWalletCmd {
         .await?;
 
         let (mut current_config, _) = load_config_file()?;
-        let account_address =
-            new_account.id().to_bech32(current_config.rpc.endpoint.0.to_network_id()?);
+        let account_address = account_id_to_address(new_account.id(), &current_config);
 
         println!("Successfully created new wallet.");
         println!(
@@ -189,8 +188,7 @@ impl NewAccountCmd {
         .await?;
 
         let (current_config, _) = load_config_file()?;
-        let account_address =
-            new_account.id().to_bech32(current_config.rpc.endpoint.0.to_network_id()?);
+        let account_address = account_id_to_address(new_account.id(), &current_config);
 
         println!("Successfully created new account.");
         println!(

--- a/bin/miden-cli/src/commands/tags.rs
+++ b/bin/miden-cli/src/commands/tags.rs
@@ -3,6 +3,7 @@ use miden_client::note::{NoteExecutionMode, NoteTag};
 use tracing::info;
 
 use crate::errors::CliError;
+use crate::utils::account_id_to_address;
 use crate::{Parser, create_dynamic_table, load_config_file};
 
 #[derive(Default, Debug, Parser, Clone)]
@@ -48,10 +49,9 @@ async fn list_tags<AUTH>(client: Client<AUTH>) -> Result<(), CliError> {
 
     for tag in tags {
         let source = match tag.source {
-            miden_client::sync::NoteTagSource::Account(account_id) => format!(
-                "Account({})",
-                account_id.to_bech32(cli_config.rpc.endpoint.0.to_network_id()?),
-            ),
+            miden_client::sync::NoteTagSource::Account(account_id) => {
+                format!("Account({})", account_id_to_address(account_id, &cli_config))
+            },
             miden_client::sync::NoteTagSource::Note(note_id) => format!("Note({note_id})"),
             miden_client::sync::NoteTagSource::User => "User".to_string(),
         };

--- a/bin/miden-cli/src/faucet_details_map.rs
+++ b/bin/miden-cli/src/faucet_details_map.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::errors::CliError;
 use crate::load_config_file;
-use crate::utils::parse_account_id;
+use crate::utils::{account_id_to_address, parse_account_id};
 
 /// Stores the detail information of a faucet to be stored in the token symbol map file.
 #[derive(Debug, Serialize, Deserialize)]
@@ -152,7 +152,7 @@ impl FaucetDetailsMap {
             let (cli_config, _) = load_config_file()?;
 
             Ok((
-                asset.faucet_id().to_bech32(cli_config.rpc.endpoint.0.to_network_id()?),
+                account_id_to_address(asset.faucet_id(), &cli_config),
                 asset.amount().to_string(),
             ))
         }

--- a/bin/miden-cli/src/utils.rs
+++ b/bin/miden-cli/src/utils.rs
@@ -6,6 +6,7 @@ use figment::Figment;
 use figment::providers::{Format, Toml};
 use miden_client::Client;
 use miden_client::account::AccountId;
+use miden_objects::address::{AccountIdAddress, Address};
 use tracing::info;
 
 use super::config::CliConfig;
@@ -66,13 +67,19 @@ pub(crate) async fn parse_account_id<AUTH>(
         .map_err(|_| CliError::Input(format!("Input account ID {account_id} is neither a valid Account ID nor a hex prefix of a known Account ID")))?
         .id())
     } else {
-        Ok(AccountId::from_bech32(account_id)
+        let address = Address::from_bech32(account_id)
             .map_err(|_| {
                 CliError::Input(format!(
-                    "Input account ID {account_id} is not a valid bech32 encoded Account ID"
+                    "Input account ID {account_id} is not a valid account address"
                 ))
             })?
-            .1)
+            .1;
+        match address {
+            Address::AccountId(account_id_address) => Ok(account_id_address.id()),
+            _ => Err(CliError::Input(format!(
+                "Input account ID {address:?} is not an ID based address"
+            ))),
+        }
     }
 }
 
@@ -115,4 +122,9 @@ fn load_config(config_file: &Path) -> Result<CliConfig, CliError> {
 pub fn load_faucet_details_map() -> Result<FaucetDetailsMap, CliError> {
     let (config, _) = load_config_file()?;
     FaucetDetailsMap::new(config.token_symbol_map_filepath)
+}
+
+pub fn account_id_to_address(account_id: AccountId, cli_config: &CliConfig) -> String {
+    let address: Address = AccountIdAddress::new(account_id).into();
+    address.to_bech32(cli_config.rpc.endpoint.0.to_network_id())
 }

--- a/bin/miden-cli/tests/cli.rs
+++ b/bin/miden-cli/tests/cli.rs
@@ -33,9 +33,18 @@ use miden_client::transaction::{OutputNote, TransactionRequestBuilder};
 use miden_client::utils::Serializable;
 use miden_client::{self, Client, ExecutionOptions, Felt};
 use miden_client_cli::CliKeyStore;
+use miden_objects::address::Address;
 use miden_objects::{MAX_TX_EXECUTION_CYCLES, MIN_TX_EXECUTION_CYCLES};
 use predicates::str::contains;
 use rand::Rng;
+
+fn account_id_from_address(bech32: &str) -> AccountId {
+    let address = Address::from_bech32(bech32).unwrap().1;
+    match address {
+        Address::AccountId(account_id_address) => account_id_address.id(),
+        _ => panic!("Input account ID {address:?} is not an ID based address"),
+    }
+}
 
 // CLI TESTS
 // ================================================================================================
@@ -344,18 +353,8 @@ async fn cli_export_import_account() {
 
     // Ensure the account was imported
     let client_2 = create_rust_client_with_store_path(&store_path_2, endpoint_2).await.0;
-    assert!(
-        client_2
-            .get_account(AccountId::from_bech32(&faucet_id).unwrap().1)
-            .await
-            .is_ok()
-    );
-    assert!(
-        client_2
-            .get_account(AccountId::from_bech32(&wallet_id).unwrap().1)
-            .await
-            .is_ok()
-    );
+    assert!(client_2.get_account(account_id_from_address(&faucet_id)).await.is_ok());
+    assert!(client_2.get_account(account_id_from_address(&wallet_id)).await.is_ok());
 
     sync_cli(&temp_dir_2);
 

--- a/crates/rust-client/src/account/mod.rs
+++ b/crates/rust-client/src/account/mod.rs
@@ -321,24 +321,19 @@ pub mod tests {
     use alloc::vec::Vec;
 
     use miden_lib::account::auth::AuthRpoFalcon512;
-    use miden_lib::transaction::TransactionKernel;
+    use miden_lib::testing::mock_account::MockAccountExt;
     use miden_objects::account::{Account, AccountFile, AuthSecretKey};
     use miden_objects::crypto::dsa::rpo_falcon512::{PublicKey, SecretKey};
     use miden_objects::testing::account_id::{
         ACCOUNT_ID_PRIVATE_FUNGIBLE_FAUCET,
         ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
     };
-    use miden_objects::{EMPTY_WORD, Felt, Word};
+    use miden_objects::{EMPTY_WORD, Word, ZERO};
 
     use crate::tests::create_test_client;
 
     fn create_account_data(account_id: u128) -> AccountFile {
-        let account = Account::mock(
-            account_id,
-            Felt::new(2),
-            AuthRpoFalcon512::new(PublicKey::new(EMPTY_WORD)),
-            TransactionKernel::testing_assembler(),
-        );
+        let account = Account::mock(account_id, AuthRpoFalcon512::new(PublicKey::new(EMPTY_WORD)));
 
         AccountFile::new(
             account.clone(),
@@ -365,10 +360,12 @@ pub mod tests {
 
         let account = Account::mock(
             ACCOUNT_ID_PRIVATE_FUNGIBLE_FAUCET,
-            Felt::new(0),
             AuthRpoFalcon512::new(PublicKey::new(EMPTY_WORD)),
-            TransactionKernel::testing_assembler(),
         );
+
+        // The mock account has nonce 1, we need it to be 0 for the test.
+        let (id, vault, storage, code, _) = account.into_parts();
+        let account = Account::from_parts(id, vault, storage, code, ZERO);
 
         assert!(client.add_account(&account, None, false).await.is_err());
         assert!(client.add_account(&account, Some(Word::default()), false).await.is_ok());

--- a/crates/rust-client/src/rpc/endpoint.rs
+++ b/crates/rust-client/src/rpc/endpoint.rs
@@ -1,7 +1,6 @@
 use alloc::string::{String, ToString};
 use core::fmt;
 
-use miden_objects::NetworkIdError;
 use miden_objects::account::NetworkId;
 
 // ENDPOINT
@@ -62,15 +61,15 @@ impl Endpoint {
         self.port
     }
 
-    pub fn to_network_id(&self) -> Result<NetworkId, NetworkIdError> {
+    pub fn to_network_id(&self) -> NetworkId {
         if self == &Endpoint::testnet() {
-            Ok(NetworkId::Testnet)
+            NetworkId::Testnet
         } else if self == &Endpoint::devnet() {
-            Ok(NetworkId::Devnet)
+            NetworkId::Devnet
         } else if self == &Endpoint::localhost() {
-            Ok(NetworkId::new("mlcl")?)
+            NetworkId::new("mlcl").expect("mlcl should be a valid network ID")
         } else {
-            Ok(NetworkId::new("mcst")?)
+            NetworkId::new("mcst").expect("mcst should be a valid network ID")
         }
     }
 }

--- a/crates/rust-client/src/rpc/generated/nostd/rpc.rs
+++ b/crates/rust-client/src/rpc/generated/nostd/rpc.rs
@@ -213,34 +213,6 @@ pub mod api_client {
             req.extensions_mut().insert(GrpcMethod::new("rpc.Api", "GetAccountProofs"));
             self.inner.unary(req, path, codec).await
         }
-        /// Returns delta of the account states in the range from `from_block_num` (exclusive) to
-        /// `to_block_num` (inclusive).
-        pub async fn get_account_state_delta(
-            &mut self,
-            request: impl tonic::IntoRequest<
-                super::super::rpc_store::AccountStateDeltaRequest,
-            >,
-        ) -> core::result::Result<
-            tonic::Response<super::super::rpc_store::AccountStateDelta>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rpc.Api/GetAccountStateDelta",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("rpc.Api", "GetAccountStateDelta"));
-            self.inner.unary(req, path, codec).await
-        }
         /// Returns raw block data for the specified block number.
         pub async fn get_block_by_number(
             &mut self,

--- a/crates/rust-client/src/rpc/generated/nostd/rpc_store.rs
+++ b/crates/rust-client/src/rpc/generated/nostd/rpc_store.rs
@@ -120,28 +120,6 @@ pub mod account_proofs {
         }
     }
 }
-/// Returns delta of the account states in the range from `from_block_num` (exclusive) to
-/// `to_block_num` (inclusive).
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct AccountStateDeltaRequest {
-    /// ID of the account for which the delta is requested.
-    #[prost(message, optional, tag = "1")]
-    pub account_id: ::core::option::Option<super::account::AccountId>,
-    /// Block number from which the delta is requested (exclusive).
-    #[prost(fixed32, tag = "2")]
-    pub from_block_num: u32,
-    /// Block number up to which the delta is requested (inclusive).
-    #[prost(fixed32, tag = "3")]
-    pub to_block_num: u32,
-}
-/// Represents the result of getting account state delta.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct AccountStateDelta {
-    /// The calculated account delta encoded using \[winter_utils::Serializable\] implementation
-    /// for \[miden_objects::account::delta::AccountDelta\].
-    #[prost(bytes = "vec", optional, tag = "1")]
-    pub delta: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
-}
 /// Returns a list of nullifiers that match the specified prefixes and are recorded in the node.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CheckNullifiersByPrefixRequest {
@@ -468,32 +446,6 @@ pub mod rpc_client {
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rpc_store.Rpc", "GetAccountProofs"));
-            self.inner.unary(req, path, codec).await
-        }
-        /// Returns delta of the account states in the range from `from_block_num` (exclusive) to
-        /// `to_block_num` (inclusive).
-        pub async fn get_account_state_delta(
-            &mut self,
-            request: impl tonic::IntoRequest<super::AccountStateDeltaRequest>,
-        ) -> core::result::Result<
-            tonic::Response<super::AccountStateDelta>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rpc_store.Rpc/GetAccountStateDelta",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("rpc_store.Rpc", "GetAccountStateDelta"));
             self.inner.unary(req, path, codec).await
         }
         /// Returns raw block data for the specified block number.

--- a/crates/rust-client/src/rpc/generated/std/rpc.rs
+++ b/crates/rust-client/src/rpc/generated/std/rpc.rs
@@ -224,34 +224,6 @@ pub mod api_client {
             req.extensions_mut().insert(GrpcMethod::new("rpc.Api", "GetAccountProofs"));
             self.inner.unary(req, path, codec).await
         }
-        /// Returns delta of the account states in the range from `from_block_num` (exclusive) to
-        /// `to_block_num` (inclusive).
-        pub async fn get_account_state_delta(
-            &mut self,
-            request: impl tonic::IntoRequest<
-                super::super::rpc_store::AccountStateDeltaRequest,
-            >,
-        ) -> std::result::Result<
-            tonic::Response<super::super::rpc_store::AccountStateDelta>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rpc.Api/GetAccountStateDelta",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("rpc.Api", "GetAccountStateDelta"));
-            self.inner.unary(req, path, codec).await
-        }
         /// Returns raw block data for the specified block number.
         pub async fn get_block_by_number(
             &mut self,

--- a/crates/rust-client/src/rpc/generated/std/rpc_store.rs
+++ b/crates/rust-client/src/rpc/generated/std/rpc_store.rs
@@ -120,28 +120,6 @@ pub mod account_proofs {
         }
     }
 }
-/// Returns delta of the account states in the range from `from_block_num` (exclusive) to
-/// `to_block_num` (inclusive).
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct AccountStateDeltaRequest {
-    /// ID of the account for which the delta is requested.
-    #[prost(message, optional, tag = "1")]
-    pub account_id: ::core::option::Option<super::account::AccountId>,
-    /// Block number from which the delta is requested (exclusive).
-    #[prost(fixed32, tag = "2")]
-    pub from_block_num: u32,
-    /// Block number up to which the delta is requested (inclusive).
-    #[prost(fixed32, tag = "3")]
-    pub to_block_num: u32,
-}
-/// Represents the result of getting account state delta.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct AccountStateDelta {
-    /// The calculated account delta encoded using \[winter_utils::Serializable\] implementation
-    /// for \[miden_objects::account::delta::AccountDelta\].
-    #[prost(bytes = "vec", optional, tag = "1")]
-    pub delta: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
-}
 /// Returns a list of nullifiers that match the specified prefixes and are recorded in the node.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CheckNullifiersByPrefixRequest {
@@ -479,32 +457,6 @@ pub mod rpc_client {
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("rpc_store.Rpc", "GetAccountProofs"));
-            self.inner.unary(req, path, codec).await
-        }
-        /// Returns delta of the account states in the range from `from_block_num` (exclusive) to
-        /// `to_block_num` (inclusive).
-        pub async fn get_account_state_delta(
-            &mut self,
-            request: impl tonic::IntoRequest<super::AccountStateDeltaRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::AccountStateDelta>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rpc_store.Rpc/GetAccountStateDelta",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("rpc_store.Rpc", "GetAccountStateDelta"));
             self.inner.unary(req, path, codec).await
         }
         /// Returns raw block data for the specified block number.

--- a/crates/rust-client/src/rpc/mod.rs
+++ b/crates/rust-client/src/rpc/mod.rs
@@ -50,7 +50,7 @@ use domain::note::{FetchedNote, NoteSyncInfo};
 use domain::nullifier::NullifierUpdate;
 use domain::sync::StateSyncInfo;
 use miden_objects::Word;
-use miden_objects::account::{Account, AccountCode, AccountDelta, AccountHeader, AccountId};
+use miden_objects::account::{Account, AccountCode, AccountHeader, AccountId};
 use miden_objects::block::{BlockHeader, BlockNumber, ProvenBlock};
 use miden_objects::crypto::merkle::{MmrProof, SmtProof};
 use miden_objects::note::{NoteId, NoteTag, Nullifier};
@@ -191,15 +191,6 @@ pub trait NodeRpcClient: Send + Sync {
         account_storage_requests: &BTreeSet<ForeignAccount>,
         known_account_codes: Vec<AccountCode>,
     ) -> Result<AccountProofs, RpcError>;
-
-    /// Fetches the account state delta for the specified account between the specified blocks
-    /// using the `/GetAccountStateDelta` RPC endpoint.
-    async fn get_account_state_delta(
-        &self,
-        account_id: AccountId,
-        from_block: BlockNumber,
-        to_block: BlockNumber,
-    ) -> Result<AccountDelta, RpcError>;
 
     /// Fetches the commit height where the nullifier was consumed. If the nullifier isn't found,
     /// then `None` is returned.

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -4,7 +4,7 @@ use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
 use miden_objects::Word;
-use miden_objects::account::{Account, AccountCode, AccountDelta, AccountId};
+use miden_objects::account::{Account, AccountCode, AccountId};
 use miden_objects::block::{AccountWitness, BlockHeader, BlockNumber, ProvenBlock};
 use miden_objects::crypto::merkle::{Forest, MerklePath, MmrProof, SmtProof};
 use miden_objects::note::{NoteId, NoteTag, Nullifier};
@@ -429,35 +429,6 @@ impl NodeRpcClient for TonicRpcClient {
         let proofs = response.proofs.iter().map(TryInto::try_into).collect::<Result<_, _>>()?;
 
         Ok(proofs)
-    }
-
-    async fn get_account_state_delta(
-        &self,
-        account_id: AccountId,
-        from_block: BlockNumber,
-        to_block: BlockNumber,
-    ) -> Result<AccountDelta, RpcError> {
-        let request = proto::rpc_store::AccountStateDeltaRequest {
-            account_id: Some(account_id.into()),
-            from_block_num: from_block.as_u32(),
-            to_block_num: to_block.as_u32(),
-        };
-
-        let mut rpc_api = self.ensure_connected().await?;
-
-        let response = rpc_api.get_account_state_delta(request).await.map_err(|err| {
-            RpcError::RequestError(
-                NodeRpcClientEndpoint::GetAccountStateDelta.to_string(),
-                err.to_string(),
-            )
-        })?;
-
-        let response = response.into_inner();
-        let delta = AccountDelta::read_from_bytes(&response.delta.ok_or(
-            RpcError::ExpectedDataMissing("GetAccountStateDeltaResponse.delta".to_string()),
-        )?)?;
-
-        Ok(delta)
     }
 
     async fn get_block_by_number(&self, block_num: BlockNumber) -> Result<ProvenBlock, RpcError> {

--- a/crates/rust-client/src/store/sqlite_store/account.rs
+++ b/crates/rust-client/src/store/sqlite_store/account.rs
@@ -578,7 +578,6 @@ mod tests {
     use miden_objects::EMPTY_WORD;
     use miden_objects::account::{AccountCode, AccountComponent};
     use miden_objects::crypto::dsa::rpo_falcon512::PublicKey;
-    use miden_objects::testing::account_component::BASIC_WALLET_CODE;
 
     use crate::store::sqlite_store::SqliteStore;
     use crate::store::sqlite_store::tests::create_test_store;
@@ -587,9 +586,16 @@ mod tests {
     async fn account_code_insertion_no_duplicates() {
         let store = create_test_store().await;
         let assembler = miden_lib::transaction::TransactionKernel::assembler();
-        let account_component = AccountComponent::compile(BASIC_WALLET_CODE, assembler, vec![])
-            .unwrap()
-            .with_supports_all_types();
+        let account_component = AccountComponent::compile(
+            "
+                export.::miden::contracts::wallets::basic::receive_asset
+                export.::miden::contracts::wallets::basic::move_asset_to_note
+            ",
+            assembler,
+            vec![],
+        )
+        .unwrap()
+        .with_supports_all_types();
         let account_code = AccountCode::from_components(
             &[AuthRpoFalcon512::new(PublicKey::new(EMPTY_WORD)).into(), account_component],
             miden_objects::account::AccountType::RegularAccountUpdatableCode,

--- a/crates/rust-client/src/tests.rs
+++ b/crates/rust-client/src/tests.rs
@@ -16,6 +16,7 @@ use miden_lib::{
         wallets::BasicWallet,
     },
     note::{utils, well_known_note::WellKnownNote},
+    testing::mock_account::MockAccountExt,
     transaction::TransactionKernel,
 };
 use miden_objects::account::{
@@ -57,7 +58,7 @@ use miden_objects::testing::account_id::{
 use miden_objects::testing::note::NoteBuilder;
 use miden_objects::transaction::{InputNote, OutputNote};
 use miden_objects::vm::AdviceInputs;
-use miden_objects::{EMPTY_WORD, Felt, FieldElement, ONE, Word, ZERO};
+use miden_objects::{EMPTY_WORD, Felt, ONE, Word, ZERO};
 use miden_testing::{MockChain, MockChainBuilder};
 use miden_tx::TransactionExecutorError;
 use miden_tx::utils::{Deserializable, Serializable};
@@ -391,9 +392,7 @@ async fn insert_same_account_twice_fails() {
 
     let account = Account::mock(
         ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_2,
-        Felt::new(2),
         AuthRpoFalcon512::new(PublicKey::new(EMPTY_WORD)),
-        TransactionKernel::testing_assembler(),
     );
 
     assert!(client.add_account(&account, Some(Word::default()), false).await.is_ok());
@@ -407,9 +406,7 @@ async fn account_code() {
 
     let account = Account::mock(
         ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE,
-        Felt::ZERO,
         AuthRpoFalcon512::new(PublicKey::new(EMPTY_WORD)),
-        TransactionKernel::testing_assembler(),
     );
 
     let account_code = account.code();
@@ -431,9 +428,7 @@ async fn get_account_by_id() {
 
     let account = Account::mock(
         ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE,
-        Felt::new(10),
         AuthRpoFalcon512::new(PublicKey::new(EMPTY_WORD)),
-        TransactionKernel::assembler(),
     );
 
     client.add_account(&account, Some(Word::default()), false).await.unwrap();

--- a/crates/rust-client/src/transaction/request/foreign.rs
+++ b/crates/rust-client/src/transaction/request/foreign.rs
@@ -147,11 +147,9 @@ impl TryFrom<AccountProof> for AccountInputs {
                     account_header.nonce(),
                     code,
                     PartialStorage::new(storage_header, storage_map_proofs.into_iter())?,
-                    PartialVault::new(PartialSmt::new()), /* We don't use
-                                                           * vault
-                                                           * information so we
-                                                           * leave it
-                                                           * empty */
+                    // We don't use vault information so we leave it empty
+                    PartialVault::new(PartialSmt::new())
+                        .expect("Empty partial vault shouldn't fail"),
                 ),
                 witness,
             ));

--- a/crates/rust-client/src/transaction/request/mod.rs
+++ b/crates/rust-client/src/transaction/request/mod.rs
@@ -474,13 +474,12 @@ mod tests {
 
     use miden_lib::account::auth::AuthRpoFalcon512;
     use miden_lib::note::create_p2id_note;
-    use miden_lib::transaction::TransactionKernel;
+    use miden_lib::testing::account_component::MockAccountComponent;
     use miden_objects::account::{AccountBuilder, AccountId, AccountType};
     use miden_objects::asset::FungibleAsset;
     use miden_objects::crypto::dsa::rpo_falcon512::PublicKey;
     use miden_objects::crypto::rand::{FeltRng, RpoRandomCoin};
     use miden_objects::note::{NoteTag, NoteType};
-    use miden_objects::testing::account_component::AccountMockComponent;
     use miden_objects::testing::account_id::{
         ACCOUNT_ID_PRIVATE_FUNGIBLE_FAUCET,
         ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE,
@@ -522,9 +521,7 @@ mod tests {
         }
 
         let account = AccountBuilder::new(Default::default())
-            .with_component(
-                AccountMockComponent::new_with_empty_slots(TransactionKernel::assembler()).unwrap(),
-            )
+            .with_component(MockAccountComponent::with_empty_slots())
             .with_auth_component(AuthRpoFalcon512::new(PublicKey::new(EMPTY_WORD)))
             .account_type(AccountType::RegularAccountImmutableCode)
             .storage_mode(miden_objects::account::AccountStorageMode::Private)

--- a/crates/rust-client/src/utils.rs
+++ b/crates/rust-client/src/utils.rs
@@ -20,7 +20,6 @@ pub use miden_tx::utils::{
     ToHex,
     bytes_to_hex_string,
     hex_to_bytes,
-    word_to_masm_push_string,
 };
 
 use crate::alloc::borrow::ToOwned;


### PR DESCRIPTION
This PR updates the base version to [this PR](https://github.com/0xMiden/miden-base/pull/1762). The main change in the linked PR is the removal of the account ID to bech 32 conversions, but it also includes other older changes. I'll list the most important ones:
- Account ID to bech 32 conversions were removed. Now the bech32 is generated from the `Address` struct.
- The `GetAccountStateDelta` endpoint was removed.
- Some minor interface changes in the testing node binary.

The current PR points to two WIP branches so we should wait until those are merged to merge this one, but we can start the reviewing process.