### PR TITLE
fix(miden-idxdb-store) fix insertAccountAddress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.4 (TBD)
+
+* Fixed a bug where insertions in the `Addresses` table in the IndexedDB Store resulted in the `id` and `address` fields being inverted with each other ([#1532](https://github.com/0xMiden/miden-client/pull/1532)).
+
 ## Miden Client CLI - 0.12.4 (2025-11-17)
 
 * Fixed CLI install process to statically include account component package files ([#1530](https://github.com/0xMiden/miden-client/pull/1530)).

--- a/crates/idxdb-store/src/js/accounts.js
+++ b/crates/idxdb-store/src/js/accounts.js
@@ -332,12 +332,12 @@ export async function insertAccountAuth(pubKey, secretKey) {
         logWebStoreError(error, `Error inserting account auth for pubKey: ${pubKey}`);
     }
 }
-export async function insertAccountAddress(address, accountId) {
+export async function insertAccountAddress(accountId, address) {
     try {
         // Prepare the data object to insert
         const data = {
-            address,
             id: accountId,
+            address,
         };
         // Perform the insert using Dexie
         await addresses.put(data);

--- a/crates/idxdb-store/src/ts/accounts.ts
+++ b/crates/idxdb-store/src/ts/accounts.ts
@@ -419,14 +419,14 @@ export async function insertAccountAuth(pubKey: string, secretKey: string) {
 }
 
 export async function insertAccountAddress(
-  address: Uint8Array,
-  accountId: string
+  accountId: string,
+  address: Uint8Array
 ) {
   try {
     // Prepare the data object to insert
     const data = {
-      address,
       id: accountId,
+      address,
     };
 
     // Perform the insert using Dexie

--- a/crates/web-client/package.json
+++ b/crates/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demox-labs/miden-sdk",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Miden Wasm SDK",
   "collaborators": [
     "Miden",


### PR DESCRIPTION
This PR fixes a bug where insertions in the `Addresses` table in the IndexedDB Store results in the `id` and `address` fields being inverted with each other.
This is caused by an inversion of the arguments in the TS implementation contrary to the parameters passed in the Rust JS bindings:
https://github.com/0xMiden/miden-client/blob/main/crates/idxdb-store/src/account/utils.rs#L106 => accountId, address
https://github.com/0xMiden/miden-client/blob/main/crates/idxdb-store/src/ts/accounts.ts#L421-L424 => address, accountId

Pre-PR check list:

- [x]  Check tools `make check-tools` and `make install-tools`
- [x]  Lint code
- [x]  Docstring & re-generate docs for web-client
- [x]  Version bump
- [x]  Changelog