### PR TITLE
docs: move CLI troubleshooting page to Rust-CLI docs folder

### DIFF
--- a/docs/external/src/rust-client/cli/cli-config.md
+++ b/docs/external/src/rust-client/cli/cli-config.md
@@ -1,5 +1,6 @@
 ---
 title: Config
+sidebar-position: 2
 ---
 
 After [installation](../install-and-run.md#install-the-client), use the client by running the following and adding the [relevant commands](index.md#commands):

--- a/docs/external/src/rust-client/cli/cli-troubleshooting.md
+++ b/docs/external/src/rust-client/cli/cli-troubleshooting.md
@@ -1,3 +1,8 @@
+---
+title: Troubleshooting
+sidebar-position: 3
+---
+
 ## Troubleshooting and transaction lifecycle (CLI)
 
 This guide helps you troubleshoot common issues and understand the end-to-end lifecycle of transactions and notes in the Miden client.


### PR DESCRIPTION
Closes #1583