### PR TITLE
tests: restore remote prover tests

### DIFF
--- a/crates/web-client/package.json
+++ b/crates/web-client/package.json
@@ -22,7 +22,7 @@
     "build": "rimraf dist && npm run build-rust-client-js && cross-env RUSTFLAGS=\"--cfg getrandom_backend=\\\"wasm_js\\\"\" rollup -c rollup.config.js && cpr js/types dist && node clean.js",
     "build-dev": "npm install && MIDEN_WEB_DEV=true npm run build",
     "test": "yarn playwright install --with-deps && yarn playwright test",
-    "test:remote_prover": "yarn install && yarn playwright install --with-deps && cross-env MIDEN_WEB_DEV=true yarn run build && cross-env REMOTE_PROVER=true && yarn playwright test -g 'with remote prover' ",
+    "test:remote_prover": "yarn install && yarn playwright install --with-deps && cross-env MIDEN_WEB_DEV=true yarn run build && cross-env REMOTE_PROVER=true yarn playwright test -g 'with remote prover' ",
     "test:clean": "yarn install && yarn playwright install --with-deps && MIDEN_WEB_DEV=true yarn run build && yarn playwright test"
   },
   "devDependencies": {

--- a/crates/web-client/package.json
+++ b/crates/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demox-labs/miden-sdk",
-  "version": "0.11.0-next.30",
+  "version": "0.11.0-next.31",
   "description": "Miden Wasm SDK",
   "collaborators": [
     "Miden",

--- a/crates/web-client/playwright.config.ts
+++ b/crates/web-client/playwright.config.ts
@@ -12,13 +12,11 @@ import { defineConfig, devices } from "@playwright/test";
  * See https://playwright.dev/docs/test-configuration.
  */
 
-const testMatch = "*.test.ts";
-
 export default defineConfig({
   timeout: 240_000,
   testDir: "./test",
   /* Run tests in files in parallel */
-  fullyParallel: true,
+  fullyParallel: process.env.REMOTE_PROVER ? false : true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */

--- a/crates/web-client/test/playwright.global.setup.ts
+++ b/crates/web-client/test/playwright.global.setup.ts
@@ -1,9 +1,10 @@
-// @ts-nocheck
+//@ts-nocheck
 import { test as base } from "@playwright/test";
 import { MockWebClient } from "../js";
 
 const TEST_SERVER_PORT = 8080;
 const MIDEN_NODE_PORT = 57291;
+const REMOTE_TX_PROVER_PORT = 50051;
 
 export const test = base.extend<{ forEachTest: void }>({
   forEachTest: [
@@ -82,7 +83,9 @@ export const test = base.extend<{ forEachTest: void }>({
             MockWebClient,
           } = await import("./index.js");
           let rpcUrl = `http://localhost:${MIDEN_NODE_PORT}`;
-          let proverUrl = undefined;
+          let proverUrl = remoteProverPort
+            ? `http://localhost:${remoteProverPort}`
+            : undefined;
           const client = await WebClient.createClient(rpcUrl, undefined);
 
           window.client = client;


### PR DESCRIPTION
## Description

After setting up playwright, there was a misconfiguration that caused the tests that had to be run with the remote prover to be run as if the remote prover wasn't specified. The issue was a missing env var in the package.json.