### PR TITLE
feat: prevent account prefix collisions in add_account

### DIFF
--- a/crates/rust-client/src/errors.rs
+++ b/crates/rust-client/src/errors.rs
@@ -43,6 +43,10 @@ pub enum ClientError {
     AccountIsPrivate(AccountId),
     #[error("account nonce is too low to import")]
     AccountNonceTooLow,
+    #[error(
+        "account prefix collision: account {0} has the same 16-bit prefix as existing account {1}"
+    )]
+    AccountPrefixCollision(AccountId, AccountId),
     #[error("asset error")]
     AssetError(#[from] AssetError),
     #[error("account data wasn't found for account id {0}")]


### PR DESCRIPTION
- Added prefix collision detection in `Client::add_account()` to prevent adding accounts with similar prefixes.
Implementation
- Added `ClientError::AccountPrefixCollision(AccountId, AccountId)`
- `check_prefix_collision()` compares new account prefix with existing tracked accounts
- Called during `add_account()` for new accounts only
