### PR TITLE
fix: disable rustc optimizations for web client when testing

### DIFF
--- a/crates/web-client/rollup.config.js
+++ b/crates/web-client/rollup.config.js
@@ -77,7 +77,7 @@ export default [
         experimental: {
           typescriptDeclarationDir: "dist/crates",
         },
-        optimize: { release: true, rustc: !devMode  },
+        optimize: { release: true, rustc: !devMode },
       }),
       resolve(),
       commonjs(),


### PR DESCRIPTION
Current compilation times for `miden-client-web` are unnecessarily long due to running the rust compiler with optimizations.

This PR sets the `rustc` flag conditionally, depending on we are running on `devMode` or not.

original:
```bash
Finished `release` profile [optimized + debuginfo] target(s) in 2m 44s
```

without rustc optimizations:
```bash
Finished `release` profile [optimized + debuginfo] target(s) in 16.11s
```