### PR TITLE
feat: dyn `NoteConsumabilityChecker` in client builder

### DIFF
--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -243,6 +243,8 @@ use rand::RngCore;
 use rpc::NodeRpcClient;
 use store::Store;
 
+use crate::note::NoteConsumabilityChecker;
+
 // MIDEN CLIENT
 // ================================================================================================
 
@@ -275,6 +277,8 @@ pub struct Client<AUTH> {
     /// Maximum number of blocks the client can be behind the network for transactions and account
     /// proofs to be considered valid.
     max_block_number_delta: Option<u32>,
+    /// Checker used to determine note consumability by executing test transactions.
+    checker: Arc<dyn NoteConsumabilityChecker>,
 }
 
 /// Construction and access methods.
@@ -313,6 +317,7 @@ where
         store: Arc<dyn Store>,
         authenticator: Option<Arc<AUTH>>,
         exec_options: ExecutionOptions,
+        checker: Arc<dyn NoteConsumabilityChecker>,
         tx_graceful_blocks: Option<u32>,
         max_block_number_delta: Option<u32>,
     ) -> Result<Self, ClientError> {
@@ -330,6 +335,7 @@ where
             tx_prover,
             authenticator,
             exec_options,
+            checker,
             tx_graceful_blocks,
             max_block_number_delta,
         })

