### PR TITLE
feat: reexport `Program`

### DIFF
--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -121,7 +121,7 @@ pub use miden_objects::transaction::{
     TransactionId,
     TransactionScript,
 };
-pub use miden_objects::vm::{AdviceInputs, AdviceMap};
+pub use miden_objects::vm::{AdviceInputs, AdviceMap, Program};
 pub use miden_tx::auth::TransactionAuthenticator;
 pub use miden_tx::{
     DataStoreError,


### PR DESCRIPTION
This is needed for compiling the masm scripts in build time and then deserializing the compiled program.

Context: https://github.com/0xMiden/miden-faucet/pull/56#discussion_r2289572869