### PR TITLE
chore: preapre patch v0.11.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.8 (2025-09-29)
+
+* Added `serialize` and `deserialize` methods for `NoteScript` [(#1117)](https://github.com/0xMiden/miden-client/pull/1117).
+
 ## 0.11.7 (2025-09-26)
 
 * Fixed an issue where `AccountId` was being left as null-pointer ([#1340](https://github.com/0xMiden/miden-client/pull/1340)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2180,7 +2180,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-cli"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2204,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-integration-tests"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2221,7 +2221,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-web"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "miden-client",
  "miden-lib",
@@ -2906,7 +2906,7 @@ dependencies = [
 
 [[package]]
 name = "node-builder"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "anyhow",
  "miden-lib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ edition      = "2024"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/miden-client"
 rust-version = "1.88"
-version      = "0.11.7"
+version      = "0.11.8"
 
 [workspace.dependencies]
 # Miden dependencies

--- a/crates/web-client/package.json
+++ b/crates/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demox-labs/miden-sdk",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "description": "Miden Wasm SDK",
   "collaborators": [
     "Miden",

--- a/crates/web-client/src/models/note_script.rs
+++ b/crates/web-client/src/models/note_script.rs
@@ -1,8 +1,10 @@
 use miden_client::note::{NoteScript as NativeNoteScript, WellKnownNote};
 use miden_objects::PrettyPrint;
 use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::js_sys::Uint8Array;
 
 use super::word::Word;
+use crate::utils::{deserialize_from_uint8array, serialize_to_uint8array};
 
 #[derive(Clone)]
 #[wasm_bindgen]
@@ -15,6 +17,14 @@ impl NoteScript {
     #[allow(clippy::inherent_to_string)]
     pub fn to_string(&self) -> String {
         self.0.to_pretty_string()
+    }
+
+    pub fn serialize(&self) -> Uint8Array {
+        serialize_to_uint8array(&self.0)
+    }
+
+    pub fn deserialize(bytes: &Uint8Array) -> Result<NoteScript, JsValue> {
+        deserialize_from_uint8array::<NativeNoteScript>(bytes).map(NoteScript)
     }
 
     pub fn p2id() -> Self {

--- a/docs/src/web-client/api/classes/NoteScript.md
+++ b/docs/src/web-client/api/classes/NoteScript.md
@@ -28,6 +28,16 @@
 
 ***
 
+### serialize()
+
+> **serialize**(): `Uint8Array`
+
+#### Returns
+
+`Uint8Array`
+
+***
+
 ### toString()
 
 > **toString**(): `string`
@@ -37,6 +47,22 @@ Print the MAST source for this script.
 #### Returns
 
 `string`
+
+***
+
+### deserialize()
+
+> `static` **deserialize**(`bytes`): `NoteScript`
+
+#### Parameters
+
+##### bytes
+
+`Uint8Array`
+
+#### Returns
+
+`NoteScript`
 
 ***
 


### PR DESCRIPTION
We [missed this](https://github.com/0xMiden/miden-client/pull/1117#issuecomment-3306368975) earlier, needed to unblock a builder team.

Note: I bumped rust client's version too to keep them consistent, but there are actually no changes on the rust client.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `serialize`/`deserialize` to web client `NoteScript`, updates API docs, and bumps changelog to v0.11.8.
> 
> - **Web Client**:
>   - **`NoteScript`**:
>     - Add `serialize()` returning `Uint8Array`.
>     - Add static `deserialize(bytes: Uint8Array)`.
> - **Docs**:
>   - Update `docs/src/web-client/api/classes/NoteScript.md` to document `serialize` and static `deserialize`.
> - **Changelog**:
>   - Add `0.11.8` entry noting new `NoteScript` serialization APIs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2301f73d0e72e994d57c0671a81c20c98d8c0cfa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->