### PR TITLE
fix: remove hardcoded 'localhost' in tests

### DIFF
--- a/crates/web-client/test/notes.test.ts
+++ b/crates/web-client/test/notes.test.ts
@@ -67,8 +67,7 @@ test.describe("get_input_note", () => {
 
     // Test RpcClient.getNotesById
     const rpcResult = await page.evaluate(async (_consumedNoteId: string) => {
-      // NOTE: this assumes the node is running on localhost
-      const endpoint = new window.Endpoint("http://localhost:57291");
+      const endpoint = new window.Endpoint(window.rpcUrl);
       const rpcClient = new window.RpcClient(endpoint);
 
       const noteId = window.NoteId.fromHex(_consumedNoteId);
@@ -97,7 +96,7 @@ test.describe("get_input_note", () => {
 
     // Get the note to extract its script root
     const noteData = await page.evaluate(async (_consumedNoteId: string) => {
-      const endpoint = new window.Endpoint("http://localhost:57291");
+      const endpoint = new window.Endpoint(window.rpcUrl);
       const rpcClient = new window.RpcClient(endpoint);
 
       const noteId = window.NoteId.fromHex(_consumedNoteId);
@@ -117,7 +116,7 @@ test.describe("get_input_note", () => {
     // Test GetNoteScriptByRoot endpoint
     const retrievedScript = await page.evaluate(
       async (scriptRootHex: string) => {
-        const endpoint = new window.Endpoint("http://localhost:57291");
+        const endpoint = new window.Endpoint(window.rpcUrl);
         const rpcClient = new window.RpcClient(endpoint);
 
         const scriptRoot = window.Word.fromHex(scriptRootHex);


### PR DESCRIPTION
## Description

While running the web client tests with devnet's url, a test was failing because of a hardcoded localhost url, this
pr simply makes it rely on window.rpcUrl