### PR TITLE
chore: bump version to 0.13.0-next.2

### DIFF
--- a/crates/web-client/package.json
+++ b/crates/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-sdk",
-  "version": "0.13.0-next.1",
+  "version": "0.13.0-next.2",
   "description": "Miden Wasm SDK",
   "collaborators": [
     "Miden"


### PR DESCRIPTION
Bump web client version to 0.13.0-next.2. Needed for wallet development.