### PR TITLE
chore: add markdowns for LLM migration guides

### DIFF
--- a/.github/agents/MIGRATION_GUIDE_PROMPT.md
+++ b/.github/agents/MIGRATION_GUIDE_PROMPT.md
@@ -1,0 +1,103 @@
+# Migration Guide Prompt
+
+Generate a migration guide for the Miden Client SDK.
+
+## Instructions
+1. Read CHANGELOG.md from the repository root
+2. Extract the changelog section for version {VERSION} (or "latest" for the most recent release)
+   - If version is "latest", find the first version section that has a date (not "TBD")
+   - Parse all `[BREAKING]` entries from that version
+3. For each breaking change, generate a migration section
+
+## Target Version
+{VERSION}  (e.g., "0.13.0", "0.12.0", or "latest")
+
+## Previous Version (for "before" examples)
+{PREVIOUS_VERSION}  (e.g., "0.12.0", or "auto" to use the version before target)
+
+## Migration Guide Structure
+
+For each `[BREAKING]` entry, generate:
+
+### [Breaking Change Title]
+**PR:** #NUMBER
+
+#### Summary
+1-2 sentence explanation of what changed and why.
+
+#### Affected Code
+
+**Rust:**
+```rust
+// Before ({PREVIOUS_VERSION})
+old_code_example();
+
+// After ({VERSION})
+new_code_example();
+```
+
+**TypeScript:** (if scope includes `web`)
+```typescript
+// Before ({PREVIOUS_VERSION})
+oldCodeExample();
+
+// After ({VERSION})
+newCodeExample();
+```
+
+#### Migration Steps
+1. Step-by-step instructions
+2. ...
+
+#### Common Errors
+| Error Message | Cause | Solution |
+|---------------|-------|----------|
+| `error[E0...]` | ... | ... |
+
+---
+
+## Guidelines
+
+1. **Read CHANGELOG.md first** to get the list of breaking changes
+2. **Explore the codebase** to find real usage patterns for before/after examples
+3. **Use PR numbers** to fetch diffs via `gh pr view #NUMBER` for context
+4. **Apply migration strategy based on category tag:**
+   - `rename`: Show find-replace, update imports
+   - `removal`: Show replacement API with equivalent functionality
+   - `param`: Show old vs new function signatures, explain new parameters
+   - `type`: Show type conversions and import changes
+   - `behavior`: Explain the behavioral difference and when code needs adaptation
+   - `arch`: Show Cargo.toml/package.json changes, new import paths
+5. **Include both Rust and TypeScript** when scope includes both `rust` and `web`
+6. **Group related changes** that affect the same workflow
+7. **Identify compile errors** users will encounter and how to fix them
+
+## Output
+
+Generate a professionally formatted markdown document suitable for the docs site.
+
+### Content Requirements
+- One section per breaking change (or grouped related changes)
+- Real, runnable code examples (not pseudocode)
+- Practical migration steps
+- Troubleshooting table for common errors
+- Do NOT include non-breaking features or fixes
+
+### Formatting & Style
+
+**Document Structure:**
+- Start with a brief version summary (1-2 sentences about the release theme)
+- Use a table of contents for guides with 5+ breaking changes
+- Order sections by impact: most disruptive changes first
+- End with a "Need Help?" section linking to Discord/GitHub issues
+
+**Code Blocks:**
+- Always specify language for syntax highlighting (```rust, ```typescript)
+- Use diff syntax (```diff) when showing inline changes
+- Include necessary imports in examples
+- Keep examples minimal but complete (compilable/runnable)
+
+**Tone:**
+- Direct and actionable ("Update your imports" not "You may want to consider updating")
+- Empathetic but not apologetic about breaking changes
+- Focus on the "what to do" not the "why we broke it"

--- a/CHANGELOG_FORMAT.md
+++ b/CHANGELOG_FORMAT.md
@@ -1,0 +1,84 @@
+# Changelog Format for LLM-Generated Migration Guides
+
+This document describes the changelog entry format for the Miden Client SDK. Following this format enables automatic generation of migration guides.
+
+---
+
+## Quick Reference
+
+### Breaking Changes
+
+```
+* [BREAKING][category][scope] Description. Context if needed. (#PR)
+```
+
+**Categories:** `rename` | `removal` | `param` | `type` | `behavior` | `arch`
+
+**Scopes:** `rust` | `web` | `cli` | `store` | `all`
+
+### Features & Fixes
+
+```
+* [FEATURE][scope] Description. (#PR)
+* [FIX][scope] Description. (#PR)
+* [DEPRECATED][scope] Description. Will be removed in vX.Y. (#PR)
+```
+
+---
+
+## Examples
+
+```markdown
+* [BREAKING][rename][all] `TonicRpcClient` → `GrpcClient`. (#1360)
+* [BREAKING][param][rust,web] `sync_state()` now requires `AccountStateAt` parameter. Use `Synced` for previous default behavior. (#1500)
+* [BREAKING][removal][web] Removed `compileNoteScript()`. Use `ScriptBuilder` instead. (#1274)
+* [BREAKING][arch][rust] `SqliteStore` moved to `miden-client-sqlite-store` crate. (#1253)
+* [FEATURE][web] Added `TransactionSummary` API for previewing transactions. (#1620)
+* [FIX][rust] Corrected balance calculation for fungible assets. (#1630)
+```
+
+---
+
+## Category Reference
+
+| Category | What It Means | Migration Strategy |
+|----------|---------------|-------------------|
+| `rename` | Type/method/crate name changed | Find-replace instructions |
+| `removal` | API/feature removed | Show replacement API |
+| `param` | Parameter added/removed/changed | Show old vs new signature |
+| `type` | Type signature changed | Show type conversions |
+| `behavior` | Same API, different behavior | Explain behavioral diff |
+| `arch` | Crate structure, imports, feature flags | Show Cargo.toml/import changes |
+
+## Scope Reference
+
+| Scope | Affects |
+|-------|---------|
+| `rust` | Rust SDK (`miden-client` crate) |
+| `web` | TypeScript/WASM SDK |
+| `cli` | CLI tool |
+| `store` | Storage layer (internal) |
+| `all` | All of the above |
+
+---
+
+## Why This Format?
+
+An LLM agent uses these structured entries to automatically generate migration guides. The tags tell it:
+- **Category** → What migration pattern to apply
+- **Scope** → Which languages to include examples for
+- **PR number** → Where to fetch detailed context
+
+This means engineers only need to write a single-line changelog entry—no migration docs required.
+
+---
+
+## Validation Checklist
+
+Before merging, verify your changelog entry:
+
+- [ ] Uses format: `* [TYPE][category][scope] Description. (#PR)`
+- [ ] Category accurately reflects the change type
+- [ ] Scope lists all affected areas
+- [ ] Description is clear and actionable
+- [ ] PR number is included

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,33 @@ We use [semver](https://semver.org/) naming convention.
 
 ### Changelog
 
-If a PR introduces anything a downstream user might notice - a new feature, a behaviour change, a bug-fix, a deprecation, or a breaking API change - add a bullet to [CHANGELOG.md](./CHANGELOG.md) under the last existing heading (corresponds to the unreleased version when working on the `next` branch). The convention is to write a past-tense summary (e.g. "* [BREAKING] Renamed foo() to bar() in `Client` {#PR number link}"). Internal refactors or smaller tweaks that don’t affect public behaviour can be left out.
+### Changelog
+
+If a PR introduces anything a downstream user might notice - a new feature, a behaviour change, a bug-fix, a deprecation, or a breaking API change - add a bullet to [CHANGELOG.md](./CHANGELOG.md) under the last existing heading (corresponds to the unreleased version when working on the `next` branch). Internal refactors or smaller tweaks that don't affect public behaviour can be left out.
+
+We use a structured changelog format that enables automatic generation of migration guides. See [CHANGELOG_FORMAT.md](./CHANGELOG_FORMAT.md) for the full specification.
+
+**Quick Reference:**
+
+Breaking changes:
+```
+* [BREAKING][category][scope] Description. (#PR)
+```
+- **Categories:** `rename` | `removal` | `param` | `type` | `behavior` | `arch`
+- **Scopes:** `rust` | `web` | `cli` | `store` | `all`
+
+Features and fixes:
+```
+* [FEATURE][scope] Description. (#PR)
+* [FIX][scope] Description. (#PR)
+```
+
+**Examples:**
+```
+* [BREAKING][rename][all] `TonicRpcClient` → `GrpcClient`. (#1360)
+* [FEATURE][web] Added `TransactionSummary` API. (#1620)
+* [FIX][rust] Fixed balance calculation. (#1630)
+```
 
 ### Docs
 


### PR DESCRIPTION
## Summary
- Add `CHANGELOG_FORMAT.md` with structured changelog entry format
- Add `.github/MIGRATION_GUIDE_PROMPT.md` with LLM prompt template
- Update `CONTRIBUTING.md` with changelog format quick reference

## Details
Introduces a tagged changelog format (`[BREAKING][category][scope]`) that enables automatic generation of migration guides using LLM agents. Engineers write single-line changelog entries; the LLM generates full migration docs with before/after examples.

Closes #1692 