### PR TITLE
chore: update `new-account` & `new-wallet` docs re:package

### DIFF
--- a/docs/external/src/rust-client/cli/index.md
+++ b/docs/external/src/rust-client/cli/index.md
@@ -112,7 +112,7 @@ After creating an account with the `new-wallet` command, it is automatically sto
 
 Creates a new account and saves it locally.
 
-An account may be composed of one or more components, each with its own storage and distinct functionality. This command lets you build a custom account by selecting an account type and optionally adding extra packages.
+An account may be composed of one or more components, each with its own storage and distinct functionality. This command lets you build a custom account by selecting an account type and optionally adding extra component packages.
 
 This command has four flags:
 


### PR DESCRIPTION
- address the remaining occurrences of "component template" -> "package"
- unify wording for `new-account` & `new-wallet` (just the argument name is different: `--packages` vs `--extra-packages`)
- add a small example for `init_data.toml` contents

closes https://github.com/0xMiden/miden-client/issues/1132

cc @lima-limon-inc