### PR TITLE
Update docs for linter compliance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,8 @@ tracing     = { version = "0.1" }
 pedantic = { level = "warn", priority = -1 }
 # cast_possible_truncation =   "allow"  # Overly many instances especially regarding indices.
 ignored_unit_patterns       = "allow" # Stylistic choice.
-missing_errors_doc          = "allow" # TODO: fixup and enable this.
-missing_panics_doc          = "allow" # TODO: fixup and enable this.
+# missing_errors_doc          = "allow" # Documentation added for non-generated files
+# missing_panics_doc          = "allow" # Documentation added for non-generated files
 module_name_repetitions     = "allow" # Many triggers, and is a stylistic choice.
 must_use_candidate          = "allow" # This marks many fn's which isn't helpful.
 should_panic_without_expect = "allow" # We don't care about the specific panic message.

--- a/bin/miden-cli/build.rs
+++ b/bin/miden-cli/build.rs
@@ -26,6 +26,14 @@ fn main() {
 }
 
 /// Builds a component template and stores it under `{OUT_DIR}/templates`.
+///
+/// # Panics
+///
+/// This function will panic if:
+/// - The metadata file cannot be read from the provided path
+/// - The TOML content in the metadata file is malformed
+/// - The `OUT_DIR` environment variable is not set
+/// - The templates directory cannot be created in `OUT_DIR`
 pub fn build_component_template(metadata_path: &Path, library: Library) {
     let toml_string = fs::read_to_string(metadata_path).expect("failed to read file");
 

--- a/bin/miden-cli/src/lib.rs
+++ b/bin/miden-cli/src/lib.rs
@@ -146,6 +146,20 @@ pub enum Command {
 
 /// CLI entry point.
 impl Cli {
+    /// Executes the CLI command.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The current directory cannot be determined
+    /// - The configuration file cannot be loaded
+    /// - The keystore cannot be created
+    /// - The client cannot be built
+    /// - The command execution fails
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the store filepath cannot be converted to a valid string.
     pub async fn execute(&self) -> Result<(), CliError> {
         let mut current_dir = std::env::current_dir()?;
         current_dir.push(CLIENT_CONFIG_FILE_NAME);

--- a/crates/rust-client/src/account/mod.rs
+++ b/crates/rust-client/src/account/mod.rs
@@ -215,6 +215,10 @@ impl<AUTH> Client<AUTH> {
     /// statuses.
     ///
     /// Said accounts' state is the state after the last performed sync.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the store operation fails.
     pub async fn get_account_headers(
         &self,
     ) -> Result<Vec<(AccountHeader, AccountStatus)>, ClientError> {
@@ -224,6 +228,10 @@ impl<AUTH> Client<AUTH> {
     /// Retrieves a full [`AccountRecord`] object for the specified `account_id`. This result
     /// represents data for the latest state known to the client, alongside its status. Returns
     /// `None` if the account ID is not found.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the store operation fails.
     pub async fn get_account(
         &self,
         account_id: AccountId,
@@ -235,6 +243,10 @@ impl<AUTH> Client<AUTH> {
     /// Returns `None` if the account ID is not found.
     ///
     /// Said account's state is the state according to the last sync performed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the store operation fails.
     pub async fn get_account_header_by_id(
         &self,
         account_id: AccountId,
@@ -355,6 +367,11 @@ pub mod tests {
         accounts
     }
 
+    /// Tests the ability to add accounts to the client.
+    ///
+    /// # Panics
+    ///
+    /// This test will panic if the assertions fail or if the test client cannot be created.
     #[tokio::test]
     pub async fn try_add_account() {
         // generate test client

--- a/crates/rust-client/src/builder.rs
+++ b/crates/rust-client/src/builder.rs
@@ -179,6 +179,10 @@ where
     /// - Returns an error if no RPC client or endpoint was provided.
     /// - Returns an error if the store cannot be instantiated.
     /// - Returns an error if the keystore is not specified or fails to initialize.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the default executor options are invalid (which should never happen).
     #[allow(clippy::unused_async, unused_mut)]
     pub async fn build(mut self) -> Result<Client<AUTH>, ClientError> {
         // Determine the RPC client to use.

--- a/crates/rust-client/src/keystore/fs_keystore.rs
+++ b/crates/rust-client/src/keystore/fs_keystore.rs
@@ -31,6 +31,11 @@ pub struct FilesystemKeyStore<R: Rng + Send + Sync> {
 }
 
 impl<R: Rng + Send + Sync> FilesystemKeyStore<R> {
+    /// Creates a new [`FilesystemKeyStore`] with the specified RNG.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the keys directory cannot be created.
     pub fn with_rng(keys_directory: PathBuf, rng: R) -> Result<Self, KeyStoreError> {
         if !keys_directory.exists() {
             std::fs::create_dir_all(&keys_directory).map_err(|err| {
@@ -45,6 +50,12 @@ impl<R: Rng + Send + Sync> FilesystemKeyStore<R> {
     }
 
     /// Adds a secret key to the keystore.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The key file cannot be created or written to
+    /// - There is an I/O error while writing the key
     pub fn add_key(&self, key: &AuthSecretKey) -> Result<(), KeyStoreError> {
         let pub_key = match key {
             AuthSecretKey::RpoFalcon512(k) => Word::from(k.public_key()),
@@ -72,6 +83,13 @@ impl<R: Rng + Send + Sync> FilesystemKeyStore<R> {
     }
 
     /// Retrieves a secret key from the keystore given its public key.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The key file cannot be opened or read
+    /// - The key data cannot be decoded from hex
+    /// - The key bytes cannot be deserialized
     pub fn get_key(&self, pub_key: Word) -> Result<Option<AuthSecretKey>, KeyStoreError> {
         let filename = hash_pub_key(pub_key);
 
@@ -107,6 +125,10 @@ impl<R: Rng + Send + Sync> FilesystemKeyStore<R> {
 // type annotations.
 impl FilesystemKeyStore<rand::rngs::StdRng> {
     /// Creates a new [`FilesystemKeyStore`] using [`rand::rngs::StdRng`] as the RNG.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the keys directory cannot be created.
     pub fn new(keys_directory: PathBuf) -> Result<Self, KeyStoreError> {
         use rand::rngs::StdRng;
         let rng = StdRng::from_os_rng();

--- a/crates/rust-client/src/note/mod.rs
+++ b/crates/rust-client/src/note/mod.rs
@@ -131,6 +131,13 @@ where
     /// The note screener runs a series of checks to determine whether the note can be executed as
     /// part of a transaction for a specific account. If the specific account ID can consume it (ie,
     /// if it's compatible with the account), it will be returned as part of the result list.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The store operation fails
+    /// - Note conversion fails
+    /// - The note screening process fails
     pub async fn get_consumable_notes(
         &self,
         account_id: Option<AccountId>,
@@ -163,6 +170,12 @@ where
     /// The note screener runs a series of checks to determine whether the note can be executed as
     /// part of a transaction for a specific account. If the specific account ID can consume it (ie,
     /// if it's compatible with the account), it will be returned as part of the result list.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Note conversion fails
+    /// - The note screening process fails
     pub async fn get_note_consumability(
         &self,
         note: InputNoteRecord,
@@ -175,6 +188,10 @@ where
     }
 
     /// Retrieves the input note given a [`NoteId`]. Returns `None` if the note is not found.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the store operation fails.
     pub async fn get_input_note(
         &self,
         note_id: NoteId,
@@ -186,6 +203,10 @@ where
     // --------------------------------------------------------------------------------------------
 
     /// Returns output notes managed by this client.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the store operation fails.
     pub async fn get_output_notes(
         &self,
         filter: NoteFilter,
@@ -194,6 +215,10 @@ where
     }
 
     /// Retrieves the output note given a [`NoteId`]. Returns `None` if the note is not found.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the store operation fails.
     pub async fn get_output_note(
         &self,
         note_id: NoteId,
@@ -210,6 +235,11 @@ where
 ///   `note_id_prefix` is a prefix of its ID.
 /// - Returns [`IdPrefixFetchError::MultipleMatches`] if there were more than one note found where
 ///   `note_id_prefix` is a prefix of its ID.
+///
+/// # Panics
+///
+/// This function will panic if the internal logic fails (which should never happen as the vector
+/// is guaranteed to have exactly one element at the point of unwrapping).
 pub async fn get_input_note_with_id_prefix<AUTH>(
     client: &Client<AUTH>,
     note_id_prefix: &str,

--- a/crates/rust-client/src/note/note_screener.rs
+++ b/crates/rust-client/src/note/note_screener.rs
@@ -74,6 +74,13 @@ where
     /// currently not available.
     ///
     /// If relevance can't be determined, the screener defaults to setting the note as consumable.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The store operations fail
+    /// - Account data cannot be retrieved
+    /// - Note script validation fails
     pub async fn check_relevance(
         &self,
         note: &Note,

--- a/crates/rust-client/src/rpc/generated/mod.rs
+++ b/crates/rust-client/src/rpc/generated/mod.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "std")]
 #[rustfmt::skip]
 #[allow(clippy::trivially_copy_pass_by_ref)]
+#[allow(clippy::missing_errors_doc)]
+#[allow(clippy::missing_panics_doc)]
 #[allow(dead_code)]
 mod std;
 #[cfg(feature = "std")]
@@ -9,6 +11,8 @@ pub use self::std::*;
 #[cfg(not(feature = "std"))]
 #[rustfmt::skip]
 #[allow(clippy::trivially_copy_pass_by_ref)]
+#[allow(clippy::missing_errors_doc)]
+#[allow(clippy::missing_panics_doc)]
 #[allow(dead_code)]
 mod nostd;
 #[cfg(not(feature = "std"))]

--- a/crates/rust-client/src/store/sqlite_store/mod.rs
+++ b/crates/rust-client/src/store/sqlite_store/mod.rs
@@ -60,6 +60,13 @@ impl SqliteStore {
     // --------------------------------------------------------------------------------------------
 
     /// Returns a new instance of [Store] instantiated with the specified configuration options.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The database pool cannot be created
+    /// - The database connection fails
+    /// - Database initialization fails
     pub async fn new(database_filepath: PathBuf) -> Result<Self, StoreError> {
         let sqlite_pool_manager = SqlitePoolManager::new(database_filepath.clone());
         let pool = Pool::builder(sqlite_pool_manager)
@@ -331,6 +338,10 @@ impl Store for SqliteStore {
 ///
 /// `Sqlite` uses `i64` as its internal representation format, and so when retrieving
 /// we need to make sure we cast as `u64` to get the original value
+///
+/// # Errors
+///
+/// Returns an error if the column value cannot be retrieved or converted.
 pub fn column_value_as_u64<I: rusqlite::RowIndex>(
     row: &rusqlite::Row<'_>,
     index: I,

--- a/crates/rust-client/src/sync/block_header.rs
+++ b/crates/rust-client/src/sync/block_header.rs
@@ -16,6 +16,13 @@ use crate::{Client, ClientError};
 impl<AUTH> Client<AUTH> {
     /// Attempts to retrieve the genesis block from the store. If not found,
     /// it requests it from the node and store it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The store operation fails
+    /// - The node request fails
+    /// - The genesis block cannot be retrieved or stored
     pub async fn ensure_genesis_in_place(&mut self) -> Result<BlockHeader, ClientError> {
         let genesis = match self.store.get_block_header_by_num(0.into()).await? {
             Some((block, _)) => block,

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -95,6 +95,10 @@ where
     // --------------------------------------------------------------------------------------------
 
     /// Returns the block number of the last state sync block.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the store operation fails.
     pub async fn get_sync_height(&self) -> Result<BlockNumber, ClientError> {
         self.store.get_sync_height().await.map_err(Into::into)
     }
@@ -118,6 +122,19 @@ where
     ///    state.
     /// 7. The MMR is updated with the new peaks and authentication nodes.
     /// 8. All updates are applied to the store to be persisted.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Genesis block cannot be retrieved
+    /// - State sync fails
+    /// - Store operations fail
+    /// - Note screening fails
+    /// - Account or transaction updates fail
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the block number exceeds `u32::MAX` (which should never happen in practice).
     pub async fn sync_state(&mut self) -> Result<SyncSummary, ClientError> {
         _ = self.ensure_genesis_in_place().await?;
 

--- a/crates/rust-client/src/sync/tag.rs
+++ b/crates/rust-client/src/sync/tag.rs
@@ -24,11 +24,19 @@ impl<AUTH> Client<AUTH> {
     /// Note: Tags for accounts that are being tracked by the client are managed automatically by
     /// the client and don't need to be added here. That is, notes for managed accounts will be
     /// retrieved automatically by the client when syncing.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the store operation fails.
     pub async fn get_note_tags(&self) -> Result<Vec<NoteTagRecord>, ClientError> {
         self.store.get_note_tags().await.map_err(Into::into)
     }
 
     /// Adds a note tag for the client to track. This tag's source will be marked as `User`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the store operation fails.
     pub async fn add_note_tag(&mut self, tag: NoteTag) -> Result<(), ClientError> {
         match self
             .store
@@ -46,6 +54,12 @@ impl<AUTH> Client<AUTH> {
     }
 
     /// Removes a note tag for the client to track. Only tags added by the user can be removed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The store operation fails
+    /// - The tag was not found or cannot be removed
     pub async fn remove_note_tag(&mut self, tag: NoteTag) -> Result<(), ClientError> {
         if self
             .store

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -593,6 +593,10 @@ where
     // --------------------------------------------------------------------------------------------
 
     /// Retrieves tracked transactions, filtered by [`TransactionFilter`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the store operation fails.
     pub async fn get_transactions(
         &self,
         filter: TransactionFilter,
@@ -711,6 +715,13 @@ where
 
     /// Proves the specified transaction using a local prover, submits it to the network, and saves
     /// the transaction into the local database for tracking.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Transaction proving fails
+    /// - Network submission fails
+    /// - Database storage fails
     pub async fn submit_transaction(
         &mut self,
         tx_result: TransactionResult,
@@ -720,6 +731,13 @@ where
 
     /// Proves the specified transaction using the provided prover, submits it to the network, and
     /// saves the transaction into the local database for tracking.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Transaction proving fails
+    /// - Network submission fails
+    /// - Database storage fails
     pub async fn submit_transaction_with_prover(
         &mut self,
         tx_result: TransactionResult,

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -190,6 +190,10 @@ pub struct TransactionResult {
 impl TransactionResult {
     /// Screens the output notes to store and track the relevant ones, and instantiates a
     /// [`TransactionResult`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the transaction result cannot be created.
     pub fn new(
         transaction: ExecutedTransaction,
         future_notes: Vec<(NoteDetails, NoteTag)>,
@@ -389,6 +393,11 @@ pub enum DiscardCause {
 }
 
 impl DiscardCause {
+    /// Converts a string to a [`DiscardCause`].
+    ///
+    /// # Errors
+    ///
+    /// Returns a `DeserializationError` if the string does not match any known discard cause.
     pub fn from_string(cause: &str) -> Result<Self, DeserializationError> {
         match cause {
             "Expired" => Ok(DiscardCause::Expired),

--- a/crates/rust-client/src/transaction/request/builder.rs
+++ b/crates/rust-client/src/transaction/request/builder.rs
@@ -270,6 +270,10 @@ impl TransactionRequestBuilder {
     /// specified notes.
     ///
     /// - `note_ids` is a list of note IDs to be consumed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the transaction request cannot be built.
     pub fn build_consume_notes(
         self,
         note_ids: Vec<NoteId>,
@@ -288,6 +292,12 @@ impl TransactionRequestBuilder {
     ///   note.
     ///
     /// This function cannot be used with a previously set custom script.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - A custom script was already set
+    /// - The transaction request cannot be built
     pub fn build_mint_fungible_asset(
         self,
         asset: FungibleAsset,
@@ -318,6 +328,13 @@ impl TransactionRequestBuilder {
     ///   note.
     ///
     /// This function cannot be used with a previously set custom script.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The payment contains no assets
+    /// - The note creation fails
+    /// - The transaction request cannot be built
     pub fn build_pay_to_id(
         self,
         payment_data: PaymentNoteDescription,
@@ -348,6 +365,12 @@ impl TransactionRequestBuilder {
     ///   note.
     ///
     /// This function cannot be used with a previously set custom script.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The swap note creation fails
+    /// - The transaction request cannot be built
     pub fn build_swap(
         self,
         swap_data: &SwapTransactionData,

--- a/crates/rust-client/src/transaction/request/foreign.rs
+++ b/crates/rust-client/src/transaction/request/foreign.rs
@@ -33,6 +33,10 @@ impl ForeignAccount {
     /// Creates a new [`ForeignAccount::Public`]. The account's components (code, storage header and
     /// inclusion proof) will be retrieved at execution time, alongside particular storage slot
     /// maps correspondent to keys passed in `indices`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the account ID is not a public account.
     pub fn public(
         account_id: AccountId,
         storage_requirements: AccountStorageRequirements,
@@ -46,6 +50,10 @@ impl ForeignAccount {
 
     /// Creates a new [`ForeignAccount::Private`]. A proof of the account's inclusion will be
     /// retrieved at execution time.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the account ID is a public account.
     pub fn private(account: impl Into<PartialAccount>) -> Result<Self, TransactionRequestError> {
         let partial_account: PartialAccount = account.into();
         if partial_account.id().is_public() {

--- a/crates/rust-client/src/transaction/request/mod.rs
+++ b/crates/rust-client/src/transaction/request/mod.rs
@@ -148,6 +148,11 @@ impl TransactionRequest {
     /// In this context "own notes" refers to notes that are expected to be created directly by the
     /// transaction script, rather than notes that are created as a result of consuming other
     /// notes.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if a recipient is not found in the expected output recipients map
+    /// (which should never happen if the transaction request is properly constructed).
     pub fn expected_output_own_notes(&self) -> Vec<Note> {
         match &self.script_template {
             Some(TransactionScriptTemplate::SendNotes(notes)) => notes

--- a/crates/rust-client/src/utils.rs
+++ b/crates/rust-client/src/utils.rs
@@ -62,6 +62,15 @@ pub enum TokenParseError {
 
 /// Converts a decimal number, represented as a string, into an integer by shifting
 /// the decimal point to the right by a specified number of decimal places.
+///
+/// # Errors
+///
+/// Returns a `TokenParseError` if:
+/// - The number of decimals exceeds the maximum allowed
+/// - The string contains multiple decimal points
+/// - The string contains invalid number format
+/// - The fractional part has too many decimal places
+/// - The resulting value would overflow a u64
 pub fn tokens_to_base_units(decimal_str: &str, n_decimals: u8) -> Result<u64, TokenParseError> {
     if n_decimals > BasicFungibleFaucet::MAX_DECIMALS {
         return Err(TokenParseError::MaxDecimals(n_decimals));

--- a/crates/testing/node-builder/src/lib.rs
+++ b/crates/testing/node-builder/src/lib.rs
@@ -86,6 +86,20 @@ impl NodeBuilder {
     // --------------------------------------------------------------------------------------------
 
     /// Starts all node components and returns a handle to manage them.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Tracing setup fails
+    /// - Genesis account creation fails
+    /// - File operations fail
+    /// - Any of the node components fail to start
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if:
+    /// - The current timestamp is before the Unix epoch
+    /// - The timestamp cannot fit into a u32
     #[allow(clippy::too_many_lines)]
     pub async fn start(self) -> Result<NodeHandle> {
         miden_node_utils::logging::setup_tracing(
@@ -340,6 +354,10 @@ pub struct NodeHandle {
 
 impl NodeHandle {
     /// Stops all node components.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any of the node components fail to stop properly.
     pub async fn stop(self) -> Result<()> {
         self.rpc_handle.abort();
         self.block_producer_handle.abort();


### PR DESCRIPTION
Add missing `# Errors` and `# Panics` documentation to comply with linter rules.

This PR addresses the `missing_errors_doc` and `missing_panics_doc` linter warnings by adding the relevant documentation to public functions in non-generated, non-test files. The `allow` directives for these lints in `Cargo.toml` have been commented out, significantly reducing the number of warnings and improving code maintainability.

closes #724 

---
<a href="https://cursor.com/background-agent?bcId=bc-0fc34e6a-0399-4db7-92f5-b4df16d19ff5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0fc34e6a-0399-4db7-92f5-b4df16d19ff5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

