### PR TITLE
Remove redundant duplicate insert_account_code call in upsert_foreign_account_code

### DIFF
--- a/crates/sqlite-store/src/account.rs
+++ b/crates/sqlite-store/src/account.rs
@@ -210,8 +210,6 @@ impl SqliteStore {
 
         tx.execute(QUERY, params![account_id.to_hex(), code.commitment().to_string()])
             .into_store_error()?;
-
-        Self::insert_account_code(&tx, code)?;
         tx.commit().into_store_error()
     }
 


### PR DESCRIPTION
The function inserted into account_code both before and after upserting into foreign_account_code. The second call is redundant because:
- the first INSERT IGNORE ensures the required FK (code_commitment → account_code) exists before the mapping write;
- the second call has no side effects and adds unnecessary overhead;
- mirrors the IndexedDB implementation that writes code once, then upserts the mapping.