--- a/crates/rust-client/src/note/consumability_checker.rs
+++ b/crates/rust-client/src/note/consumability_checker.rs
@@ -1,0 +1,89 @@
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+
+use miden_lib::account::interface::AccountInterface;
+use miden_objects::account::Account;
+use miden_objects::note::Note;
+use miden_tx::auth::TransactionAuthenticator;
+use miden_tx::{NoteConsumptionChecker, TransactionExecutor};
+
+use super::note_screener::NoteScreenerError;
+use crate::note::NoteRelevance;
+use crate::store::Store;
+use crate::store::data_store::ClientDataStore;
+use crate::transaction::TransactionRequestBuilder;
+
+/// Lightweight result type for note execution checks used by the client.
+#[derive(Debug, Default, Clone)]
+pub struct NoteExecutionCheck {
+    pub successful: Vec<Note>,
+    pub failed: Vec<Note>,
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+pub trait NoteConsumabilityChecker: Send + Sync {
+    async fn check_notes_consumability(
+        &self,
+        account: &Account,
+        note: &Note,
+    ) -> Result<Option<NoteRelevance>, NoteScreenerError>;
+}
+
+/// Default adapter that mirrors today's behavior using the base NoteConsumptionChecker.
+pub struct StandardConsumabilityChecker<AUTH> {
+    store: Arc<dyn Store>,
+    authenticator: Arc<AUTH>,
+}
+
+impl<AUTH> StandardConsumabilityChecker<AUTH> {
+    pub fn new(store: Arc<dyn Store>, authenticator: Arc<AUTH>) -> Self {
+        Self { store, authenticator }
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<AUTH> NoteConsumabilityChecker for StandardConsumabilityChecker<AUTH>
+where
+    AUTH: TransactionAuthenticator + Sync + Send,
+{
+    async fn check_notes_consumability(
+        &self,
+        account: &Account,
+        note: &Note,
+    ) -> Result<Option<NoteRelevance>, NoteScreenerError> {
+        let transaction_request =
+            TransactionRequestBuilder::new().build_consume_notes(vec![note.id()])?;
+
+        let tx_script = transaction_request.build_transaction_script(
+            &AccountInterface::from(account),
+            crate::DebugMode::Enabled,
+        )?;
+
+        let tx_args = transaction_request.clone().into_transaction_args(tx_script, vec![]);
+
+        // Build a fresh executor per call to avoid lifetime issues.
+        let data_store = ClientDataStore::new(self.store.clone());
+        let mut transaction_executor = TransactionExecutor::new(&data_store);
+        transaction_executor = transaction_executor.with_authenticator(self.authenticator.as_ref());
+
+        let consumption_checker = NoteConsumptionChecker::new(&transaction_executor);
+
+        data_store.mast_store().load_account_code(account.code());
+        let note_execution_check = consumption_checker
+            .check_notes_consumability(
+                account.id(),
+                self.store.get_sync_height().await?,
+                vec![note.clone()],
+                tx_args,
+            )
+            .await?;
+
+        if !note_execution_check.successful.is_empty() {
+            return Ok(Some(NoteRelevance::Now));
+        }
+        Ok(None)
+    }
+}

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -121,7 +121,7 @@ where
     pub async fn sync_state(&mut self) -> Result<SyncSummary, ClientError> {
         _ = self.ensure_genesis_in_place().await?;
 
-        let note_screener = NoteScreener::new(self.store.clone(), self.authenticator.clone());
+        let note_screener = NoteScreener::new(self.store.clone(), self.checker.clone());
         let state_sync =
             StateSync::new(self.rpc_api.clone(), Arc::new(note_screener), self.tx_graceful_blocks);
 

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -875,7 +875,7 @@ where
 
         // New relevant input notes
         let mut new_input_notes = vec![];
-        let note_screener = NoteScreener::new(self.store.clone(), self.authenticator.clone());
+        let note_screener = NoteScreener::new(self.store.clone(), self.checker.clone());
 
         for note in notes_from_output(executed_tx.output_notes()) {
             // TODO: check_relevance() should have the option to take multiple notes


### PR DESCRIPTION
Creates a new trait `NoteConsumabilityChecker` in miden-client.
Then, it enables the client builder to specify the `NoteConsumabilityChecker` to construct a new `Client` instance.
By default, we use the current implementation (standard checker), but it can be replaced, so for example, we can rather easily create a specialized checker for the client used in the multisig application.
The public API for the `Client` doesn't change, only how the builder initializes the client (internal details)

As a side effect, `NoteScreener` no longer holds an authenticator.

---

Then, this can quite easily compliment https://github.com/0xMiden/miden-base/issues/1881. We'd need to either:
1. expose `TransactionCheckerError` and `NoteConsumptionChecker::try_execute_notes` to be public, or 
2. create a new `NoteConsumptionChecker::try_execute_till_epilogue` (name TBD)

For 1., then it's easy to create a checker for multisig in miden-client

```rust
pub struct MultisigConsumabilityChecker {
    store: Arc<dyn Store>,
}

impl MultisigConsumabilityChecker {
    pub fn new(store: Arc<dyn Store>) -> Self {
        Self { store }
    }
}

#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
impl NoteConsumabilityChecker for MultisigConsumabilityChecker {
    async fn check_notes_consumability(
        &self,
        account: &Account,
        note: &Note,
    ) -> Result<Option<NoteRelevance>, NoteScreenerError> {
        let transaction_request =
            TransactionRequestBuilder::new().build_consume_notes(vec![note.id()])?;

        let tx_script = transaction_request.build_transaction_script(
            &AccountInterface::from(account),
            crate::DebugMode::Enabled,
        )?;

        let tx_args = transaction_request.clone().into_transaction_args(tx_script, vec![]);

        // Build a fresh executor per call to avoid lifetime issues.
        let data_store = ClientDataStore::new(self.store.clone());
        let mut transaction_executor = TransactionExecutor::new(&data_store);

        let consumption_checker = NoteConsumptionChecker::new(&transaction_executor);

        let note_execution_check = consumption_checker
            .try_execute_notes( // <-------------- need this public
                account.id(),
                self.store.get_sync_height().await?,
                vec![note.clone()],
                tx_args,
            )
            .await;

        match note_execution_check { // 
            Err(err) => { <---------- also need this error (TransactionCheckerError) to be public
                let tx_execution_error = err.into(); // we have From<TransactionCheckerError> for TransactionExecutorError

                match tx_execution_error {
                    // otherwise match on Unauthorized
                    TransactionExecutorError::Unauthorized(_) => {
                        return Ok(Some(NoteRelevance::Now));
                    },
                    _ => {
                        return Err(NoteScreenerError::CustomCheckerError(
                            "expected a dry run, but tx was executed".into(),
                        ));
                    },
                }
            },
            _ => {
                // This should not happen for multisig
                return Err(NoteScreenerError::CustomCheckerError(
                    "expected a dry run, but tx was executed".into(),
                ));
            },
        }
    }
}
```

For option 2., we'd do something similar, but encapsulate most of the above error handling logic in miden-base instead.


closes #1316 