### PR TITLE
fix: remove duplicate wasm_bindgen import from account bindings

### DIFF
--- a/crates/idxdb-store/src/account/js_bindings.rs
+++ b/crates/idxdb-store/src/account/js_bindings.rs
@@ -6,7 +6,7 @@ use miden_client::account::{StorageMap, StorageSlot};
 use miden_client::asset::Asset;
 use miden_client::utils::Serializable;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen_futures::{js_sys, wasm_bindgen};
+use wasm_bindgen_futures::js_sys;
 
 // INDEXED DB BINDINGS
 // ================================================================================================


### PR DESCRIPTION
The macro is already available through wasm_bindgen::prelude::*, making the duplicate import unnecessary. 

This aligns with the pattern used in sync/js_bindings.rs and lib.rs.