### PR TITLE
refactor: RPC errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Store changes after transaction execution no longer require fetching the whole account state ([#1147](https://github.com/0xMiden/miden-client/pull/1147)).
 * Tracked creation and committed timestamps for `TransactionRecord` ([#1173](https://github.com/0xMiden/miden-client/pull/1173)).
 * [BREAKING] Changed `exportNoteFile` to fail fast on invalid export type ([#1198](https://github.com/0xMiden/miden-client/pull/1198)).
+* [BREAKING] Refactored RPC errors ([#1202](https://github.com/0xMiden/miden-client/pull/1202)).
 
 ### Features
 

--- a/bin/integration-tests/src/tests/onchain.rs
+++ b/bin/integration-tests/src/tests/onchain.rs
@@ -389,8 +389,9 @@ pub async fn incorrect_genesis(client_config: ClientConfig) -> Result<()> {
     // because the genesis commitment in the request header does not match the one in the node.
     let result = client.test_rpc_api().get_block_header_by_number(None, false).await;
 
-    match result.unwrap_err() {
-        RpcError::AcceptHeaderError(AcceptHeaderError::UnsupportedMediaRange) => Ok(()),
-        _ => panic!("expected accept header error"),
+    match result {
+        Err(RpcError::AcceptHeaderError(AcceptHeaderError::NoSupportedMediaRange)) => Ok(()),
+        Ok(_) => anyhow::bail!("grpc request was unexpectedly successful"),
+        _ => anyhow::bail!("expected accept header error"),
     }
 }

--- a/bin/integration-tests/src/tests/onchain.rs
+++ b/bin/integration-tests/src/tests/onchain.rs
@@ -4,6 +4,7 @@ use miden_client::account::{AccountStorageMode, build_wallet_id};
 use miden_client::asset::{Asset, FungibleAsset};
 use miden_client::auth::AuthSecretKey;
 use miden_client::note::{NoteFile, NoteType};
+use miden_client::rpc::{AcceptHeaderError, RpcError};
 use miden_client::store::{InputNoteState, NoteFilter};
 use miden_client::testing::common::*;
 use miden_client::testing::config::ClientConfig;
@@ -388,6 +389,8 @@ pub async fn incorrect_genesis(client_config: ClientConfig) -> Result<()> {
     // because the genesis commitment in the request header does not match the one in the node.
     let result = client.test_rpc_api().get_block_header_by_number(None, false).await;
 
-    assert!(result.is_err());
-    Ok(())
+    match result.unwrap_err() {
+        RpcError::AcceptHeaderError(AcceptHeaderError::UnsupportedMediaRange) => Ok(()),
+        _ => panic!("expected accept header error"),
+    }
 }

--- a/crates/rust-client/src/rpc/errors.rs
+++ b/crates/rust-client/src/rpc/errors.rs
@@ -116,11 +116,40 @@ pub enum GrpcError {
     Unknown(String),
 }
 
+impl GrpcError {
+    /// Creates a `GrpcError` from a gRPC status code following the official specification
+    /// <https://github.com/grpc/grpc/blob/master/doc/statuscodes.md#status-codes-and-their-use-in-grpc>
+    pub fn from_code(code: i32, message: Option<String>) -> Self {
+        match code {
+            0 => Self::Unknown("OK status received as error".to_string()),
+            1 => Self::Cancelled,
+            2 => Self::Unknown(message.unwrap_or_else(|| "Unknown error".to_string())),
+            3 => Self::InvalidArgument,
+            4 => Self::DeadlineExceeded,
+            5 => Self::NotFound,
+            6 => Self::AlreadyExists,
+            7 => Self::PermissionDenied,
+            8 => Self::ResourceExhausted,
+            9 => Self::FailedPrecondition,
+            10 => Self::Unknown(message.unwrap_or_else(|| "Aborted".to_string())),
+            11 => Self::Unknown(message.unwrap_or_else(|| "Out of range".to_string())),
+            12 => Self::Unimplemented,
+            13 => Self::Internal,
+            14 => Self::Unavailable,
+            15 => Self::Unknown(message.unwrap_or_else(|| "Data loss".to_string())),
+            16 => Self::Unauthenticated,
+            _ => Self::Unknown(
+                message.unwrap_or_else(|| format!("Unknown gRPC status code: {code}")),
+            ),
+        }
+    }
+}
+
 // ACCEPT HEADER ERROR
 // ================================================================================================
 
 // TODO: Once the node returns structure error information, replace this with a more structure
-// approach.
+// approach. See miden-client/#1129 for more information.
 
 /// Errors that can occur during accept header validation.
 #[derive(Debug, Error)]

--- a/crates/rust-client/src/rpc/errors.rs
+++ b/crates/rust-client/src/rpc/errors.rs
@@ -127,9 +127,8 @@ impl GrpcError {
     /// <https://github.com/grpc/grpc/blob/master/doc/statuscodes.md#status-codes-and-their-use-in-grpc>
     pub fn from_code(code: i32, message: Option<String>) -> Self {
         match code {
-            0 => Self::Unknown("OK status received as error".to_string()),
             1 => Self::Cancelled,
-            2 => Self::Unknown(message.unwrap_or_else(|| "Unknown error".to_string())),
+            2 => Self::Unknown(message.unwrap_or_default()),
             3 => Self::InvalidArgument,
             4 => Self::DeadlineExceeded,
             5 => Self::NotFound,

--- a/crates/rust-client/src/rpc/errors.rs
+++ b/crates/rust-client/src/rpc/errors.rs
@@ -10,11 +10,15 @@ use miden_objects::note::NoteId;
 use miden_objects::utils::DeserializationError;
 use thiserror::Error;
 
+use super::NodeRpcClientEndpoint;
+
 // RPC ERROR
 // ================================================================================================
 
 #[derive(Debug, Error)]
 pub enum RpcError {
+    #[error("accept header validation failed: {0}")]
+    AcceptHeaderError(#[from] AcceptHeaderError),
     #[error("rpc api response contained an update for a private account: {0}")]
     AccountUpdateForPrivateAccountReceived(AccountId),
     #[error("failed to connect to the api server: {0}")]
@@ -25,10 +29,15 @@ pub enum RpcError {
     ExpectedDataMissing(String),
     #[error("rpc api response is invalid: {0}")]
     InvalidResponse(String),
+    #[error("grpc request failed for {endpoint}: {error_kind}")]
+    GrpcError {
+        endpoint: NodeRpcClientEndpoint,
+        error_kind: GrpcError,
+        #[source]
+        source: Option<Box<dyn Error + Send + Sync + 'static>>,
+    },
     #[error("note with id {0} was not found")]
     NoteNotFound(NoteId),
-    #[error("rpc request failed for {0}: {1}")]
-    RequestError(String, String),
 }
 
 impl From<DeserializationError> for RpcError {
@@ -71,4 +80,71 @@ pub enum RpcConversionError {
         entity: &'static str,
         field_name: &'static str,
     },
+}
+
+// GRPC ERROR KIND
+// ================================================================================================
+
+/// Categorizes gRPC errors based on their status codes and common patterns
+#[derive(Debug, Error)]
+pub enum GrpcError {
+    #[error("resource not found")]
+    NotFound,
+    #[error("invalid request parameters")]
+    InvalidArgument,
+    #[error("permission denied")]
+    PermissionDenied,
+    #[error("resource already exists")]
+    AlreadyExists,
+    #[error("resource exhausted or rate limited")]
+    ResourceExhausted,
+    #[error("precondition failed")]
+    FailedPrecondition,
+    #[error("operation was cancelled")]
+    Cancelled,
+    #[error("deadline exceeded")]
+    DeadlineExceeded,
+    #[error("service unavailable")]
+    Unavailable,
+    #[error("internal server error")]
+    Internal,
+    #[error("unimplemented method")]
+    Unimplemented,
+    #[error("unauthenticated request")]
+    Unauthenticated,
+    #[error("unknown error: {0}")]
+    Unknown(String),
+}
+
+// ACCEPT HEADER ERROR
+// ================================================================================================
+
+// TODO: Once the node returns structure error information, replace this with a more structure
+// approach.
+
+/// Errors that can occur during accept header validation.
+#[derive(Debug, Error)]
+pub enum AcceptHeaderError {
+    #[error("server rejected request - please check your version and network settings")]
+    UnsupportedMediaRange,
+    #[error("server rejected request - parsing error: {0}")]
+    ParsingError(String),
+}
+
+impl AcceptHeaderError {
+    /// Try to parse an accept header error from a message string
+    pub fn try_from_message(message: &str) -> Option<Self> {
+        // Check for the main compatibility error message
+        if message.contains(
+            "server does not support any of the specified application/vnd.miden content types",
+        ) {
+            return Some(Self::UnsupportedMediaRange);
+        }
+        if message.contains("genesis value failed to parse")
+            || message.contains("version value failed to parse")
+        {
+            return Some(Self::ParsingError(message.to_string()));
+        }
+        None
+    }
 }

--- a/crates/rust-client/src/rpc/errors.rs
+++ b/crates/rust-client/src/rpc/errors.rs
@@ -112,6 +112,12 @@ pub enum GrpcError {
     Unimplemented,
     #[error("unauthenticated request")]
     Unauthenticated,
+    #[error("operation was aborted")]
+    Aborted,
+    #[error("operation was attempted past the valid range")]
+    OutOfRange,
+    #[error("unrecoverable data loss or corruption")]
+    DataLoss,
     #[error("unknown error: {0}")]
     Unknown(String),
 }
@@ -131,12 +137,12 @@ impl GrpcError {
             7 => Self::PermissionDenied,
             8 => Self::ResourceExhausted,
             9 => Self::FailedPrecondition,
-            10 => Self::Unknown(message.unwrap_or_else(|| "Aborted".to_string())),
-            11 => Self::Unknown(message.unwrap_or_else(|| "Out of range".to_string())),
+            10 => Self::Aborted,
+            11 => Self::OutOfRange,
             12 => Self::Unimplemented,
             13 => Self::Internal,
             14 => Self::Unavailable,
-            15 => Self::Unknown(message.unwrap_or_else(|| "Data loss".to_string())),
+            15 => Self::DataLoss,
             16 => Self::Unauthenticated,
             _ => Self::Unknown(
                 message.unwrap_or_else(|| format!("Unknown gRPC status code: {code}")),

--- a/crates/rust-client/src/rpc/errors.rs
+++ b/crates/rust-client/src/rpc/errors.rs
@@ -126,7 +126,7 @@ pub enum GrpcError {
 #[derive(Debug, Error)]
 pub enum AcceptHeaderError {
     #[error("server rejected request - please check your version and network settings")]
-    UnsupportedMediaRange,
+    NoSupportedMediaRange,
     #[error("server rejected request - parsing error: {0}")]
     ParsingError(String),
 }
@@ -138,7 +138,7 @@ impl AcceptHeaderError {
         if message.contains(
             "server does not support any of the specified application/vnd.miden content types",
         ) {
-            return Some(Self::UnsupportedMediaRange);
+            return Some(Self::NoSupportedMediaRange);
         }
         if message.contains("genesis value failed to parse")
             || message.contains("version value failed to parse")

--- a/crates/rust-client/src/rpc/mod.rs
+++ b/crates/rust-client/src/rpc/mod.rs
@@ -61,7 +61,7 @@ use miden_objects::transaction::ProvenTransaction;
 pub mod domain;
 
 mod errors;
-pub use errors::RpcError;
+pub use errors::*;
 
 mod endpoint;
 pub use endpoint::Endpoint;
@@ -305,6 +305,7 @@ pub enum NodeRpcClientEndpoint {
     GetAccountProofs,
     GetBlockByNumber,
     GetBlockHeaderByNumber,
+    GetNotesById,
     SyncState,
     SubmitProvenTx,
     SyncNotes,
@@ -324,6 +325,7 @@ impl fmt::Display for NodeRpcClientEndpoint {
             NodeRpcClientEndpoint::GetBlockHeaderByNumber => {
                 write!(f, "get_block_header_by_number")
             },
+            NodeRpcClientEndpoint::GetNotesById => write!(f, "get_notes_by_id"),
             NodeRpcClientEndpoint::SyncState => write!(f, "sync_state"),
             NodeRpcClientEndpoint::SubmitProvenTx => write!(f, "submit_proven_transaction"),
             NodeRpcClientEndpoint::SyncNotes => write!(f, "sync_notes"),

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -2,6 +2,7 @@ use alloc::boxed::Box;
 use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
+use core::error::Error;
 
 use miden_objects::Word;
 use miden_objects::account::{Account, AccountCode, AccountId};
@@ -12,6 +13,7 @@ use miden_objects::transaction::ProvenTransaction;
 use miden_objects::utils::Deserializable;
 use miden_tx::utils::Serializable;
 use miden_tx::utils::sync::RwLock;
+use tonic::Status;
 use tracing::info;
 
 use super::domain::account::{AccountProof, AccountProofs, AccountUpdateSummary};
@@ -27,7 +29,7 @@ use super::{
     StateSyncInfo,
     generated as proto,
 };
-use crate::rpc::errors::RpcConversionError;
+use crate::rpc::errors::{AcceptHeaderError, GrpcError, RpcConversionError};
 use crate::transaction::ForeignAccount;
 
 mod api_client;
@@ -115,11 +117,8 @@ impl NodeRpcClient for TonicRpcClient {
 
         let mut rpc_api = self.ensure_connected().await?;
 
-        let api_response = rpc_api.submit_proven_transaction(request).await.map_err(|err| {
-            RpcError::RequestError(
-                NodeRpcClientEndpoint::SubmitProvenTx.to_string(),
-                err.to_string(),
-            )
+        let api_response = rpc_api.submit_proven_transaction(request).await.map_err(|status| {
+            RpcError::from_grpc_error(NodeRpcClientEndpoint::SubmitProvenTx, status)
         })?;
 
         Ok(BlockNumber::from(api_response.into_inner().block_height))
@@ -139,11 +138,8 @@ impl NodeRpcClient for TonicRpcClient {
 
         let mut rpc_api = self.ensure_connected().await?;
 
-        let api_response = rpc_api.get_block_header_by_number(request).await.map_err(|err| {
-            RpcError::RequestError(
-                NodeRpcClientEndpoint::GetBlockHeaderByNumber.to_string(),
-                err.to_string(),
-            )
+        let api_response = rpc_api.get_block_header_by_number(request).await.map_err(|status| {
+            RpcError::from_grpc_error(NodeRpcClientEndpoint::GetBlockHeaderByNumber, status)
         })?;
 
         let response = api_response.into_inner();
@@ -181,11 +177,8 @@ impl NodeRpcClient for TonicRpcClient {
 
         let mut rpc_api = self.ensure_connected().await?;
 
-        let api_response = rpc_api.get_notes_by_id(request).await.map_err(|err| {
-            RpcError::RequestError(
-                NodeRpcClientEndpoint::GetBlockHeaderByNumber.to_string(),
-                err.to_string(),
-            )
+        let api_response = rpc_api.get_notes_by_id(request).await.map_err(|status| {
+            RpcError::from_grpc_error(NodeRpcClientEndpoint::GetNotesById, status)
         })?;
 
         let response_notes = api_response
@@ -218,8 +211,8 @@ impl NodeRpcClient for TonicRpcClient {
 
         let mut rpc_api = self.ensure_connected().await?;
 
-        let response = rpc_api.sync_state(request).await.map_err(|err| {
-            RpcError::RequestError(NodeRpcClientEndpoint::SyncState.to_string(), err.to_string())
+        let response = rpc_api.sync_state(request).await.map_err(|status| {
+            RpcError::from_grpc_error(NodeRpcClientEndpoint::SyncState, status)
         })?;
         response.into_inner().try_into()
     }
@@ -240,11 +233,8 @@ impl NodeRpcClient for TonicRpcClient {
 
         let mut rpc_api = self.ensure_connected().await?;
 
-        let response = rpc_api.get_account_details(request).await.map_err(|err| {
-            RpcError::RequestError(
-                NodeRpcClientEndpoint::GetAccountDetails.to_string(),
-                err.to_string(),
-            )
+        let response = rpc_api.get_account_details(request).await.map_err(|status| {
+            RpcError::from_grpc_error(NodeRpcClientEndpoint::GetAccountDetails, status)
         })?;
         let response = response.into_inner();
         let account_summary = response.summary.ok_or(RpcError::ExpectedDataMissing(
@@ -315,11 +305,8 @@ impl NodeRpcClient for TonicRpcClient {
         let response = rpc_api
             .get_account_proofs(request)
             .await
-            .map_err(|err| {
-                RpcError::RequestError(
-                    NodeRpcClientEndpoint::GetAccountProofs.to_string(),
-                    err.to_string(),
-                )
+            .map_err(|status| {
+                RpcError::from_grpc_error(NodeRpcClientEndpoint::GetAccountProofs, status)
             })?
             .into_inner();
 
@@ -374,8 +361,8 @@ impl NodeRpcClient for TonicRpcClient {
 
         let mut rpc_api = self.ensure_connected().await?;
 
-        let response = rpc_api.sync_notes(request).await.map_err(|err| {
-            RpcError::RequestError(NodeRpcClientEndpoint::SyncNotes.to_string(), err.to_string())
+        let response = rpc_api.sync_notes(request).await.map_err(|status| {
+            RpcError::from_grpc_error(NodeRpcClientEndpoint::SyncNotes, status)
         })?;
 
         response.into_inner().try_into()
@@ -394,11 +381,8 @@ impl NodeRpcClient for TonicRpcClient {
 
         let mut rpc_api = self.ensure_connected().await?;
 
-        let response = rpc_api.check_nullifiers_by_prefix(request).await.map_err(|err| {
-            RpcError::RequestError(
-                NodeRpcClientEndpoint::CheckNullifiersByPrefix.to_string(),
-                err.to_string(),
-            )
+        let response = rpc_api.check_nullifiers_by_prefix(request).await.map_err(|status| {
+            RpcError::from_grpc_error(NodeRpcClientEndpoint::CheckNullifiersByPrefix, status)
         })?;
         let response = response.into_inner();
         let nullifiers = response
@@ -418,11 +402,8 @@ impl NodeRpcClient for TonicRpcClient {
 
         let mut rpc_api = self.ensure_connected().await?;
 
-        let response = rpc_api.check_nullifiers(request).await.map_err(|err| {
-            RpcError::RequestError(
-                NodeRpcClientEndpoint::CheckNullifiers.to_string(),
-                err.to_string(),
-            )
+        let response = rpc_api.check_nullifiers(request).await.map_err(|status| {
+            RpcError::from_grpc_error(NodeRpcClientEndpoint::CheckNullifiers, status)
         })?;
 
         let response = response.into_inner();
@@ -436,11 +417,8 @@ impl NodeRpcClient for TonicRpcClient {
 
         let mut rpc_api = self.ensure_connected().await?;
 
-        let response = rpc_api.get_block_by_number(request).await.map_err(|err| {
-            RpcError::RequestError(
-                NodeRpcClientEndpoint::GetBlockByNumber.to_string(),
-                err.to_string(),
-            )
+        let response = rpc_api.get_block_by_number(request).await.map_err(|status| {
+            RpcError::from_grpc_error(NodeRpcClientEndpoint::GetBlockByNumber, status)
         })?;
 
         let response = response.into_inner();
@@ -481,5 +459,45 @@ mod tests {
         let client = TonicRpcClient::new(endpoint, 10000);
         let client: Box<TonicRpcClient> = client.into();
         tokio::task::spawn(async move { dyn_trait_send_fut(client).await });
+    }
+}
+
+// ERRORS
+// ================================================================================================
+
+impl RpcError {
+    pub fn from_grpc_error(endpoint: NodeRpcClientEndpoint, status: Status) -> Self {
+        if let Some(accept_error) = AcceptHeaderError::try_from_message(&status.message()) {
+            return Self::AcceptHeaderError(accept_error);
+        }
+
+        let error_kind = GrpcError::from(&status);
+        let source = Box::new(status) as Box<dyn Error + Send + Sync + 'static>;
+
+        Self::GrpcError {
+            endpoint,
+            error_kind,
+            source: Some(source),
+        }
+    }
+}
+
+impl From<&Status> for GrpcError {
+    fn from(status: &Status) -> Self {
+        match status.code() {
+            tonic::Code::NotFound => GrpcError::NotFound,
+            tonic::Code::InvalidArgument => GrpcError::InvalidArgument,
+            tonic::Code::PermissionDenied => GrpcError::PermissionDenied,
+            tonic::Code::AlreadyExists => GrpcError::AlreadyExists,
+            tonic::Code::ResourceExhausted => GrpcError::ResourceExhausted,
+            tonic::Code::FailedPrecondition => GrpcError::FailedPrecondition,
+            tonic::Code::Cancelled => GrpcError::Cancelled,
+            tonic::Code::DeadlineExceeded => GrpcError::DeadlineExceeded,
+            tonic::Code::Unavailable => GrpcError::Unavailable,
+            tonic::Code::Internal => GrpcError::Internal,
+            tonic::Code::Unimplemented => GrpcError::Unimplemented,
+            tonic::Code::Unauthenticated => GrpcError::Unauthenticated,
+            _ => GrpcError::Unknown(format!("{:?}: {}", status.code(), status.message())),
+        }
     }
 }

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -453,21 +453,7 @@ impl RpcError {
 
 impl From<&Status> for GrpcError {
     fn from(status: &Status) -> Self {
-        match status.code() {
-            tonic::Code::NotFound => GrpcError::NotFound,
-            tonic::Code::InvalidArgument => GrpcError::InvalidArgument,
-            tonic::Code::PermissionDenied => GrpcError::PermissionDenied,
-            tonic::Code::AlreadyExists => GrpcError::AlreadyExists,
-            tonic::Code::ResourceExhausted => GrpcError::ResourceExhausted,
-            tonic::Code::FailedPrecondition => GrpcError::FailedPrecondition,
-            tonic::Code::Cancelled => GrpcError::Cancelled,
-            tonic::Code::DeadlineExceeded => GrpcError::DeadlineExceeded,
-            tonic::Code::Unavailable => GrpcError::Unavailable,
-            tonic::Code::Internal => GrpcError::Internal,
-            tonic::Code::Unimplemented => GrpcError::Unimplemented,
-            tonic::Code::Unauthenticated => GrpcError::Unauthenticated,
-            _ => GrpcError::Unknown(format!("{:?}: {}", status.code(), status.message())),
-        }
+        GrpcError::from_code(status.code() as i32, Some(status.message().to_string()))
     }
 }
 

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -467,7 +467,7 @@ mod tests {
 
 impl RpcError {
     pub fn from_grpc_error(endpoint: NodeRpcClientEndpoint, status: Status) -> Self {
-        if let Some(accept_error) = AcceptHeaderError::try_from_message(&status.message()) {
+        if let Some(accept_error) = AcceptHeaderError::try_from_message(status.message()) {
             return Self::AcceptHeaderError(accept_error);
         }
 


### PR DESCRIPTION
Closes #935. Also does some other smaller refactors like changing up some error variants.

As long as the node does not return more structured errors (sort of related: https://github.com/0xMiden/miden-node/issues/1106), we can't do without parsing the incoming message and giving it some more context in relation to the client (aka, basically all that can fail right now is either version not being compatible and genesis commitment not matching up). If somehow the message drifts away from what the node returns, the test should catch it.