### PR TITLE
fix: Make the react sdk example use newly published react sdk and vite plugin

### DIFF
--- a/packages/react-sdk/examples/wallet/package.json
+++ b/packages/react-sdk/examples/wallet/package.json
@@ -10,11 +10,12 @@
   },
   "dependencies": {
     "@miden-sdk/miden-sdk": "^0.13.0",
-    "@miden-sdk/react": "^0.13.0",
+    "@miden-sdk/react": "^0.13.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@miden-sdk/vite-plugin": "^0.13.4",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^4.2.0",

--- a/packages/react-sdk/examples/wallet/vite.config.ts
+++ b/packages/react-sdk/examples/wallet/vite.config.ts
@@ -1,11 +1,9 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { midenVitePlugin } from "@miden-sdk/vite-plugin";
 
 export default defineConfig({
-  plugins: [react()],
-  optimizeDeps: {
-    exclude: ["@miden-sdk/miden-sdk"],
-  },
+  plugins: [react(), midenVitePlugin()],
   resolve: {
     dedupe: ["react", "react-dom", "react/jsx-runtime"],
   },

--- a/packages/react-sdk/examples/wallet/yarn.lock
+++ b/packages/react-sdk/examples/wallet/yarn.lock
@@ -323,12 +323,17 @@
     dexie "^4.0.1"
     glob "^11.0.0"
 
-"@miden-sdk/react@^0.13.0":
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/@miden-sdk/react/-/react-0.13.2.tgz#bad9b88449bb7ca1a2e55274b360b1e729a409fe"
-  integrity sha512-78i3/5YUUwitqvJA02HVXZ61RXEOyaiRsm1agVUtOblOmazuIgMEW4P3gdlX9YUiGr06l9O+Rw1ol5FZCOJTXQ==
+"@miden-sdk/react@^0.13.3":
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/@miden-sdk/react/-/react-0.13.3.tgz#943f560709053f78d2914912571780e4690609f7"
+  integrity sha512-jJ/j61C/53bsDXi80AllZSygoGd5+GSFRFLSMHLIto3zO9IiQ7JTbmHOtKLp7qTh+VozLyE0wE/pTsWYoVtKQg==
   dependencies:
     zustand "^5.0.0"
+
+"@miden-sdk/vite-plugin@^0.13.4":
+  version "0.13.4"
+  resolved "https://registry.yarnpkg.com/@miden-sdk/vite-plugin/-/vite-plugin-0.13.4.tgz#72370985960b888395e1850d3b1e2ab41bde8b12"
+  integrity sha512-BojOl1hF01wsHAXWDTm9gcMkMDqngE28SDLXZFJT2c6lgUouB7LzMkmKvWz0+qO0clOKY2/4R5LBQeAj5m74ZA==
 
 "@rolldown/pluginutils@1.0.0-beta.27":
   version "1.0.0-beta.27"

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/vite-plugin",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "Vite plugin for Miden dApps — WASM dedup, COOP/COEP headers, and gRPC-web proxy",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
## Summary
- Update the react SDK wallet example to use the newly published `@miden-sdk/react@^0.13.3` and `@miden-sdk/vite-plugin@^0.13.4`
- Replace manual `optimizeDeps.exclude` config with the `midenVitePlugin()` in vite.config.ts
- Bump vite-plugin version to 0.13.4

## Test plan
- [ ] Verify the example app builds successfully with `yarn build`
- [ ] Verify the example app runs correctly with `yarn dev`