### PR TITLE
feat: relax constraints to allow inflight tx

### DIFF
--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -98,7 +98,6 @@ use crate::store::{
     InputNoteState,
     NoteFilter,
     OutputNoteRecord,
-    StoreError,
     TransactionFilter,
 };
 use crate::sync::NoteTagRecord;
@@ -755,13 +754,6 @@ where
 
         if account_record.is_locked() {
             return Err(ClientError::AccountLocked(account_id));
-        }
-
-        let final_commitment = tx_result.executed_transaction().final_account().commitment();
-        if self.store.get_account_header_by_commitment(final_commitment).await?.is_some() {
-            return Err(ClientError::StoreError(StoreError::AccountCommitmentAlreadyExists(
-                final_commitment,
-            )));
         }
 
         let note_updates = self.get_note_updates(submission_height, &tx_result).await?;

--- a/crates/sqlite-store/src/store.sql
+++ b/crates/sqlite-store/src/store.sql
@@ -66,9 +66,7 @@ CREATE TABLE accounts (
     account_seed BLOB NULL,                     -- Account seed used to generate the ID. Expected to be NULL for non-new accounts
     locked BOOLEAN NOT NULL,                    -- True if the account is locked, false if not.
     PRIMARY KEY (account_commitment),
-    FOREIGN KEY (code_commitment) REFERENCES account_code(commitment),
-
-    CONSTRAINT check_seed_nonzero CHECK (NOT (nonce = 0 AND account_seed IS NULL))
+    FOREIGN KEY (code_commitment) REFERENCES account_code(commitment)
 );
 
 CREATE UNIQUE INDEX idx_account_commitment ON accounts(account_commitment);
@@ -104,7 +102,7 @@ CREATE TABLE input_notes (
     state BLOB NOT NULL,                                    -- serialized note state
     created_at UNSIGNED BIG INT NOT NULL,                   -- timestamp of the note creation/import
 
-    PRIMARY KEY (note_id)
+    PRIMARY KEY (note_id),
     FOREIGN KEY (script_root) REFERENCES notes_scripts(script_root)
 );
 
@@ -165,4 +163,4 @@ CREATE TABLE partial_blockchain_nodes (
     id UNSIGNED BIG INT NOT NULL,   -- in-order index of the internal MMR node
     node BLOB NOT NULL,             -- internal node value (commitment)
     PRIMARY KEY (id)
-)
+);


### PR DESCRIPTION
Fix support for in-flight transactions (e.g. orderbook matcher accounts) by allowing transactions that don’t change account state to not error in `apply_transaction` due to store constraints:
1. account commitment can be unchanged, 
2. nonce can stay 0 on non-new accounts

closes #1334 