### PR TITLE
feat: Add a mutable getter for `TransactionRequest`'s advice map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.3 (2025-09-04)
+
+* Added a mutable getter for `TransactionRequest`'s advice map ([#1254](https://github.com/0xMiden/miden-client/pull/1254)).
+
 ## 0.11.2 (2025-09-02)
 
 * Added WASM bindings for the `Address` type from the miden_objects crate([#1244](https://github.com/0xMiden/miden-client/pull/1244)).

--- a/crates/rust-client/src/transaction/request/mod.rs
+++ b/crates/rust-client/src/transaction/request/mod.rs
@@ -187,6 +187,11 @@ impl TransactionRequest {
         &self.advice_map
     }
 
+    /// Returns a mutable reference to the [`AdviceMap`] for the transaction request.
+    pub fn advice_map_mut(&mut self) -> &mut AdviceMap {
+        &mut self.advice_map
+    }
+
     /// Returns the [`MerkleStore`] for the transaction request.
     pub fn merkle_store(&self) -> &MerkleStore {
         &self.merkle_store


### PR DESCRIPTION
Needed for multisig support:
```rust
pub async fn new_multisig_transaction(
    &mut self,
    account: Account,
    mut transaction_request: TransactionRequest,
    transaction_summary: TransactionSummary,
    signatures: Vec<Option<Vec<Felt>>>,
) -> Result<TransactionResult, MultisigClientError> {
    // Add signatures to the advice provider
    let advice_inputs = transaction_request.advice_map_mut(); // <----------- need this
    let msg = transaction_summary.to_commitment();
    let num_approvers: u32 = account.storage().get_item(0).unwrap().as_elements()[1]
        .try_into()
        .unwrap();

    for i in 0..num_approvers as usize {
        let pub_key_index_word = Word::from([Felt::from(i as u32), ZERO, ZERO, ZERO]);
        let pub_key = account
            .storage()
            .get_map_item(1, pub_key_index_word)
            .unwrap();
        let sig_key = Hasher::merge(&[pub_key, msg]);
        if let Some(signature) = signatures.get(i).and_then(|s| s.as_ref()) {
            advice_inputs.extend(vec![(sig_key, signature.clone())]); // <---- so that we can extend the map here
        }
    }
```

This is a non-breaking change, and ideally would be patch-released.

see https://github.com/0xMiden/miden-client/issues/1077 for more details