### PR TITLE
fix: make idxdb-store build.rs file work with cargo publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2650,6 +2650,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasmbind-js-file-macro",
  "web-sys",
 ]
 
@@ -6228,6 +6229,17 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmbind-js-file-macro"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b895bdece3b926b188fbb76773375fc6b6f4058499cbe9f32491b0e264b27f71"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.109",
 ]
 
 [[package]]

--- a/crates/idxdb-store/Cargo.toml
+++ b/crates/idxdb-store/Cargo.toml
@@ -8,6 +8,7 @@ name                   = "miden-idxdb-store"
 repository.workspace   = true
 rust-version.workspace = true
 version.workspace      = true
+include = [ "src", "Cargo.toml", "build.rs", "Cargo.lock" ]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -26,6 +27,7 @@ base64               = { version = "0.22" }
 serde-wasm-bindgen   = { version = "0.6" }
 wasm-bindgen         = { features = ["serde-serialize"], version = "0.2" }
 wasm-bindgen-futures = { version = "0.4" }
+wasmbind-js-file-macro = "=0.1.6"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { features = ["Storage", "Window", "console"], version = "0.3" }

--- a/crates/idxdb-store/build.rs
+++ b/crates/idxdb-store/build.rs
@@ -5,7 +5,7 @@ fn run_yarn(args: &[&str]) -> Result<(), String> {
     let status = Command::new("cmd")
         .args(["/C", "yarn"])
         .args(args)
-        .current_dir("src")
+        .current_dir(&std::env::var("OUT_DIR").unwrap())
         .status()
         .map_err(|err| format!("could not run yarn via cmd: {err}"))?;
     if !status.success() {
@@ -16,9 +16,13 @@ fn run_yarn(args: &[&str]) -> Result<(), String> {
 
 #[cfg(not(windows))]
 fn run_yarn(args: &[&str]) -> Result<(), String> {
+    use std::{path::PathBuf, str::FromStr};
+
+    let mut path = PathBuf::from_str(&std::env::var("OUT_DIR").unwrap()).unwrap();
+    path.push("src");
     let status = Command::new("yarn")
         .args(args)
-        .current_dir("src")
+        .current_dir(path)
         .status()
         .map_err(|err| format!("could not run yarn: {err}"))?;
     if !status.success() {
@@ -28,13 +32,28 @@ fn run_yarn(args: &[&str]) -> Result<(), String> {
 }
 
 fn main() -> miette::Result<(), String> {
-    println!("cargo::rerun-if-changed=src");
+    // println!("cargo::rerun-if-changed=src");
+
+    Command::new("mkdir")
+        .args([&std::env::var("OUT_DIR").unwrap()])
+        .status()
+        .unwrap();
+
+    Command::new("cp")
+        .args(["-r", "src", &std::env::var("OUT_DIR").unwrap()])
+        .status()
+        .unwrap();
 
     // Install deps
     run_yarn(&[]).map_err(|e| format!("could not install ts dependencies: {e}"))?;
 
     // Build TS
     run_yarn(&["build"]).map_err(|e| format!("failed to build typescript: {e}"))?;
+
+    // Command::new("cp")
+    //     .args(["-r", &format!("{}/src/js", &std::env::var("OUT_DIR").unwrap()), "."])
+    //     .status()
+    //     .unwrap();
 
     Ok(())
 }

--- a/crates/idxdb-store/src/account/js_bindings.rs
+++ b/crates/idxdb-store/src/account/js_bindings.rs
@@ -7,12 +7,13 @@ use miden_client::asset::Asset;
 use miden_client::utils::Serializable;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::{js_sys, wasm_bindgen};
+use wasmbind_js_file_macro::wasmbind_dump_js_file_as_inline;
 
 // INDEXED DB BINDINGS
 // ================================================================================================
 
 // Account IndexedDB Operations
-#[wasm_bindgen(module = "/src/js/accounts.js")]
+#[wasmbind_dump_js_file_as_inline(path = "${outDir}/src/js/sync.js")]
 extern "C" {
     // GETS
     // --------------------------------------------------------------------------------------------

--- a/crates/idxdb-store/src/auth.rs
+++ b/crates/idxdb-store/src/auth.rs
@@ -3,6 +3,7 @@ use serde_wasm_bindgen::from_value;
 use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen_futures::{JsFuture, js_sys};
+use wasmbind_js_file_macro::wasmbind_dump_js_file_as_inline;
 
 // WEB KEYSTORE HELPER
 // ================================================================================================
@@ -16,7 +17,7 @@ pub struct AccountAuthIdxdbObject {
     pub secret_key: String,
 }
 
-#[wasm_bindgen(module = "/src/js/accounts.js")]
+#[wasmbind_dump_js_file_as_inline(path = "${outDir}/src/js/accounts.js")]
 extern "C" {
     #[wasm_bindgen(js_name = insertAccountAuth)]
     pub fn idxdb_insert_account_auth(pub_key: String, secret_key: String) -> js_sys::Promise;

--- a/crates/idxdb-store/src/chain_data/js_bindings.rs
+++ b/crates/idxdb-store/src/chain_data/js_bindings.rs
@@ -3,9 +3,10 @@ use alloc::vec::Vec;
 
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::{js_sys, wasm_bindgen};
+use wasmbind_js_file_macro::wasmbind_dump_js_file_as_inline;
 
 // ChainData IndexedDB Operations
-#[wasm_bindgen(module = "/src/js/chainData.js")]
+#[wasmbind_dump_js_file_as_inline(path = "${outDir}/src/js/chainData.js")]
 extern "C" {
     // GETS
     // ================================================================================================

--- a/crates/idxdb-store/src/export/js_bindings.rs
+++ b/crates/idxdb-store/src/export/js_bindings.rs
@@ -1,7 +1,8 @@
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::{js_sys, wasm_bindgen};
+use wasmbind_js_file_macro::wasmbind_dump_js_file_as_inline;
 
-#[wasm_bindgen(module = "/src/js/export.js")]
+#[wasmbind_dump_js_file_as_inline(path = "${outDir}/src/js/export.js")]
 extern "C" {
     #[wasm_bindgen(js_name = exportStore)]
     pub fn idxdb_export_store() -> js_sys::Promise;

--- a/crates/idxdb-store/src/import/js_bindings.rs
+++ b/crates/idxdb-store/src/import/js_bindings.rs
@@ -1,7 +1,8 @@
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::{js_sys, wasm_bindgen};
+use wasmbind_js_file_macro::wasmbind_dump_js_file_as_inline;
 
-#[wasm_bindgen(module = "/src/js/import.js")]
+#[wasmbind_dump_js_file_as_inline(path = "${outDir}/src/js/import.js")]
 extern "C" {
     #[wasm_bindgen(js_name = forceImportStore)]
     pub fn idxdb_force_import_store(store_dump: JsValue) -> js_sys::Promise;

--- a/crates/idxdb-store/src/lib.rs
+++ b/crates/idxdb-store/src/lib.rs
@@ -16,28 +16,15 @@ use base64::Engine;
 use base64::engine::general_purpose;
 use miden_client::Word;
 use miden_client::account::{
-    Account,
-    AccountCode,
-    AccountHeader,
-    AccountId,
-    AccountStorage,
-    Address,
+    Account, AccountCode, AccountHeader, AccountId, AccountStorage, Address,
 };
 use miden_client::asset::AssetVault;
 use miden_client::block::BlockHeader;
 use miden_client::crypto::{InOrderIndex, MmrPeaks};
 use miden_client::note::{BlockNumber, NoteScript, Nullifier};
 use miden_client::store::{
-    AccountRecord,
-    AccountStatus,
-    BlockRelevance,
-    InputNoteRecord,
-    NoteFilter,
-    OutputNoteRecord,
-    PartialBlockchainFilter,
-    Store,
-    StoreError,
-    TransactionFilter,
+    AccountRecord, AccountStatus, BlockRelevance, InputNoteRecord, NoteFilter, OutputNoteRecord,
+    PartialBlockchainFilter, Store, StoreError, TransactionFilter,
 };
 use miden_client::sync::{NoteTagRecord, StateSyncUpdate};
 use miden_client::transaction::{TransactionRecord, TransactionStoreUpdate};
@@ -57,14 +44,16 @@ pub mod settings;
 pub mod sync;
 pub mod transaction;
 
-#[wasm_bindgen(module = "/src/js/utils.js")]
+use wasmbind_js_file_macro::wasmbind_dump_js_file_as_inline;
+
+#[wasmbind_dump_js_file_as_inline(path = "${outDir}/src/js/utils.js")]
 extern "C" {
     #[wasm_bindgen(js_name = logWebStoreError)]
     fn log_web_store_error(error: JsValue, error_context: alloc::string::String);
 }
 
 // Initialize IndexedDB
-#[wasm_bindgen(module = "/src/js/schema.js")]
+#[wasmbind_dump_js_file_as_inline(path = "${outDir}/src/js/schema.js")]
 extern "C" {
     #[wasm_bindgen(js_name = openDatabase)]
     fn setup_indexed_db() -> js_sys::Promise;

--- a/crates/idxdb-store/src/note/js_bindings.rs
+++ b/crates/idxdb-store/src/note/js_bindings.rs
@@ -3,10 +3,9 @@ use alloc::vec::Vec;
 
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::{js_sys, wasm_bindgen};
+use wasmbind_js_file_macro::wasmbind_dump_js_file_as_inline;
 
-// Notes IndexedDB Operations
-#[wasm_bindgen(module = "/src/js/notes.js")]
-
+#[wasmbind_dump_js_file_as_inline(path = "${outDir}/src/js/notes.js")]
 extern "C" {
     // GETS
     // ================================================================================================

--- a/crates/idxdb-store/src/package.json
+++ b/crates/idxdb-store/src/package.json
@@ -7,8 +7,8 @@
     "typescript": "^5.9.2"
   },
   "scripts": {
-    "build": "yarn tsc --build --force ./tsconfig.json",
-    "build:bundler": "yarn tsc --build --force ./tsconfig.bundler.json",
+    "build": "./node_modules/typescript/bin/tsc --build --force ./tsconfig.json",
+    "build:bundler": "./node_modules/typescript/bin/tsc --build --force ./tsconfig.bundler.json",
     "lint": "yarn build && yarn eslint --config ./ts/eslint.config.mjs ./ts"
   },
   "devDependencies": {

--- a/crates/idxdb-store/src/settings/js_bindings.rs
+++ b/crates/idxdb-store/src/settings/js_bindings.rs
@@ -3,9 +3,10 @@ use alloc::vec::Vec;
 
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::{js_sys, wasm_bindgen};
+use wasmbind_js_file_macro::wasmbind_dump_js_file_as_inline;
 
 // Settings IndexedDB Operations
-#[wasm_bindgen(module = "/src/js/settings.js")]
+#[wasmbind_dump_js_file_as_inline(path = "${outDir}/src/js/settings.js")]
 extern "C" {
     #[wasm_bindgen(js_name = getSetting)]
     pub fn idxdb_get_setting(key: String) -> js_sys::Promise;

--- a/crates/idxdb-store/src/sync/js_bindings.rs
+++ b/crates/idxdb-store/src/sync/js_bindings.rs
@@ -11,9 +11,10 @@ use super::flattened_vec::FlattenedU8Vec;
 use crate::account::{JsStorageMapEntry, JsStorageSlot, JsVaultAsset};
 use crate::note::utils::{SerializedInputNoteData, SerializedOutputNoteData};
 use crate::transaction::utils::SerializedTransactionData;
+use wasmbind_js_file_macro::wasmbind_dump_js_file_as_inline;
 
 // Sync IndexedDB Operations
-#[wasm_bindgen(module = "/src/js/sync.js")]
+#[wasmbind_dump_js_file_as_inline(path = "${outDir}/src/js/sync.js")]
 extern "C" {
     // GETS
     // --------------------------------------------------------------------------------------------

--- a/crates/idxdb-store/src/transaction/js_bindings.rs
+++ b/crates/idxdb-store/src/transaction/js_bindings.rs
@@ -3,10 +3,10 @@ use alloc::vec::Vec;
 
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::{js_sys, wasm_bindgen};
+use wasmbind_js_file_macro::wasmbind_dump_js_file_as_inline;
 
 // Transactions IndexedDB Operations
-#[wasm_bindgen(module = "/src/js/transactions.js")]
-
+#[wasmbind_dump_js_file_as_inline(path = "${outDir}/src/js/transactions.js")]
 extern "C" {
     // GETS
     // ================================================================================================


### PR DESCRIPTION
## Description

Since the build.rs was modifying files outside the [$OUT_DIR](https://doc.rust-lang.org/cargo/reference/environment-variables.html) the cargo publish command was failing. This PR should fix it.

To check it's working, you can run: `cargo publish --dry-run` in the idxdb-store crate.

Closes #1493.