### PR TITLE
ci: disable publish-dry-run on next

### DIFF
--- a/.github/workflows/publish-crates-dry-run.yml
+++ b/.github/workflows/publish-crates-dry-run.yml
@@ -2,7 +2,7 @@ name: Dry Run Publish Rust Crates
 
 on:
   push:
-    branches: [main, next]
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description

We've been having some failing checks in the CI since the introduction of the dry-run publish check, this PR disables it for the next branch, from now on it will only run when targeting main.

Closes #1449.