### PR TITLE
Fix #1568 Dont use AuthScheme in createAuthComponentFromCommitment

### DIFF
--- a/crates/web-client/src/models/account_component.rs
+++ b/crates/web-client/src/models/account_component.rs
@@ -2,19 +2,18 @@ use miden_client::Word as NativeWord;
 use miden_client::account::StorageSlot as NativeStorageSlot;
 use miden_client::account::component::AccountComponent as NativeAccountComponent;
 use miden_client::auth::{
-    AuthEcdsaK256Keccak as NativeEcdsaK256Keccak, AuthEcdsaK256Keccak as NativeEcdsaK256Keccak,
-    AuthEcdsaK256Keccak as NativeEcdsaK256Keccak, AuthRpoFalcon512 as NativeRpoFalcon512,
-    AuthRpoFalcon512 as NativeRpoFalcon512, AuthRpoFalcon512 as NativeRpoFalcon512,
-    AuthSecretKey as NativeSecretKey, AuthSecretKey as NativeSecretKey,
-    AuthSecretKey as NativeSecretKey, ECDSA_K256_KECCAK_SCHEME_ID, PublicKeyCommitment,
-    PublicKeyCommitment, PublicKeyCommitment, RPO_FALCON_SCHEME_ID,
+    AuthEcdsaK256Keccak as NativeEcdsaK256Keccak,
+    AuthRpoFalcon512 as NativeRpoFalcon512,
+    AuthSecretKey as NativeSecretKey,
+    ECDSA_K256_KECCAK_SCHEME_ID,
+    PublicKeyCommitment,
+    RPO_FALCON_SCHEME_ID,
 };
 use miden_client::vm::Package as NativePackage;
 use miden_core::mast::MastNodeExt;
 use wasm_bindgen::prelude::*;
 
 use crate::js_error_with_context;
-use crate::models::auth::AuthScheme;
 use crate::models::miden_arrays::StorageSlotArray;
 use crate::models::package::Package;
 use crate::models::script_builder::ScriptBuilder;
@@ -136,19 +135,22 @@ impl AccountComponent {
     #[wasm_bindgen(js_name = "createAuthComponentFromCommitment")]
     pub fn create_auth_component_from_commitment(
         commitment: &Word,
-        auth_scheme: AuthScheme,
+        auth_scheme_id: u8,
     ) -> Result<AccountComponent, JsValue> {
         let native_word: NativeWord = commitment.into();
         let pkc = PublicKeyCommitment::from(native_word);
-        match auth_scheme {
-            AuthScheme::AuthRpoFalcon512 => {
+        match auth_scheme_id {
+            RPO_FALCON_SCHEME_ID => {
                 let auth = NativeRpoFalcon512::new(pkc);
                 Ok(AccountComponent(auth.into()))
             },
-            AuthScheme::AuthEcdsaK256Keccak => {
+            ECDSA_K256_KECCAK_SCHEME_ID => {
                 let auth = NativeEcdsaK256Keccak::new(pkc);
                 Ok(AccountComponent(auth.into()))
             },
+            _unimplemented => Err(JsValue::from_str(
+                "building auth component for this auth scheme is not supported yet",
+            )),
         }
     }
 

--- a/docs/typedoc/web-client/classes/AccountComponent.md
+++ b/docs/typedoc/web-client/classes/AccountComponent.md
@@ -106,7 +106,7 @@
 
 ### createAuthComponentFromCommitment()
 
-> `static` **createAuthComponentFromCommitment**(`commitment`, `auth_scheme`): `AccountComponent`
+> `static` **createAuthComponentFromCommitment**(`commitment`, `auth_scheme_id`): `AccountComponent`
 
 #### Parameters
 
@@ -114,9 +114,9 @@
 
 [`Word`](Word.md)
 
-##### auth\_scheme
+##### auth\_scheme\_id
 
-[`AuthScheme`](../enumerations/AuthScheme.md)
+`number`
 
 #### Returns
 


### PR DESCRIPTION
After changing base to main on #1568  I introduced a bug which basically uses `AuthScheme` a model on `next` 