### PR TITLE
fix: remove duplicate apply transactions

### DIFF
--- a/crates/web-client/js/index.js
+++ b/crates/web-client/js/index.js
@@ -334,11 +334,6 @@ export class WebClient {
         new Uint8Array(result.serializedTransactionResult)
       );
 
-      await this.wasmWebClient.applyTransaction(
-        transactionResult,
-        result.submissionHeight
-      );
-
       return transactionResult.id();
     } catch (error) {
       console.error(
@@ -634,10 +629,6 @@ export class MockWebClient extends WebClient {
       );
 
       if (!(this instanceof MockWebClient)) {
-        await this.wasmWebClient.applyTransaction(
-          transactionResult,
-          result.submissionHeight
-        );
         return transactionResult.id();
       }
 


### PR DESCRIPTION
There is a bug in the `submitNewTransaction` in the event of web workers. 

The worker already calls `applyTransaction` whenever the `SUBMIT_NEW_TRANSACTION` method handler was invoked, and `applyTransaction` was also called in `index.js`