### PR TITLE
feat: Add callbacks to web keystore to store keys and request signatu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Bumped web-client version in package.json after merging main into next.
 * Added support for getting specific vault and storage elements from `Store` along with their proofs ([#1164](https://github.com/0xMiden/miden-client/pull/1164)).
 * Modified the RPC client to avoid reconnection when setting commitment header ([#1166](https://github.com/0xMiden/miden-client/pull/1166)).
+* Added remote key storage and signature requesting to the `WebKeyStore` ([#1267](https://github.com/0xMiden/miden-client/pull/1267))
 
 ## 0.11.2 (2025-09-02)
 

--- a/crates/rust-client/src/keystore/web_keystore.rs
+++ b/crates/rust-client/src/keystore/web_keystore.rs
@@ -5,6 +5,9 @@ use alloc::vec::Vec;
 use miden_lib::utils::{Deserializable, Serializable};
 use miden_tx::auth::SigningInputs;
 use rand::Rng;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::JsFuture;
+use wasm_bindgen_futures::js_sys::{Array, Function, Promise};
 
 use super::KeyStoreError;
 use crate::auth::{AuthSecretKey, TransactionAuthenticator};
@@ -18,15 +21,68 @@ use crate::{AuthenticationError, Felt, Word};
 pub struct WebKeyStore<R: Rng> {
     /// The random number generator used to generate signatures.
     rng: Arc<RwLock<R>>,
+    /// Optional JavaScript callbacks for remote key storage and signing.
+    callbacks: Option<Arc<JsCallbacks>>,
 }
+
+struct JsCallbacks {
+    get_key_cb: Option<Function>,
+    insert_key_cb: Option<Function>,
+    sign_cb: Option<Function>,
+}
+
+// Since Function is not Send/Sync, we need to explicitly mark our struct as Send + Sync
+// This is safe in WASM because it's single-threaded
+unsafe impl Send for JsCallbacks {}
+unsafe impl Sync for JsCallbacks {}
 
 impl<R: Rng> WebKeyStore<R> {
     /// Creates a new instance of the web keystore with the provided RNG.
     pub fn new(rng: R) -> Self {
-        WebKeyStore { rng: Arc::new(RwLock::new(rng)) }
+        WebKeyStore {
+            rng: Arc::new(RwLock::new(rng)),
+            callbacks: None,
+        }
+    }
+
+    /// Creates a new instance with optional JavaScript callbacks.
+    /// When provided, these callbacks override the default IndexedDB storage and local signing.
+    pub fn new_with_callbacks(
+        rng: R,
+        get_key_cb: Option<Function>,
+        insert_key_cb: Option<Function>,
+        sign_cb: Option<Function>,
+    ) -> Self {
+        WebKeyStore {
+            rng: Arc::new(RwLock::new(rng)),
+            callbacks: Some(Arc::new(JsCallbacks { get_key_cb, insert_key_cb, sign_cb })),
+        }
     }
 
     pub async fn add_key(&self, key: &AuthSecretKey) -> Result<(), KeyStoreError> {
+        if let Some(callbacks) = &self.callbacks {
+            if let Some(insert_key_cb) = &callbacks.insert_key_cb {
+                let pub_key = match &key {
+                    AuthSecretKey::RpoFalcon512(k) => Word::from(k.public_key()).to_hex(),
+                };
+                let secret_key_hex = hex::encode(key.to_bytes());
+
+                let result = insert_key_cb
+                    .call2(&JsValue::NULL, &JsValue::from(pub_key), &JsValue::from(secret_key_hex))
+                    .map_err(|err| {
+                        KeyStoreError::StorageError(format!("JS insertKey threw: {err:?}"))
+                    })?;
+
+                if let Some(promise) = result.dyn_ref::<Promise>() {
+                    JsFuture::from(promise.clone()).await.map_err(|_| {
+                        KeyStoreError::StorageError("Failed to insert key via callback".to_string())
+                    })?;
+                }
+
+                return Ok(());
+            }
+        }
+
         let pub_key = match &key {
             AuthSecretKey::RpoFalcon512(k) => Word::from(k.public_key()).to_hex(),
         };
@@ -40,6 +96,43 @@ impl<R: Rng> WebKeyStore<R> {
     }
 
     pub async fn get_key(&self, pub_key: Word) -> Result<Option<AuthSecretKey>, KeyStoreError> {
+        if let Some(callbacks) = &self.callbacks {
+            if let Some(get_key_cb) = &callbacks.get_key_cb {
+                let pub_key_str = pub_key.to_hex();
+                let call_result =
+                    get_key_cb.call1(&JsValue::NULL, &JsValue::from(pub_key_str)).map_err(
+                        |err| KeyStoreError::StorageError(format!("JS getKey threw: {err:?}")),
+                    )?;
+
+                let resolved = if let Some(promise) = call_result.dyn_ref::<Promise>() {
+                    JsFuture::from(promise.clone()).await.map_err(|_| {
+                        KeyStoreError::StorageError("Failed to get key via callback".to_string())
+                    })?
+                } else {
+                    call_result
+                };
+
+                if resolved.is_null() || resolved.is_undefined() {
+                    return Ok(None);
+                }
+
+                let secret_key_hex = resolved.as_string().ok_or_else(|| {
+                    KeyStoreError::DecodingError("Expected secret key hex string".to_string())
+                })?;
+
+                let secret_key_bytes = hex::decode(secret_key_hex).map_err(|err| {
+                    KeyStoreError::DecodingError(format!("error decoding secret key hex: {err:?}"))
+                })?;
+
+                let secret_key =
+                    AuthSecretKey::read_from_bytes(&secret_key_bytes).map_err(|err| {
+                        KeyStoreError::DecodingError(format!("error reading secret key: {err:?}"))
+                    })?;
+
+                return Ok(Some(secret_key));
+            }
+        }
+
         let pub_key_str = pub_key.to_hex();
         let secret_key_hex = get_account_auth_by_pub_key(pub_key_str).await.map_err(|err| {
             KeyStoreError::StorageError(format!("failed to get item from local storage: {err:?}"))
@@ -70,6 +163,54 @@ impl<R: Rng> TransactionAuthenticator for WebKeyStore<R> {
         pub_key: Word,
         signing_inputs: &SigningInputs,
     ) -> Result<Vec<Felt>, AuthenticationError> {
+        // If a JavaScript signing callback is provided, use it directly.
+        if let Some(callbacks) = &self.callbacks {
+            if let Some(sign_cb) = &callbacks.sign_cb {
+                let commitment_hex = signing_inputs.to_commitment().to_hex();
+                let pub_key_hex = pub_key.to_hex();
+
+                let call_result = sign_cb
+                    .call2(
+                        &JsValue::NULL,
+                        &JsValue::from(pub_key_hex),
+                        &JsValue::from(commitment_hex),
+                    )
+                    .map_err(|err| AuthenticationError::other(format!("JS sign threw: {err:?}")))?;
+
+                let resolved = if let Some(promise) = call_result.dyn_ref::<Promise>() {
+                    JsFuture::from(promise.clone()).await.map_err(|err| {
+                        AuthenticationError::other(format!("Failed to sign via callback: {err:?}"))
+                    })?
+                } else {
+                    call_result
+                };
+
+                let arr = Array::is_array(&resolved).then(|| Array::from(&resolved)).ok_or_else(
+                    || AuthenticationError::other("sign callback must return an array"),
+                )?;
+
+                let mut result: Vec<Felt> = Vec::with_capacity(arr.length() as usize);
+                for value in arr.iter() {
+                    if let Some(s) = value.as_string() {
+                        let n = s.parse::<u64>().map_err(|_| {
+                            AuthenticationError::other(
+                                "failed to parse signature element string as u64",
+                            )
+                        })?;
+                        result.push(Felt::new(n));
+                    } else if let Some(f) = value.as_f64() {
+                        result.push(Felt::new(f as u64));
+                    } else {
+                        return Err(AuthenticationError::other(
+                            "signature elements must be numbers or numeric strings",
+                        ));
+                    }
+                }
+
+                return Ok(result);
+            }
+        }
+
         let message = signing_inputs.to_commitment();
 
         let secret_key = self

--- a/crates/web-client/package.json
+++ b/crates/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demox-labs/miden-sdk",
-  "version": "0.12.0-next.4",
+  "version": "0.12.0-next.5",
   "description": "Miden Wasm SDK",
   "collaborators": [
     "Miden",

--- a/crates/web-client/src/mock.rs
+++ b/crates/web-client/src/mock.rs
@@ -26,7 +26,7 @@ impl WebClient {
             None => Arc::new(MockRpcApi::default()),
         };
 
-        self.setup_client(mock_rpc_api.clone(), seed).await?;
+        self.setup_client(mock_rpc_api.clone(), seed, None, None, None).await?;
 
         self.mock_rpc_api = Some(mock_rpc_api);
 

--- a/crates/web-client/test/global.test.d.ts
+++ b/crates/web-client/test/global.test.d.ts
@@ -74,6 +74,7 @@ declare global {
     MockWebClient: typeof MockWebClient;
     remoteProverUrl?: string;
     remoteProverInstance: TransactionProver;
+    rpcUrl?: string;
     Account: typeof Account;
     AccountBuilder: typeof AccountBuilder;
     AccountComponent: typeof AccountComponent;

--- a/crates/web-client/test/playwright.global.setup.ts
+++ b/crates/web-client/test/playwright.global.setup.ts
@@ -165,6 +165,7 @@ export const test = base.extend<{ forEachTest: void }>({
           window.helpers = window.helpers || {};
 
           // Add the remote prover url to window
+          window.rpcUrl = rpcUrl;
           window.remoteProverUrl = proverUrl;
           if (window.remoteProverUrl) {
             window.remoteProverInstance =

--- a/crates/web-client/test/remote_keystore.test.ts
+++ b/crates/web-client/test/remote_keystore.test.ts
@@ -1,0 +1,65 @@
+import test from "./playwright.global.setup";
+
+import { expect } from "@playwright/test";
+
+test.describe.only("remote keystore", () => {
+  test("should create a client with a remote keystore", async ({ page }) => {
+    const client = await page.evaluate(async () => {
+      const insertKeyCb = async (_publicKey: string, _secretKey: string) => {};
+      const getKeyCb = async (_publicKey: string) => {
+        return undefined;
+      };
+      const signCb = async (_publicKey: string, _message: string) => {
+        return undefined;
+      };
+      const client = await window.WebClient.createClientWithExternalKeystore(
+        window.rpcUrl,
+        undefined,
+        insertKeyCb,
+        getKeyCb,
+        signCb
+      );
+      return client;
+    });
+    console.log("client", client);
+    expect(client).toBeDefined();
+  });
+
+  test("should create a client with a remote keystore and insert a key", async ({
+    page,
+  }) => {
+    const { publicKey, secretKey, publicKeySerialized, secretKeySerialized } =
+      await page.evaluate(async () => {
+        let publicKey: string | undefined;
+        let secretKey: string | undefined;
+        const insertKeyCb = async (
+          publicKeyStr: string,
+          secretKeyStr: string
+        ) => {
+          publicKey = publicKeyStr;
+          secretKey = secretKeyStr;
+        };
+        const client = await window.WebClient.createClientWithExternalKeystore(
+          window.rpcUrl,
+          undefined,
+          undefined,
+          insertKeyCb,
+          undefined
+        );
+        await client.newWallet(
+          window.AccountStorageMode.private(),
+          true,
+          undefined
+        );
+
+        return {
+          publicKey,
+          secretKey,
+        };
+      });
+    console.log("publicKey", publicKey);
+    console.log("secretKey", secretKey);
+    expect(publicKey).toBeDefined();
+    expect(secretKey).toBeDefined();
+  });
+});


### PR DESCRIPTION
…res externally

There's still a lot of cleanup to do, so ready for detailed feedback.

Probably the biggest question is how to handle the serialization between the `web_keystore` and the models inside of the web client. Because the web store is inside of the Rust client, we have to define our own serialization here instead of being able to use models that we create inside of the web client. This doesn't feel ideal and I'm wondering if we should move the `web_keystore` into the web client.