### PR TITLE
fix: install cargo-msrv with --locked in CI

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Ensure stable toolchain is installed
         run: rustup toolchain install stable --profile minimal
       - name: Install cargo-msrv
-        run: cargo install cargo-msrv
+        run: cargo install cargo-msrv --locked
       - name: Check MSRV for each workspace member
         run: |
           ./scripts/check-msrv.sh


### PR DESCRIPTION
Without `--locked`, `cargo install cargo-msrv` resolves fresh dependencies on every run. The `aws-smithy-*` crates recently bumped their MSRV to 1.91, which makes `cargo-msrv` fail to compile on the CI runner's stable toolchain (1.90).

Using `--locked` makes it use `cargo-msrv`'s published lockfile with known-compatible dependency versions.