### PR TITLE
chore: add test-dev profile to `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ repository   = "https://github.com/0xMiden/miden-client"
 rust-version = "1.89"
 version      = "0.12.0"
 
+[profile.test-dev]
+inherits  = "dev"
+opt-level = 1
+
 [workspace.dependencies]
 # Miden base/protocol dependencies
 miden-lib     = { branch = "next", default-features = false, git = "https://github.com/0xMiden/miden-base" }


### PR DESCRIPTION
As in `miden-base` for good balance of local development and integration test times