### PR TITLE
chore: remove redundant `Send` bound

### DIFF
--- a/crates/rust-client/src/builder.rs
+++ b/crates/rust-client/src/builder.rs
@@ -48,7 +48,7 @@ enum AuthenticatorConfig<AUTH> {
 /// uses `FilesystemKeyStore<rand::rngs::StdRng>`.
 pub struct ClientBuilder<AUTH> {
     /// An optional custom RPC client. If provided, this takes precedence over `rpc_endpoint`.
-    rpc_api: Option<Arc<dyn NodeRpcClient + Send>>,
+    rpc_api: Option<Arc<dyn NodeRpcClient>>,
     /// An optional store provided by the user.
     store: Option<Arc<dyn Store>>,
     /// An optional RNG provided by the user.
@@ -103,7 +103,7 @@ where
 
     /// Sets a custom RPC client directly.
     #[must_use]
-    pub fn rpc(mut self, client: Arc<dyn NodeRpcClient + Send>) -> Self {
+    pub fn rpc(mut self, client: Arc<dyn NodeRpcClient>) -> Self {
         self.rpc_api = Some(client);
         self
     }
@@ -182,7 +182,7 @@ where
     #[allow(clippy::unused_async, unused_mut)]
     pub async fn build(mut self) -> Result<Client<AUTH>, ClientError> {
         // Determine the RPC client to use.
-        let rpc_api: Arc<dyn NodeRpcClient + Send> = if let Some(client) = self.rpc_api {
+        let rpc_api: Arc<dyn NodeRpcClient> = if let Some(client) = self.rpc_api {
             client
         } else {
             return Err(ClientError::ClientInitializationError(

--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -255,7 +255,7 @@ pub struct Client<AUTH> {
     rng: ClientRng,
     /// An instance of [`NodeRpcClient`] which provides a way for the client to connect to the
     /// Miden node.
-    rpc_api: Arc<dyn NodeRpcClient + Send>,
+    rpc_api: Arc<dyn NodeRpcClient>,
     /// An instance of a [`LocalTransactionProver`] which will be the default prover for the
     /// client.
     tx_prover: Arc<LocalTransactionProver>,
@@ -302,7 +302,7 @@ where
     ///
     /// Returns an error if the client couldn't be instantiated.
     pub async fn new(
-        rpc_api: Arc<dyn NodeRpcClient + Send>,
+        rpc_api: Arc<dyn NodeRpcClient>,
         rng: Box<dyn FeltRng>,
         store: Arc<dyn Store>,
         authenticator: Option<Arc<AUTH>>,
@@ -349,7 +349,7 @@ where
     // --------------------------------------------------------------------------------------------
 
     #[cfg(any(test, feature = "testing"))]
-    pub fn test_rpc_api(&mut self) -> &mut Arc<dyn NodeRpcClient + Send> {
+    pub fn test_rpc_api(&mut self) -> &mut Arc<dyn NodeRpcClient> {
         &mut self.rpc_api
     }
 

--- a/crates/rust-client/src/sync/state_sync.rs
+++ b/crates/rust-client/src/sync/state_sync.rs
@@ -67,7 +67,7 @@ pub trait OnNoteReceived {
 /// in the sync response.
 pub struct StateSync {
     /// The RPC client used to communicate with the node.
-    rpc_api: Arc<dyn NodeRpcClient + Send>,
+    rpc_api: Arc<dyn NodeRpcClient>,
     /// Responsible for checking the relevance of notes and executing the
     /// [`OnNoteReceived`] callback when a new note inclusion is received.
     note_screener: Arc<dyn OnNoteReceived>,
@@ -86,7 +86,7 @@ impl StateSync {
     /// * `tx_graceful_blocks` - The number of blocks that are considered old enough to discard.
     /// * `note_screener` - The note screener used to check the relevance of notes.
     pub fn new(
-        rpc_api: Arc<dyn NodeRpcClient + Send>,
+        rpc_api: Arc<dyn NodeRpcClient>,
         note_screener: Arc<dyn OnNoteReceived>,
         tx_graceful_blocks: Option<u32>,
     ) -> Self {


### PR DESCRIPTION
`NodeRpcClient` is already `Send`