### PR TITLE
feat: Optional limit on note-transport fetch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2948,8 +2948,7 @@ dependencies = [
 [[package]]
 name = "miden-note-transport-proto-build"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d7a7b3a64c71d33f771d32cde58559207819a64ada9add0acb31857e111b9d"
+source = "git+https://github.com/0xMiden/miden-note-transport?branch=ev%2Ffetch-limit#e8e70d80ed189434051ce66bcd076de6e3f3a410"
 dependencies = [
  "fs-err",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ miden-node-proto-build           = { default-features = false, version = "0.12" 
 miden-node-rpc                   = { version = "0.12" }
 miden-node-store                 = { version = "0.12" }
 miden-node-utils                 = { version = "0.12" }
-miden-note-transport-proto-build = { default-features = false, version = "0.1" }
+miden-note-transport-proto-build = { default-features = false, git = "https://github.com/0xMiden/miden-note-transport", branch = "ev/fetch-limit" }
 miden-remote-prover              = { features = ["concurrent"], version = "0.12" }
 miden-remote-prover-client       = { default-features = false, features = ["tx-prover"], version = "0.12" }
 

--- a/crates/rust-client/src/note_transport/generated/nostd/miden_note_transport.rs
+++ b/crates/rust-client/src/note_transport/generated/nostd/miden_note_transport.rs
@@ -26,6 +26,8 @@ pub struct FetchNotesRequest {
     pub tags: ::prost::alloc::vec::Vec<u32>,
     #[prost(fixed64, tag = "2")]
     pub cursor: u64,
+    #[prost(fixed32, optional, tag = "3")]
+    pub limit: ::core::option::Option<u32>,
 }
 /// API response for fetching notes
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/crates/rust-client/src/note_transport/generated/std/miden_note_transport.rs
+++ b/crates/rust-client/src/note_transport/generated/std/miden_note_transport.rs
@@ -26,6 +26,8 @@ pub struct FetchNotesRequest {
     pub tags: ::prost::alloc::vec::Vec<u32>,
     #[prost(fixed64, tag = "2")]
     pub cursor: u64,
+    #[prost(fixed32, optional, tag = "3")]
+    pub limit: ::core::option::Option<u32>,
 }
 /// API response for fetching notes
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/crates/rust-client/src/note_transport/grpc.rs
+++ b/crates/rust-client/src/note_transport/grpc.rs
@@ -111,9 +111,14 @@ impl GrpcNoteTransportClient {
         &self,
         tags: &[NoteTag],
         cursor: NoteTransportCursor,
+        limit: Option<u32>,
     ) -> Result<(Vec<NoteInfo>, NoteTransportCursor), NoteTransportError> {
         let tags_int = tags.iter().map(NoteTag::as_u32).collect();
-        let request = FetchNotesRequest { tags: tags_int, cursor: cursor.value() };
+        let request = FetchNotesRequest {
+            tags: tags_int,
+            cursor: cursor.value(),
+            limit,
+        };
 
         let response = self
             .api()
@@ -199,8 +204,9 @@ impl super::NoteTransportClient for GrpcNoteTransportClient {
         &self,
         tags: &[NoteTag],
         cursor: NoteTransportCursor,
+        limit: Option<u32>,
     ) -> Result<(Vec<NoteInfo>, NoteTransportCursor), NoteTransportError> {
-        self.fetch_notes(tags, cursor).await
+        self.fetch_notes(tags, cursor, limit).await
     }
 
     async fn stream_notes(

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -166,7 +166,7 @@ where
         // TODO We can run both sync_state, fetch_notes futures in parallel
         let note_transport_update = if let Some(mut note_transport) = note_transport {
             let cursor = self.store.get_note_transport_cursor().await?;
-            Some(note_transport.fetch_notes(cursor, note_tags).await?)
+            Some(note_transport.fetch_notes(note_tags, cursor, None).await?)
         } else {
             None
         };


### PR DESCRIPTION
A client may have too many notes to fetch from the transport layer. This adds an optional limit to the downloaded notes per each fetch request. Requires sync with https://github.com/0xMiden/miden-note-transport/pull/56.

Unsure how best to incorporate with the new `limit: Option<u32>` argument in the client interface. Could be as a new argument in `Client::fetch_private_notes`. Currently it is not used (no limit is applied) on transport layer fetch request.
