### PR TITLE
chore: Add missing ScriptBuilder typing

### DIFF
--- a/crates/web-client/js/types/index.d.ts
+++ b/crates/web-client/js/types/index.d.ts
@@ -59,6 +59,7 @@ export {
   PublicKey,
   Rpo256,
   RpcClient,
+  ScriptBuilder,
   SecretKey,
   ProvenTransaction,
   SerializedAccountHeader,


### PR DESCRIPTION
The new ScriptBuilder does not have a typing exposed in the js types.
Adding it here.