### PR TITLE
chore: compilation flag

### DIFF
--- a/crates/web-client/rollup.config.js
+++ b/crates/web-client/rollup.config.js
@@ -17,7 +17,7 @@ const baseCargoArgs = [
   "--features",
   "testing",
   "--config",
-  `build.rustflags=["-C", "target-feature=+atomics,+bulk-memory,+mutable-globals", "-C", "link-arg=--max-memory=4294967296"]`,
+  `build.rustflags=["-C", "target-feature=+atomics,+bulk-memory,+mutable-globals", "-C", "link-arg=--max-memory=4294967296", "-Z", "unstable-options", "-C", "panic=immediate-abort"]`,
   "--no-default-features",
 ];
 


### PR DESCRIPTION
I think this solves the [error we've been seeing when merging to `next`](https://github.com/0xMiden/miden-client/actions/runs/18048215005/job/51364096673):

```
error: panic_immediate_abort is now a real panic strategy! Enable it with the compiler flags `-Zunstable-options -Cpanic=immediate-abort`
  --> /home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panicking.rs:36:1
   |
36 | / compile_error!(
37 | |     "panic_immediate_abort is now a real panic strategy! \
38 | |     Enable it with the compiler flags `-Zunstable-options -Cpanic=immediate-abort`"
39 | | );
   | |_^
```

See [this PR](https://github.com/rust-lang/rust/pull/146317) for more context