### PR TITLE
fix: publish `miden-idxdb-store` separately

### DIFF
--- a/.github/workflows/publish-crates-dry-run.yml
+++ b/.github/workflows/publish-crates-dry-run.yml
@@ -26,6 +26,8 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
         run: |
-          cargo publish --workspace --exclude miden-client-web --dry-run
+          cargo publish --workspace --exclude miden-client-web --exclude miden-idxdb-store --dry-run
           cd crates/web-client
+          cargo publish --dry-run
+          cd ../idxdb-store
           cargo publish --dry-run

--- a/.github/workflows/publish-crates-release.yml
+++ b/.github/workflows/publish-crates-release.yml
@@ -43,14 +43,18 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
         run: |
-          cargo publish --workspace --exclude miden-client-web --dry-run
+          cargo publish --workspace --exclude miden-client-web --exclude miden-idxdb-store --dry-run
           cd crates/web-client
+          cargo publish --dry-run
+          cd ../idxdb-store
           cargo publish --dry-run
 
       - name: Publish crates
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
         run: |
-          cargo publish --workspace --exclude miden-client-web
+          cargo publish --workspace --exclude miden-client-web --exclude miden-idxdb-store
           cd crates/web-client
+          cargo publish
+          cd ../idxdb-store
           cargo publish


### PR DESCRIPTION
similar to how `web-client` is published (with `wasm32-unknown-unknown` target)

closes the second part of https://github.com/0xMiden/miden-client/issues/1488