### PR TITLE
feat(web-client): add AccountCode hasProcedure and AccountComponent getProcedures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.12.3 (TBD)
+* Added `hasProcedure` to `AccountCode` and `getProcedures` to `AccountComponent` in the web client ([#1514](https://github.com/0xMiden/miden-client/pull/1514)).
+
 ## 0.12.0 (2025-11-08)
 
 ### Features

--- a/crates/web-client/package.json
+++ b/crates/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demox-labs/miden-sdk",
-  "version": "0.12.0-next.34",
+  "version": "0.12.0-next.35",
   "description": "Miden Wasm SDK",
   "collaborators": [
     "Miden",

--- a/crates/web-client/src/models/account_code.rs
+++ b/crates/web-client/src/models/account_code.rs
@@ -12,6 +12,11 @@ impl AccountCode {
     pub fn commitment(&self) -> Word {
         self.0.commitment().into()
     }
+
+    #[wasm_bindgen(js_name = "hasProcedure")]
+    pub fn has_procedure(&self, mast_root: Word) -> bool {
+        self.0.has_procedure(mast_root.into())
+    }
 }
 
 // CONVERSIONS

--- a/crates/web-client/src/models/account_component.rs
+++ b/crates/web-client/src/models/account_component.rs
@@ -1,3 +1,4 @@
+use miden_client::Word as NativeWord;
 use miden_client::account::StorageSlot as NativeStorageSlot;
 use miden_client::account::component::AccountComponent as NativeAccountComponent;
 use miden_client::auth::{AuthRpoFalcon512 as NativeRpoFalcon512, PublicKeyCommitment};
@@ -12,6 +13,36 @@ use crate::models::package::Package;
 use crate::models::script_builder::ScriptBuilder;
 use crate::models::secret_key::SecretKey;
 use crate::models::storage_slot::StorageSlot;
+use crate::models::word::Word;
+
+#[derive(Clone)]
+#[wasm_bindgen]
+pub struct GetProceduresResultItem {
+    digest: Word,
+    is_auth: bool,
+}
+
+#[wasm_bindgen]
+impl GetProceduresResultItem {
+    #[wasm_bindgen(getter)]
+    pub fn digest(&self) -> Word {
+        self.digest.clone()
+    }
+
+    #[wasm_bindgen(getter, js_name = "isAuth")]
+    pub fn is_auth(&self) -> bool {
+        self.is_auth
+    }
+}
+
+impl From<&(NativeWord, bool)> for GetProceduresResultItem {
+    fn from(native_get_procedures_result_item: &(NativeWord, bool)) -> Self {
+        Self {
+            digest: native_get_procedures_result_item.0.into(),
+            is_auth: native_get_procedures_result_item.1,
+        }
+    }
+}
 
 #[wasm_bindgen]
 #[derive(Clone)]
@@ -65,6 +96,11 @@ impl AccountComponent {
             .to_hex();
 
         Ok(digest_hex)
+    }
+
+    #[wasm_bindgen(js_name = "getProcedures")]
+    pub fn get_procedures(&self) -> Vec<GetProceduresResultItem> {
+        self.0.get_procedures().iter().map(Into::into).collect()
     }
 
     #[wasm_bindgen(js_name = "createAuthComponent")]

--- a/docs/typedoc/web-client/README.md
+++ b/docs/typedoc/web-client/README.md
@@ -51,6 +51,7 @@
 - [FungibleAsset](classes/FungibleAsset.md)
 - [FungibleAssetDelta](classes/FungibleAssetDelta.md)
 - [FungibleAssetDeltaItem](classes/FungibleAssetDeltaItem.md)
+- [GetProceduresResultItem](classes/GetProceduresResultItem.md)
 - [InputNote](classes/InputNote.md)
 - [InputNoteRecord](classes/InputNoteRecord.md)
 - [InputNotes](classes/InputNotes.md)

--- a/docs/typedoc/web-client/classes/AccountCode.md
+++ b/docs/typedoc/web-client/classes/AccountCode.md
@@ -35,3 +35,19 @@
 #### Returns
 
 `void`
+
+***
+
+### hasProcedure()
+
+> **hasProcedure**(`mast_root`): `boolean`
+
+#### Parameters
+
+##### mast\_root
+
+[`Word`](Word.md)
+
+#### Returns
+
+`boolean`

--- a/docs/typedoc/web-client/classes/AccountComponent.md
+++ b/docs/typedoc/web-client/classes/AccountComponent.md
@@ -44,6 +44,16 @@
 
 ***
 
+### getProcedures()
+
+> **getProcedures**(): [`GetProceduresResultItem`](GetProceduresResultItem.md)[]
+
+#### Returns
+
+[`GetProceduresResultItem`](GetProceduresResultItem.md)[]
+
+***
+
 ### withSupportsAllTypes()
 
 > **withSupportsAllTypes**(): `AccountComponent`

--- a/docs/typedoc/web-client/classes/GetProceduresResultItem.md
+++ b/docs/typedoc/web-client/classes/GetProceduresResultItem.md
@@ -1,0 +1,39 @@
+[**@demox-labs/miden-sdk**](../README.md)
+
+***
+
+[@demox-labs/miden-sdk](../README.md) / GetProceduresResultItem
+
+# Class: GetProceduresResultItem
+
+## Properties
+
+### digest
+
+> `readonly` **digest**: [`Word`](Word.md)
+
+***
+
+### isAuth
+
+> `readonly` **isAuth**: `boolean`
+
+## Methods
+
+### \[dispose\]()
+
+> **\[dispose\]**(): `void`
+
+#### Returns
+
+`void`
+
+***
+
+### free()
+
+> **free**(): `void`
+
+#### Returns
+
+`void`


### PR DESCRIPTION
This PR exposes `hasProcedure` in `AccountCode` and `getProcedures` in `AccountComponent`, primitives that are needed for implementing partial contract verification.

Contract verification in Miden can be implemented by recompiling the whole account and comparing the resulting code commitment with what's stored on-chain, in a similar fashion to what Sourcify does for the EVM.
With this PR, we expose some functions from Rust not available in the WebClient that will enable performing "partial" contract verification by testing if an Account code contains all the procedures from a given AccountComponent.

Here's a POC leveraging the functions introduced in this PR:

```typescript
  // compile counter component
  const builder = client.createScriptBuilder();
  const counterComponent = AccountComponent.compile(
    counterContractCode,
    builder,
    [
      StorageSlot.fromValue(
        Word.fromHex(
          "0x0000000000000000000000000000000000000000000000000000000000000000"
        )
      ),
    ]
  ).withSupportsAllTypes();

  // prints list of counter component procedures digests
  const procedures = counterComponent.getProcedures();
  for (const procedure of procedures) {
    console.log({ digest: procedure.digest.toHex(), isAuth: procedure.isAuth });
  }

  // create new account implementing counter component
  const initSeed = new Uint8Array(32);
  crypto.getRandomValues(initSeed);
  const { account: counterContractAccount, seed } = new AccountBuilder(initSeed)
    .storageMode(AccountStorageMode.public())
    .withNoAuthComponent()
    .withComponent(counterComponent)
    .build();

  // helper function to test if an account code contains all procedure roots from a component
  const implementsAccountComponent = (
    account: AccountType,
    component: AccountComponentType
  ) => {
    const code = account.code();
    return component
      .getProcedures()
      .every((procedure) => code.hasProcedure(procedure.digest));
  };

  // partial contract verification:
  const hasCounterComponent = implementsAccountComponent(
    counterContractAccount,
    counterComponent
  );
  console.log({ hasCounterComponent }); // true
```

Pre-PR check list:

- [x]  Check tools `make check-tools` and `make install-tools`
- [x]  Lint code
- [x]  Docstring & re-generate docs for web-client
- [x]  Version bump
- [x]  Changelog
