### PR TITLE
chore: add a test run with debug assertions in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,8 @@ jobs:
         run: make start-note-transport-background
       - name: Run integration tests
         run: make integration-test-full
+      - name: Run integration tests with debug assertions
+        run: make integration-test-dev
       - name: Stop test node
         if: always()
         run: |


### PR DESCRIPTION
as per title
closes https://github.com/0xMiden/miden-client/issues/1651

this will slightly increase the running time of the integration job, but I think we should run both the `release` mode and the mode with debug-assertions on.

With https://github.com/0xMiden/miden-client/pull/1652 the CI running time should be better so these should sort of balance out