### PR TITLE
Add Signature to List of Exported Types in index.d.ts

### DIFF
--- a/crates/web-client/js/types/index.d.ts
+++ b/crates/web-client/js/types/index.d.ts
@@ -57,6 +57,7 @@ export {
   RpcClient,
   SecretKey,
   SerializedAccountHeader,
+  Signature,
   SigningInputs,
   SlotAndKeys,
   SlotAndKeysArray,

--- a/crates/web-client/package.json
+++ b/crates/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demox-labs/miden-sdk",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "Miden Wasm SDK",
   "collaborators": [
     "Miden",


### PR DESCRIPTION
The `Signature` type is missing from the list of exported types in `index.d.ts`. This PR just adds it! I will file an issue to see if we can auto-generate this file in the future as this happens quite frequently. 