### PR TITLE
chore(CLI): remove genesis block retrieval

### DIFF
--- a/crates/rust-client/src/sync/block_header.rs
+++ b/crates/rust-client/src/sync/block_header.rs
@@ -16,7 +16,7 @@ use crate::{Client, ClientError};
 impl<AUTH> Client<AUTH> {
     /// Attempts to retrieve the genesis block from the store. If not found,
     /// it requests it from the node and store it.
-    pub(crate) async fn ensure_genesis_in_place(&mut self) -> Result<BlockHeader, ClientError> {
+    pub async fn ensure_genesis_in_place(&mut self) -> Result<BlockHeader, ClientError> {
         let genesis = match self.store.get_block_header_by_num(0.into()).await? {
             Some((block, _)) => block,
             None => self.retrieve_and_store_genesis().await?,

--- a/crates/testing/miden-client-tests/src/tests.rs
+++ b/crates/testing/miden-client-tests/src/tests.rs
@@ -2080,7 +2080,8 @@ async fn account_addresses_non_basic_wallet() {
 pub async fn create_test_client()
 -> (MockClient<FilesystemKeyStore<StdRng>>, MockRpcApi, FilesystemKeyStore<StdRng>) {
     let (builder, rpc_api, keystore) = Box::pin(create_test_client_builder()).await;
-    let client = builder.build().await.unwrap();
+    let mut client = builder.build().await.unwrap();
+    client.ensure_genesis_in_place().await.unwrap();
 
     (client, rpc_api, keystore)
 }


### PR DESCRIPTION
This is not really needed, so removing it. I think it might have been introduced when accounts required an anchor block. Because of the version checks in the gRPC connections, this was blocking doing things like `miden-client info` when the versions did not match for example which was not nice