### PR TITLE
fix: remove unnecessary clones and redundant allocations

### DIFF
--- a/crates/rust-client/src/note/mod.rs
+++ b/crates/rust-client/src/note/mod.rs
@@ -57,7 +57,6 @@
 //! For more details on the API and error handling, see the documentation for the specific functions
 //! and types in this module.
 
-use alloc::string::ToString;
 use alloc::vec::Vec;
 
 use miden_protocol::account::AccountId;
@@ -187,10 +186,7 @@ where
         &self,
         note: InputNoteRecord,
     ) -> Result<Vec<NoteConsumability>, ClientError> {
-        self.note_screener()
-            .can_consume(&note.clone().try_into()?)
-            .await
-            .map_err(Into::into)
+        self.note_screener().can_consume(&note.try_into()?).await.map_err(Into::into)
     }
 
     /// Retrieves the input note given a [`NoteId`]. Returns `None` if the note is not found.
@@ -241,16 +237,14 @@ where
         .await
         .map_err(|err| {
             tracing::error!("Error when fetching all notes from the store: {err}");
-            IdPrefixFetchError::NoMatch(format!("note ID prefix {note_id_prefix}").to_string())
+            IdPrefixFetchError::NoMatch(format!("note ID prefix {note_id_prefix}"))
         })?
         .into_iter()
         .filter(|note_record| note_record.id().to_hex().starts_with(note_id_prefix))
         .collect::<Vec<_>>();
 
     if input_note_records.is_empty() {
-        return Err(IdPrefixFetchError::NoMatch(
-            format!("note ID prefix {note_id_prefix}").to_string(),
-        ));
+        return Err(IdPrefixFetchError::NoMatch(format!("note ID prefix {note_id_prefix}")));
     }
     if input_note_records.len() > 1 {
         let input_note_record_ids =
@@ -260,9 +254,9 @@ where
             note_id_prefix,
             input_note_record_ids
         );
-        return Err(IdPrefixFetchError::MultipleMatches(
-            format!("note ID prefix {note_id_prefix}").to_string(),
-        ));
+        return Err(IdPrefixFetchError::MultipleMatches(format!(
+            "note ID prefix {note_id_prefix}"
+        )));
     }
 
     Ok(input_note_records

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -600,7 +600,7 @@ impl NodeRpcClient for GrpcClient {
         let account_id = foreign_account.account_id();
         let storage_requirements = foreign_account.storage_slot_requirements();
 
-        let storage_maps: Vec<StorageMapDetailRequest> = storage_requirements.clone().into();
+        let storage_maps: Vec<StorageMapDetailRequest> = storage_requirements.into();
 
         // Only request details for public accounts; include known code commitment for this
         // account when available
@@ -942,9 +942,8 @@ impl NodeRpcClient for GrpcClient {
     }
 
     async fn get_network_id(&self) -> Result<NetworkId, RpcError> {
-        let endpoint_str: &str = &self.endpoint.clone();
         let endpoint: Endpoint =
-            Endpoint::try_from(endpoint_str).map_err(RpcError::InvalidNodeEndpoint)?;
+            Endpoint::try_from(self.endpoint.as_str()).map_err(RpcError::InvalidNodeEndpoint)?;
         Ok(endpoint.to_network_id())
     }
 

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -529,14 +529,15 @@ where
         for note in output_notes {
             if output_note_relevances.contains_key(&note.id()) {
                 let metadata = note.metadata().clone();
+                let tag = metadata.tag();
 
                 new_input_notes.push(InputNoteRecord::new(
                     note.into(),
                     current_timestamp,
                     ExpectedNoteState {
-                        metadata: Some(metadata.clone()),
+                        metadata: Some(metadata),
                         after_block_num: submission_height,
-                        tag: Some(metadata.tag()),
+                        tag: Some(tag),
                     }
                     .into(),
                 ));
@@ -719,7 +720,7 @@ where
                 ForeignAccount::Private(partial_account) => {
                     let (witness, _) = account_proof.into_parts();
 
-                    AccountInputs::new(partial_account.clone(), witness)
+                    AccountInputs::new(partial_account, witness)
                 },
             };
 


### PR DESCRIPTION
same pattern as #1787 - found a few more spots:

- removed .clone() on transaction_request in note_screener.rs since it's consumed by into_transaction_args() and never used after
- extracted Copy-type NoteTag before moving metadata in transaction/mod.rs
- removed redundant format!().to_string() in note/mod.rs (format! already returns String)
- removed unnecessary endpoint.clone() in tonic_client (use as_str() instead)
- removed partial_account.clone() in transaction/mod.rs (already owned)

cargo check passes.