### PR TITLE
fix: remove unnecessary clones of NoteInclusionProof and NoteMetadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Added `--rpc-status` flag to `miden-client info` command to display RPC node status information including node version, genesis commitment, store status, and block producer status; also added `get_status_unversioned` to `NodeRpcClient` trait ([#1742](https://github.com/0xMiden/miden-client/pull/1742)).
 * Prevent a potential unwrap panic in `insert_storage_map_nodes_for_map` ([#1750](https://github.com/0xMiden/miden-client/pull/1750)).
 * Changed the `StateSync::sync_state()` to take a reference of the MMR ([#1764](https://github.com/0xMiden/miden-client/pull/1764)).
+* Remove unnecessary clones of `NoteInclusionProof` and `NoteMetadata` in note import and sync paths ([#1787](https://github.com/0xMiden/miden-client/pull/1787)).
 * [FEATURE][web] WebClient now automatically syncs state before account creation when the client has never been synced, preventing a slow full-chain scan on the next sync (#1704).
 
 ### Changes

--- a/crates/rust-client/src/note/import.rs
+++ b/crates/rust-client/src/note/import.rs
@@ -265,8 +265,9 @@ where
                 let block_height = inclusion_proof.location().block_num();
                 let current_block_num = self.get_sync_height().await?;
 
+                let tag = metadata.tag();
                 let mut note_changed =
-                    note_record.inclusion_proof_received(inclusion_proof, metadata.clone())?;
+                    note_record.inclusion_proof_received(inclusion_proof, metadata)?;
 
                 if block_height <= current_block_num {
                     // FIXME: We should be able to build the mmr only once (outside the for loop).
@@ -284,11 +285,8 @@ where
                 } else {
                     // If the note is in the future we import it as unverified. We add the note tag
                     // so that the note is verified naturally in the next sync.
-                    self.insert_note_tag(NoteTagRecord::with_note_source(
-                        metadata.tag(),
-                        note_record.id(),
-                    ))
-                    .await?;
+                    self.insert_note_tag(NoteTagRecord::with_note_source(tag, note_record.id()))
+                        .await?;
                 }
 
                 if note_changed {
@@ -344,15 +342,13 @@ where
                         )
                         .await?;
 
+                    let tag = metadata.tag();
                     let note_changed =
-                        note_record.inclusion_proof_received(inclusion_proof, metadata.clone())?;
+                        note_record.inclusion_proof_received(inclusion_proof, metadata)?;
 
                     if note_record.block_header_received(&block_header)? | note_changed {
                         self.store
-                            .remove_note_tag(NoteTagRecord::with_note_source(
-                                metadata.tag(),
-                                note_record.id(),
-                            ))
+                            .remove_note_tag(NoteTagRecord::with_note_source(tag, note_record.id()))
                             .await?;
 
                         note_records.push(Some(note_record));

--- a/crates/rust-client/src/note/note_update_tracker.rs
+++ b/crates/rust-client/src/note/note_update_tracker.rs
@@ -295,7 +295,7 @@ impl NoteUpdateTracker {
 
         if let Some(output_note_record) = self.get_output_note_by_id(*committed_note.note_id()) {
             // The note belongs to our locally tracked set of output notes
-            output_note_record.inclusion_proof_received(inclusion_proof.clone())?;
+            output_note_record.inclusion_proof_received(inclusion_proof)?;
         }
 
         Ok(is_tracked_as_input_note)


### PR DESCRIPTION
noticed a few spots where NoteInclusionProof and NoteMetadata were being cloned at their last use site - these both contain heap-allocated fields (MerklePath, etc) so the clones are wasteful.

fixed by:
- removing the final .clone() on inclusion_proof in note_update_tracker.rs since it's the last use
- extracting the Copy-type NoteTag before moving metadata in import.rs (two places) instead of cloning the whole NoteMetadata struct

cargo check passes.