### PR TITLE
chore: re-export all auth components from miden-lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.11.5
 
 * Added a way to retrieve a secret key in the client given a pub key ([#1293](https://github.com/0xMiden/miden-client/pull/1293))
+* Reexport all authentication components from `miden-lib` ([#1297](https://github.com/0xMiden/miden-client/pull/1297)).
 
 ## 0.11.4 (2025-09-11)
 

--- a/crates/rust-client/src/account/mod.rs
+++ b/crates/rust-client/src/account/mod.rs
@@ -73,7 +73,7 @@ use crate::store::{AccountRecord, AccountStatus};
 pub mod component {
     pub const COMPONENT_TEMPLATE_EXTENSION: &str = "mct";
 
-    pub use miden_lib::account::auth::AuthRpoFalcon512;
+    pub use miden_lib::account::auth::*;
     pub use miden_lib::account::faucets::{BasicFungibleFaucet, FungibleFaucetExt};
     pub use miden_lib::account::wallets::BasicWallet;
     pub use miden_objects::account::{


### PR DESCRIPTION
If my application relies only on the `miden-client` dependency (i.e. not on `miden-lib`), I'd like the ability to use all the different auth component types, not just `AuthRpoFalcon512`

can be patch released