### PR TITLE
feat: use paths in config relative to `.miden` directory

### DIFF
--- a/bin/miden-cli/src/config.rs
+++ b/bin/miden-cli/src/config.rs
@@ -60,16 +60,15 @@ impl Default for CliConfig {
         const STORE_FILENAME: &str = "store.sqlite3";
         const KEYSTORE_DIRECTORY: &str = "keystore";
 
-        // Create paths relative to the .miden directory
-        let miden_dir = PathBuf::from(MIDEN_DIR);
-
+        // Create paths relative to the config file location (which is in .miden directory)
+        // These will be resolved relative to the .miden directory when the config is loaded
         Self {
             rpc: RpcConfig::default(),
-            store_filepath: miden_dir.join(STORE_FILENAME),
-            secret_keys_directory: miden_dir.join(KEYSTORE_DIRECTORY),
-            token_symbol_map_filepath: miden_dir.join(TOKEN_SYMBOL_MAP_FILEPATH),
+            store_filepath: PathBuf::from(STORE_FILENAME),
+            secret_keys_directory: PathBuf::from(KEYSTORE_DIRECTORY),
+            token_symbol_map_filepath: PathBuf::from(TOKEN_SYMBOL_MAP_FILEPATH),
             remote_prover_endpoint: None,
-            package_directory: miden_dir.join(DEFAULT_PACKAGES_DIR),
+            package_directory: PathBuf::from(DEFAULT_PACKAGES_DIR),
             max_block_number_delta: None,
             note_transport: None,
         }

--- a/bin/miden-cli/src/utils.rs
+++ b/bin/miden-cli/src/utils.rs
@@ -81,12 +81,31 @@ pub(crate) async fn parse_account_id<AUTH>(
 ///
 /// This function will look for the configuration file at the .miden/miden-client.toml path.
 /// If the path is relative, searches in parent directories all the way to the root as well.
+///
+/// Note: Relative paths in the config are resolved relative to the .miden directory.
 pub(super) fn load_config_file() -> Result<(CliConfig, PathBuf), CliError> {
     let mut config_path = std::env::current_dir()?;
     config_path.push(MIDEN_DIR);
     config_path.push(CLIENT_CONFIG_FILE_NAME);
 
-    let cli_config = load_config(config_path.as_path())?;
+    let mut cli_config = load_config(config_path.as_path())?;
+
+    // Resolve relative paths in the config relative to the .miden directory
+    let config_dir = config_path.parent().unwrap();
+
+    if cli_config.store_filepath.is_relative() {
+        cli_config.store_filepath = config_dir.join(&cli_config.store_filepath);
+    }
+    if cli_config.secret_keys_directory.is_relative() {
+        cli_config.secret_keys_directory = config_dir.join(&cli_config.secret_keys_directory);
+    }
+    if cli_config.token_symbol_map_filepath.is_relative() {
+        cli_config.token_symbol_map_filepath =
+            config_dir.join(&cli_config.token_symbol_map_filepath);
+    }
+    if cli_config.package_directory.is_relative() {
+        cli_config.package_directory = config_dir.join(&cli_config.package_directory);
+    }
 
     Ok((cli_config, config_path))
 }

--- a/bin/miden-cli/tests/cli.rs
+++ b/bin/miden-cli/tests/cli.rs
@@ -114,12 +114,18 @@ fn silent_initialization_uses_default_values() {
     // Verify default values are used
     assert!(config_content.contains("testnet"), "Should use testnet as default network");
     assert!(
-        config_content.contains(&format!("{MIDEN_DIR}/store.sqlite3")),
-        "Should use default store path in {MIDEN_DIR}"
+        config_content.contains("store.sqlite3"),
+        "Should use default store path (relative to config file)"
     );
     assert!(
-        config_content.contains(&format!("{MIDEN_DIR}/keystore")),
-        "Should use default keystore directory in {MIDEN_DIR}"
+        config_content.contains("keystore"),
+        "Should use default keystore directory (relative to config file)"
+    );
+    // Verify that the paths don't have the .miden prefix in the config
+    // (they're relative to the config file location now)
+    assert!(
+        !config_content.contains(&format!("{MIDEN_DIR}/store.sqlite3")),
+        "Paths should be relative to config file, not include {MIDEN_DIR}/ prefix"
     );
 }
 
@@ -159,23 +165,28 @@ fn miden_directory_structure_creation() {
     let basic_faucet_package = packages_dir.join("basic-fungible-faucet.masp");
     assert!(basic_faucet_package.exists(), "basic-fungible-faucet package should be created");
 
-    // Verify config file contains correct paths relative to .miden directory
+    // Verify config file contains correct paths relative to config file location
     let config_content = std::fs::read_to_string(&config_file).unwrap();
     assert!(
-        config_content.contains(&format!("{MIDEN_DIR}/store.sqlite3")),
-        "Config should reference store in .miden directory"
+        config_content.contains("store.sqlite3"),
+        "Config should reference store path relative to config file"
     );
     assert!(
-        config_content.contains(&format!("{MIDEN_DIR}/keystore")),
-        "Config should reference keystore in .miden directory"
+        config_content.contains("keystore"),
+        "Config should reference keystore path relative to config file"
     );
     assert!(
-        config_content.contains(&format!("{MIDEN_DIR}/packages")),
-        "Config should reference packages in .miden directory"
+        config_content.contains("packages"),
+        "Config should reference packages path relative to config file"
     );
     assert!(
-        config_content.contains(&format!("{MIDEN_DIR}/token_symbol_map.toml")),
-        "Config should reference token symbol map in .miden directory"
+        config_content.contains("token_symbol_map.toml"),
+        "Config should reference token symbol map path relative to config file"
+    );
+    // Verify that the paths don't have the .miden prefix (they're relative to config file now)
+    assert!(
+        !config_content.contains(&format!("{MIDEN_DIR}/store.sqlite3")),
+        "Paths should be relative to config file, not include {MIDEN_DIR}/ prefix"
     );
 
     // Verify default RPC endpoint is set


### PR DESCRIPTION
addresses https://github.com/0xMiden/miden-client/pull/1464#discussion_r2500031376

Currently, paths in `miden-client.toml` contain redundant `.miden/` prefix:
```toml
store_filepath = ".miden/store.sqlite3"
secret_keys_directory = ".miden/keystore"
# etc.
```

Solution:
Remove the prefix and resolve relative paths from the config file's directory:
```toml
store_filepath = "store.sqlite3"
secret_keys_directory = "keystore"
```
