### PR TITLE
feat(web-client): add package manifest exports

### DIFF
--- a/crates/web-client/src/models/mod.rs
+++ b/crates/web-client/src/models/mod.rs
@@ -78,6 +78,8 @@ pub mod note_type;
 pub mod output_note;
 pub mod output_notes;
 pub mod package;
+pub mod package_export;
+pub mod package_manifest;
 pub mod partial_note;
 pub mod program;
 pub mod proven_transaction;

--- a/crates/web-client/src/models/package.rs
+++ b/crates/web-client/src/models/package.rs
@@ -3,6 +3,7 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::js_sys::Uint8Array;
 
 use crate::models::library::Library;
+use crate::models::package_manifest::PackageManifest;
 use crate::models::program::Program;
 use crate::utils::{deserialize_from_uint8array, serialize_to_uint8array};
 
@@ -42,6 +43,10 @@ impl Package {
 
         let native_program = self.0.unwrap_program();
         Ok((*native_program).clone().into())
+    }
+
+    pub fn manifest(&self) -> PackageManifest {
+        self.0.manifest.clone().into()
     }
 }
 

--- a/crates/web-client/src/models/package_export.rs
+++ b/crates/web-client/src/models/package_export.rs
@@ -1,0 +1,73 @@
+use miden_client::vm::PackageExport as NativePackageExport;
+use wasm_bindgen::prelude::*;
+
+use crate::models::word::Word;
+
+#[derive(Clone)]
+#[wasm_bindgen]
+pub struct FunctionType {
+    abi: String,
+    params: Vec<String>,
+    results: Vec<String>,
+}
+
+#[wasm_bindgen]
+impl FunctionType {
+    #[wasm_bindgen(constructor)]
+    pub fn new(abi: String, params: Vec<String>, results: Vec<String>) -> FunctionType {
+        FunctionType { abi, params, results }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn abi(&self) -> String {
+        self.abi.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn params(&self) -> Vec<String> {
+        self.params.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn results(&self) -> Vec<String> {
+        self.results.clone()
+    }
+}
+
+#[derive(Clone)]
+#[wasm_bindgen]
+pub struct PackageExport(NativePackageExport);
+
+#[wasm_bindgen]
+impl PackageExport {
+    pub fn name(&self) -> String {
+        self.0.name.name.as_str().to_string()
+    }
+
+    pub fn digest(&self) -> Word {
+        self.0.digest.into()
+    }
+
+    pub fn signature(&self) -> FunctionType {
+        let native_function_type = self.0.signature.clone().unwrap();
+        let abi = native_function_type.abi.to_string();
+        let params = native_function_type.params.iter().map(|ty| ty.to_string()).collect();
+        let results = native_function_type.results.iter().map(|ty| ty.to_string()).collect();
+        FunctionType::new(abi, params, results)
+    }
+}
+
+// CONVERSIONS
+// ================================================================================================
+
+impl From<NativePackageExport> for PackageExport {
+    fn from(native_package_export: NativePackageExport) -> Self {
+        PackageExport(native_package_export)
+    }
+}
+
+impl From<&NativePackageExport> for PackageExport {
+    fn from(native_package_export: &NativePackageExport) -> Self {
+        PackageExport(native_package_export.clone())
+    }
+}

--- a/crates/web-client/src/models/package_manifest.rs
+++ b/crates/web-client/src/models/package_manifest.rs
@@ -1,0 +1,30 @@
+use miden_client::vm::PackageManifest as NativePackageManifest;
+use wasm_bindgen::prelude::*;
+
+use crate::models::package_export::PackageExport;
+
+#[derive(Clone)]
+#[wasm_bindgen]
+pub struct PackageManifest(NativePackageManifest);
+
+#[wasm_bindgen]
+impl PackageManifest {
+    pub fn exports(&self) -> Vec<PackageExport> {
+        self.0.exports().map(Into::into).collect()
+    }
+}
+
+// CONVERSIONS
+// ================================================================================================
+
+impl From<NativePackageManifest> for PackageManifest {
+    fn from(native_package_manifest: NativePackageManifest) -> Self {
+        PackageManifest(native_package_manifest)
+    }
+}
+
+impl From<&NativePackageManifest> for PackageManifest {
+    fn from(native_package_manifest: &NativePackageManifest) -> Self {
+        PackageManifest(native_package_manifest.clone())
+    }
+}


### PR DESCRIPTION
This PR improves `Package` introspection in the `WebClient` by exposing the `PackageManifest` along with the list of exported procedures with name, digest and function signature.
