### PR TITLE
refactor: await tests

### DIFF
--- a/crates/web-client/test/miden_array.test.ts
+++ b/crates/web-client/test/miden_array.test.ts
@@ -212,8 +212,8 @@ test.describe("Specific array tests (using AccountIdArray)", () => {
 
 test.describe("Generic array tests (using each exposed array type)", () => {
   test("Instance empty arrays", async ({ page, exposedMidenArrayTypes }) => {
-    exposedMidenArrayTypes.forEach(async (arrayTypeToInstance) => {
-      test.step(`Empty array ${arrayTypeToInstance}`, async () => {
+    for (const arrayTypeToInstance of exposedMidenArrayTypes) {
+      await test.step(`Empty array ${arrayTypeToInstance}`, async () => {
         await expect(
           instanceEmptyArray({
             page,
@@ -221,20 +221,20 @@ test.describe("Generic array tests (using each exposed array type)", () => {
           })
         ).resolves.toBe(true);
       });
-    });
+    }
   });
 
   test("Building array of mixed types fails", async ({
     page,
     exposedMidenArrayTypes,
   }) => {
-    exposedMidenArrayTypes.forEach(async (arrayTypeToInstance) => {
-      test.step(`Mixed typed array of ${arrayTypeToInstance} fails`, async () => {
+    for (const arrayTypeToInstance of exposedMidenArrayTypes) {
+      await test.step(`Mixed typed array of ${arrayTypeToInstance} fails`, async () => {
         await expect(
           instanceMixedArray({ page, arrayTypeToInstance }),
           `Should not be able to build array of type ${arrayTypeToInstance} with mixed types`
         ).rejects.toThrow();
       });
-    });
+    }
   });
 });


### PR DESCRIPTION
Awaits each iteration instead of running a `forEach`, which does not await async callbacks.
I think this may be the cause of this test being flaky. I'm not too sure, but using `Promise.all` might be an alternative. This should be as explicit as that so I went with this instead. I'm not entirely sure why this seems to happen mostly on `main` though.