### PR TITLE
chore: use new miden-remote-prover crate with the clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2122,7 +2122,7 @@ dependencies = [
  "miden-lib",
  "miden-node-proto-build",
  "miden-objects",
- "miden-remote-prover-client",
+ "miden-remote-prover",
  "miden-testing",
  "miden-tx",
  "miette",
@@ -2328,7 +2328,7 @@ dependencies = [
 [[package]]
 name = "miden-node-block-producer"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#7434171ce33eaf8cb58d928193d11fbcb7219a0b"
+source = "git+https://github.com/0xMiden/miden-node?branch=santiagopittella-merge-remote-prover-crates#3098c672f8e565a56c42cc54c7ec795a743972a9"
 dependencies = [
  "anyhow",
  "futures",
@@ -2339,7 +2339,7 @@ dependencies = [
  "miden-node-proto-build",
  "miden-node-utils",
  "miden-objects",
- "miden-remote-prover-client",
+ "miden-remote-prover",
  "miden-tx",
  "miden-tx-batch-prover",
  "rand 0.9.2",
@@ -2356,14 +2356,14 @@ dependencies = [
 [[package]]
 name = "miden-node-ntx-builder"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#7434171ce33eaf8cb58d928193d11fbcb7219a0b"
+source = "git+https://github.com/0xMiden/miden-node?branch=santiagopittella-merge-remote-prover-crates#3098c672f8e565a56c42cc54c7ec795a743972a9"
 dependencies = [
  "anyhow",
  "futures",
  "miden-node-proto",
  "miden-node-utils",
  "miden-objects",
- "miden-remote-prover-client",
+ "miden-remote-prover",
  "miden-tx",
  "thiserror 2.0.12",
  "tokio",
@@ -2376,7 +2376,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#7434171ce33eaf8cb58d928193d11fbcb7219a0b"
+source = "git+https://github.com/0xMiden/miden-node?branch=santiagopittella-merge-remote-prover-crates#3098c672f8e565a56c42cc54c7ec795a743972a9"
 dependencies = [
  "anyhow",
  "hex",
@@ -2396,7 +2396,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto-build"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#7434171ce33eaf8cb58d928193d11fbcb7219a0b"
+source = "git+https://github.com/0xMiden/miden-node?branch=santiagopittella-merge-remote-prover-crates#3098c672f8e565a56c42cc54c7ec795a743972a9"
 dependencies = [
  "anyhow",
  "prost",
@@ -2407,7 +2407,7 @@ dependencies = [
 [[package]]
 name = "miden-node-rpc"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#7434171ce33eaf8cb58d928193d11fbcb7219a0b"
+source = "git+https://github.com/0xMiden/miden-node?branch=santiagopittella-merge-remote-prover-crates#3098c672f8e565a56c42cc54c7ec795a743972a9"
 dependencies = [
  "anyhow",
  "futures",
@@ -2434,7 +2434,7 @@ dependencies = [
 [[package]]
 name = "miden-node-store"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#7434171ce33eaf8cb58d928193d11fbcb7219a0b"
+source = "git+https://github.com/0xMiden/miden-node?branch=santiagopittella-merge-remote-prover-crates#3098c672f8e565a56c42cc54c7ec795a743972a9"
 dependencies = [
  "anyhow",
  "deadpool",
@@ -2465,7 +2465,7 @@ dependencies = [
 [[package]]
 name = "miden-node-utils"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#7434171ce33eaf8cb58d928193d11fbcb7219a0b"
+source = "git+https://github.com/0xMiden/miden-node?branch=santiagopittella-merge-remote-prover-crates#3098c672f8e565a56c42cc54c7ec795a743972a9"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2544,13 +2544,14 @@ dependencies = [
 [[package]]
 name = "miden-remote-prover"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#7434171ce33eaf8cb58d928193d11fbcb7219a0b"
+source = "git+https://github.com/0xMiden/miden-node?branch=santiagopittella-merge-remote-prover-crates#3098c672f8e565a56c42cc54c7ec795a743972a9"
 dependencies = [
  "anyhow",
  "async-trait",
  "axum",
  "bytes",
  "clap 4.5.43",
+ "getrandom 0.3.3",
  "http",
  "humantime",
  "miden-block-prover",
@@ -2579,29 +2580,10 @@ dependencies = [
  "tonic-build",
  "tonic-health",
  "tonic-web",
+ "tonic-web-wasm-client",
  "tower-http",
  "tracing",
  "uuid",
-]
-
-[[package]]
-name = "miden-remote-prover-client"
-version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#7434171ce33eaf8cb58d928193d11fbcb7219a0b"
-dependencies = [
- "getrandom 0.3.3",
- "miden-node-proto-build",
- "miden-objects",
- "miden-tx",
- "miette",
- "prost",
- "prost-build",
- "protox 0.8.0",
- "thiserror 2.0.12",
- "tokio",
- "tonic",
- "tonic-build",
- "tonic-web-wasm-client",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,17 +23,14 @@ version      = "0.11.0"
 [workspace.dependencies]
 # Miden dependencies
 miden-lib = { branch = "next", default-features = false, git = "https://github.com/0xMiden/miden-base" }
-miden-node-block-producer = { branch = "next", git = "https://github.com/0xMiden/miden-node" }
-miden-node-ntx-builder = { branch = "next", git = "https://github.com/0xMiden/miden-node" }
-miden-node-proto-build = { branch = "next", default-features = false, git = "https://github.com/0xMiden/miden-node" }
-miden-node-rpc = { branch = "next", git = "https://github.com/0xMiden/miden-node" }
-miden-node-store = { branch = "next", git = "https://github.com/0xMiden/miden-node" }
-miden-node-utils = { branch = "next", git = "https://github.com/0xMiden/miden-node" }
+miden-node-block-producer = { branch = "santiagopittella-merge-remote-prover-crates", git = "https://github.com/0xMiden/miden-node" }
+miden-node-ntx-builder = { branch = "santiagopittella-merge-remote-prover-crates", git = "https://github.com/0xMiden/miden-node" }
+miden-node-proto-build = { branch = "santiagopittella-merge-remote-prover-crates", default-features = false, git = "https://github.com/0xMiden/miden-node" }
+miden-node-rpc = { branch = "santiagopittella-merge-remote-prover-crates", git = "https://github.com/0xMiden/miden-node" }
+miden-node-store = { branch = "santiagopittella-merge-remote-prover-crates", git = "https://github.com/0xMiden/miden-node" }
+miden-node-utils = { branch = "santiagopittella-merge-remote-prover-crates", git = "https://github.com/0xMiden/miden-node" }
 miden-objects = { branch = "next", default-features = false, git = "https://github.com/0xMiden/miden-base" }
-miden-remote-prover = { branch = "next", features = ["concurrent"], git = "https://github.com/0xMiden/miden-node" }
-miden-remote-prover-client = { branch = "next", default-features = false, features = [
-  "tx-prover",
-], git = "https://github.com/0xMiden/miden-node" }
+miden-remote-prover = { branch = "santiagopittella-merge-remote-prover-crates", default-features = false, git = "https://github.com/0xMiden/miden-node" }
 miden-testing = { branch = "next", default-features = false, features = [
 ], git = "https://github.com/0xMiden/miden-base" }
 miden-tx = { branch = "next", default-features = false, git = "https://github.com/0xMiden/miden-base" }

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -29,18 +29,18 @@ idxdb = [
   "dep:wasm-bindgen-futures",
 ]
 sqlite = ["dep:deadpool", "dep:deadpool-sync", "dep:rusqlite", "dep:rusqlite_migration", "std"]
-std = ["miden-objects/std", "miden-remote-prover-client/std", "miden-tx/concurrent"]
+std = ["miden-objects/std", "miden-remote-prover/std", "miden-tx/concurrent"]
 testing = ["dep:miden-testing", "dep:uuid", "miden-lib/testing", "miden-objects/testing", "miden-tx/testing"]
 tonic = ["std", "tonic/tls-native-roots", "tonic/tls-ring", "tonic/transport"]
 web-tonic = ["dep:getrandom", "dep:tonic-web-wasm-client"]
 
 [dependencies]
 # Miden dependencies
-miden-lib                  = { workspace = true }
-miden-objects              = { workspace = true }
-miden-remote-prover-client = { default-features = false, features = ["tx-prover"], workspace = true }
-miden-testing              = { optional = true, workspace = true }
-miden-tx                   = { workspace = true }
+miden-lib           = { workspace = true }
+miden-objects       = { workspace = true }
+miden-remote-prover = { features = ["client"], workspace = true }
+miden-testing       = { optional = true, workspace = true }
+miden-tx            = { workspace = true }
 
 # External dependencies
 async-trait           = { workspace = true }

--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -211,7 +211,7 @@ pub mod crypto {
 
 pub use errors::{AuthenticationError, ClientError, IdPrefixFetchError};
 pub use miden_objects::{EMPTY_WORD, Felt, ONE, StarkField, Word, ZERO};
-pub use miden_remote_prover_client::remote_prover::tx_prover::RemoteTransactionProver;
+pub use miden_remote_prover::client::RemoteTransactionProver;
 pub use miden_tx::ExecutionOptions;
 
 /// Provides test utilities for working with accounts and account IDs

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -83,7 +83,7 @@ use miden_objects::block::BlockNumber;
 use miden_objects::note::{Note, NoteDetails, NoteId, NoteRecipient, NoteTag};
 use miden_objects::transaction::{AccountInputs, TransactionArgs};
 use miden_objects::{AssetError, Felt, Word};
-use miden_remote_prover_client::remote_prover::tx_prover::RemoteTransactionProver;
+use miden_remote_prover::client::RemoteTransactionProver;
 use miden_tx::utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 use miden_tx::{DataStore, NoteConsumptionChecker, TransactionExecutor};
 use tracing::info;

--- a/crates/testing/prover/Cargo.toml
+++ b/crates/testing/prover/Cargo.toml
@@ -10,7 +10,7 @@ version                = "0.1.0"
 [dependencies]
 # Miden dependencies
 miden-node-utils    = { workspace = true }
-miden-remote-prover = { features = ["concurrent"], workspace = true }
+miden-remote-prover = { features = ["server"], workspace = true }
 
 # External dependencies
 anyhow             = "1.0"


### PR DESCRIPTION
This PR updates the crate used for the remote prover clients, follows https://github.com/0xMiden/miden-node/pull/1163