### PR TITLE
Fix broken relative links in RPC client docs example

### DIFF
--- a/docs/src/web-client/examples/rpc_client.md
+++ b/docs/src/web-client/examples/rpc_client.md
@@ -23,9 +23,9 @@ try {
 
 For more detailed information about the classes and methods used in these examples, refer to the following API documentation:
 
-- [Endpoint](docs/src/web-client/api/classes/Endpoint.md) - Represents a network endpoint for the RPC client.
-- [RpcClient](docs/src/web-client/api/classes/RpcClient.md) - Client for interacting with a Miden node via RPC.
-- [NoteId](docs/src/web-client/api/classes/NoteId.md) - Represents a unique identifier for a note.
+- [Endpoint](../api/classes/Endpoint.md) - Represents a network endpoint for the RPC client.
+- [RpcClient](../api/classes/RpcClient.md) - Client for interacting with a Miden node via RPC.
+- [NoteId](../api/classes/NoteId.md) - Represents a unique identifier for a note.
 
-For a complete list of available classes and utilities, see the [SDK API Reference](docs/src/web-client/api/README.md).
+For a complete list of available classes and utilities, see the [SDK API Reference](../api/README.md).
 


### PR DESCRIPTION
This PR corrects four links in docs/src/web-client/examples/rpc_client.md from docs/src/web-client/api/... to ../api/.... Markdown resolves links relative to the current file; the old form expands to docs/src/web-client/examples/docs/src/web-client/api/... and 404s on GitHub and mdBook. The ../api/... form correctly targets docs/src/web-client/api/ and works across preview/build. Scope is docs-only with zero runtime impact.

Before:
<img width="2404" height="1094" alt="image" src="https://github.com/user-attachments/assets/45a3c0fd-3200-47e0-b45c-6ea7e91597ec" />

After:
<img width="2376" height="1182" alt="image" src="https://github.com/user-attachments/assets/c01f2489-cfce-42ae-9049-35c5752fef35" />
