### PR TITLE
fix: exclude zero deltas from added fungible assets

### DIFF
--- a/crates/web-client/src/models/account_delta/vault.rs
+++ b/crates/web-client/src/models/account_delta/vault.rs
@@ -192,8 +192,6 @@ impl From<&FungibleAssetDelta> for NativeFungibleAssetDelta {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     #[test]
     fn fungible_delta_sign_classification_excludes_zero() {
         let deltas = [10_i64, 0_i64, -5_i64];


### PR DESCRIPTION
Previously addedFungibleAssets used a >= 0 filter, which caused zero-delta entries to be exposed as “increased” assets and broke the intended semantics of the API.

Switched the filter to > 0 so only strictly positive deltas are reported as added, and adds a small unit test to lock in the sign-based classification (positive vs negative) while excluding zero.