### PR TITLE
chore: refresh docs and bump SDK version

### DIFF
--- a/bin/integration-tests/README.md
+++ b/bin/integration-tests/README.md
@@ -153,3 +153,6 @@ pub async fn test_my_feature(client_config: ClientConfig) -> Result<()> {
 ```
 
 The build system will automatically discover this function and include it in both the test registry and generate tokio test wrappers.
+
+## License
+This project is [MIT licensed](../../LICENSE).

--- a/crates/web-client/package.json
+++ b/crates/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demox-labs/miden-sdk",
-  "version": "0.12.0",
+  "version": "0.12.0-next.1",
   "description": "Miden Wasm SDK",
   "collaborators": [
     "Miden",

--- a/docs/src/web-client/api/classes/RpcClient.md
+++ b/docs/src/web-client/api/classes/RpcClient.md
@@ -52,7 +52,7 @@ Fetches notes by their IDs from the connected Miden node.
 
 [`NoteId`](NoteId.md)[]
 
-Array of [`NoteId`] objects to fetch.
+Array of [`NoteId`] objects to fetch
 
 #### Returns
 


### PR DESCRIPTION
The docs check was failing on `next` so refreshing the docs so that it doesn't fail anymore. Also adding license section for the integration tests binary.