### PR TITLE
fix: fpi tests

### DIFF
--- a/bin/integration-tests/src/tests/fpi.rs
+++ b/bin/integration-tests/src/tests/fpi.rs
@@ -54,9 +54,6 @@ pub async fn test_fpi_execute_program(client_config: ClientConfig) -> Result<()>
     .await?;
     let foreign_account_id = foreign_account.id();
 
-    let (wallet, ..) =
-        insert_new_wallet(&mut client, AccountStorageMode::Private, &keystore).await?;
-
     let code = format!(
         "
         use.miden::tx
@@ -77,15 +74,20 @@ pub async fn test_fpi_execute_program(client_config: ClientConfig) -> Result<()>
     );
 
     let tx_script = client.script_builder().compile_tx_script(&code)?;
-    _ = client.sync_state().await?;
+    client.sync_state().await?;
 
     // Wait for a couple of blocks so that the account gets committed
-    _ = wait_for_blocks(&mut client, 2).await;
+    wait_for_blocks(&mut client, 2).await;
 
     let storage_requirements =
         AccountStorageRequirements::new([(1u8, &[StorageMapKey::from(MAP_KEY)])]);
 
-    let output_stack = client
+    let (mut client2, keystore2) = ClientConfig::default().into_client().await?;
+
+    let (wallet, ..) =
+        insert_new_wallet(&mut client2, AccountStorageMode::Private, &keystore2).await?;
+
+    let output_stack = client2
         .execute_program(
             wallet.id(),
             tx_script,
@@ -157,9 +159,6 @@ pub async fn test_nested_fpi_calls(client_config: ClientConfig) -> Result<()> {
 
     println!("Calling FPI function inside a FPI function with new account");
 
-    let (native_account, _native_seed, _) =
-        insert_new_wallet(&mut client, AccountStorageMode::Public, &keystore).await?;
-
     let tx_script = format!(
         "
         use.miden::tx
@@ -200,9 +199,15 @@ pub async fn test_nested_fpi_calls(client_config: ClientConfig) -> Result<()> {
     ];
 
     let tx_request = builder.foreign_accounts(foreign_accounts).build()?;
-    let tx_result = client.new_transaction(native_account.id(), tx_request).await?;
 
-    client.submit_transaction(tx_result).await?;
+    let (mut client2, keystore2) = ClientConfig::default().into_client().await?;
+
+    let (native_account, _native_seed, _) =
+        insert_new_wallet(&mut client2, AccountStorageMode::Public, &keystore2).await?;
+
+    let tx_result = client2.new_transaction(native_account.id(), tx_request).await?;
+
+    client2.submit_transaction(tx_result).await?;
     Ok(())
 }
 
@@ -241,9 +246,6 @@ async fn standard_fpi(storage_mode: AccountStorageMode, client_config: ClientCon
 
     println!("Calling FPI functions with new account");
 
-    let (native_account, _native_seed, _) =
-        insert_new_wallet(&mut client, AccountStorageMode::Public, &keystore).await?;
-
     let tx_script = format!(
         "
         use.miden::tx
@@ -266,10 +268,10 @@ async fn standard_fpi(storage_mode: AccountStorageMode, client_config: ClientCon
     );
 
     let tx_script = ScriptBuilder::new(true).compile_tx_script(tx_script)?;
-    _ = client.sync_state().await?;
+    client.sync_state().await?;
 
     // Wait for a couple of blocks so that the account gets committed
-    _ = wait_for_blocks(&mut client, 2).await;
+    wait_for_blocks(&mut client, 2).await;
 
     // Before the transaction there are no cached foreign accounts
     let foreign_accounts =
@@ -297,17 +299,19 @@ async fn standard_fpi(storage_mode: AccountStorageMode, client_config: ClientCon
 
     let tx_request = builder.foreign_accounts([foreign_account?]).build()?;
 
-    // Create a fresh client to prove with a fresh LocalTransactionProver
-    // (see miden-base/issues/1865 for more details)
-    let (mut client, _keystore) = client_config.clone().into_client().await?;
-    let tx_result = client.new_transaction(native_account.id(), tx_request).await?;
+    let (mut client2, keystore2) = ClientConfig::default().into_client().await?;
 
-    client.submit_transaction(tx_result).await?;
+    let (native_account, _native_seed, _) =
+        insert_new_wallet(&mut client2, AccountStorageMode::Public, &keystore2).await?;
+
+    let tx_result = client2.new_transaction(native_account.id(), tx_request).await?;
+
+    client2.submit_transaction(tx_result).await?;
 
     // After the transaction the foreign account should be cached (for public accounts only)
     if storage_mode == AccountStorageMode::Public {
         let foreign_accounts =
-            client.test_store().get_foreign_account_code(vec![foreign_account_id]).await?;
+            client2.test_store().get_foreign_account_code(vec![foreign_account_id]).await?;
         assert_eq!(foreign_accounts.len(), 1);
     }
     Ok(())

--- a/crates/rust-client/src/store/sqlite_store/account.rs
+++ b/crates/rust-client/src/store/sqlite_store/account.rs
@@ -178,12 +178,13 @@ impl SqliteStore {
     ) -> Result<(), StoreError> {
         let tx = conn.transaction()?;
 
+        Self::insert_account_code(&tx, code)?;
+
         const QUERY: &str =
             insert_sql!(foreign_account_code { account_id, code_commitment } | REPLACE);
 
         tx.execute(QUERY, params![account_id.to_hex(), code.commitment().to_string()])?;
 
-        Self::insert_account_code(&tx, code)?;
         Ok(tx.commit()?)
     }
 


### PR DESCRIPTION
This PR changes the FPI tests so that they use fresh clients when executing the transactions, it also fixes a small bug encountered related to the order of insertions in the Sqlite store.