### PR TITLE
fix: propagate error from AccountWitness::new instead of unwrap

### DIFF
--- a/crates/rust-client/src/rpc/domain/account.rs
+++ b/crates/rust-client/src/rpc/domain/account.rs
@@ -630,7 +630,8 @@ impl TryFrom<proto::account::AccountWitness> for AccountWitness {
             .ok_or(proto::account::AccountWitness::missing_field(stringify!(witness_id)))?
             .try_into()?;
 
-        let witness = AccountWitness::new(account_id, state_commitment, merkle_path).unwrap();
+        let witness = AccountWitness::new(account_id, state_commitment, merkle_path)
+            .map_err(|err| RpcError::InvalidResponse(err.to_string()))?;
         Ok(witness)
     }
 }


### PR DESCRIPTION
Spotted this while reading through the RPC domain conversion code — `AccountWitness::new()` can fail if the merkle path depth doesn't match `SMT_DEPTH`, but the `TryFrom` impl was calling `.unwrap()` on it. Since this runs on data coming from the RPC node, a bad response would crash the client instead of returning an error.

Changed it to use `.map_err()` + `?` which matches what the rest of the conversion functions in this file already do.