### PR TITLE
chore: extend eslint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,6 +40,16 @@ module.exports = [
           functions: "never",
         },
       ],
+      "eol-last": ["error", "always"],
+      "space-before-blocks": ["error", "always"],
+      "no-multiple-empty-lines": [
+        "error",
+        {
+          max: 1,
+          maxBOF: 0,
+          maxEOF: 0,
+        },
+      ],
     },
   },
   {
@@ -72,6 +82,16 @@ module.exports = [
           imports: "always-multiline",
           exports: "always-multiline",
           functions: "never",
+        },
+      ],
+      "eol-last": ["error", "always"],
+      "space-before-blocks": ["error", "always"],
+      "no-multiple-empty-lines": [
+        "error",
+        {
+          max: 1,
+          maxBOF: 0,
+          maxEOF: 0,
         },
       ],
     },


### PR DESCRIPTION
Extends eslint rules for the javascript code with forcing semicolons, keyword spacing and comma dangle rules.
Happy for this to be a conversation starter about javascript coding conventions in the client repo.