### PR TITLE
docs: rewrite README with three-repo SDK architecture and split strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,428 @@
-# Miden client
+# Miden Client
 
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/0xMiden/miden-client/blob/main/LICENSE)
 [![test](https://github.com/0xMiden/miden-client/actions/workflows/test.yml/badge.svg)](https://github.com/0xMiden/miden-client/actions/workflows/test.yml)
 [![build](https://github.com/0xMiden/miden-client/actions/workflows/build.yml/badge.svg)](https://github.com/0xMiden/miden-client/actions/workflows/build.yml)
-[![RUST_VERSION](https://img.shields.io/badge/rustc-1.88+-lightgray.svg)](https://www.rust-lang.org/tools/install)
+[![RUST_VERSION](https://img.shields.io/badge/rustc-1.90+-lightgray.svg)](https://www.rust-lang.org/tools/install)
 [![crates.io](https://img.shields.io/crates/v/miden-client)](https://crates.io/crates/miden-client)
 
-This repository contains the Miden client, which provides a way to execute and prove transactions, facilitating the interaction with the Miden rollup.
+The official client SDK for the [Miden](https://miden.io) rollup. This monorepo provides everything needed to interact with the Miden network — from the low-level Rust core to high-level React hooks — across native and browser environments.
 
 ### Status
 
-The Miden client is still under heavy development and the project can be considered to be in an *alpha* stage. Many features are yet to be implemented and there is a number of limitations which we will lift in the near future.
+The Miden client is under active development and should be considered *alpha*. APIs may change between releases. Many features are planned but not yet implemented.
 
-## Overview
+## Architecture
 
-The Miden client currently consists of two components:
+The SDK is organized as a layered stack. Each layer builds on the one below it, providing progressively higher-level abstractions while maintaining full access to the underlying capabilities when needed.
 
-- `miden-client` library, which can be used by other project to programmatically interact with the Miden rollup. You can find more information about the library in the [Rust client Library](./crates/rust-client/README.md) section.
-- `miden-client-cli`, which is a wrapper around the library exposing its functionality via a simple command-line interface (CLI). You can find more information about the CLI in the [Miden client CLI](./bin/miden-cli/README.md) section.
+```mermaid
+%%{init: {
+    'theme': 'base',
+    'themeVariables': {
+      'primaryColor': '#0d1117',
+      'primaryTextColor': '#c9d1d9',
+      'primaryBorderColor': '#30363d',
+      'lineColor': '#484f58',
+      'fontFamily': 'JetBrains Mono, Fira Code, Consolas, monospace',
+      'fontSize': '13px'
+    }
+  }}%%
 
-The client's main responsibility is to maintain a partial view of the blockchain which allows for locally executing and proving transactions. It keeps a local store of various entities that periodically get updated by syncing with the node.
+  graph TB
+      rust-sdk["<b>rust-sdk</b><br/><span style='color:#484f58'>───────────────────────────</span><br/><span
+  style='color:#7ee787'>lang: Rust │ target: native</span><br/><span
+  style='color:#484f58'>───────────────────────────</span><br/><br/><span style='color:#c9d1d9'>Core client
+  library</span><br/><span style='color:#8b949e'>accounts · notes · transactions</span><br/><span
+  style='color:#8b949e'>@miden-sdk/rust-sdk</span><br/><br/><span
+  style='color:#484f58'>───────────────────────────</span><br/><span style='color:#7ee787'>▸ Rust Backends</span>"]
 
-For more info check:
+      wasm-bridge["<b>wasm-bridge</b><br/><span style='color:#484f58'>───────────────────────────</span><br/><span
+  style='color:#d2a8ff'>lang: Rust → WASM │ internal</span><br/><span
+  style='color:#484f58'>───────────────────────────</span><br/><br/><span style='color:#c9d1d9'>Compiled via
+  wasm-bindgen</span><br/><span style='color:#8b949e'>wasm-pack · wasm-bindgen</span><br/><span
+  style='color:#8b949e'>idxdb-store · web-tonic</span><br/><br/><span
+  style='color:#484f58'>───────────────────────────</span><br/><span style='color:#d2a8ff'>▸ WASM Base Layer ·
+  Internal</span>"]
 
-- [Getting started](https://0xMiden.github.io/miden-docs/miden-client/get-started/prerequisites.html)
+      ts-sdk["<b>ts-sdk</b><br/><span style='color:#484f58'>───────────────────────────</span><br/><span
+  style='color:#79c0ff'>lang: TypeScript │ target: web</span><br/><span
+  style='color:#484f58'>───────────────────────────</span><br/><br/><span style='color:#c9d1d9'>Idiomatic TS
+  wrapper</span><br/><span style='color:#8b949e'>typed API · async helpers</span><br/><span
+  style='color:#8b949e'>@miden-sdk/ts-sdk</span><br/><br/><span
+  style='color:#484f58'>───────────────────────────</span><br/><span style='color:#79c0ff'>▸ TS Backends · non-React
+  FEs</span>"]
+
+      react-sdk["<b>react-sdk</b><br/><span style='color:#484f58'>───────────────────────────</span><br/><span
+  style='color:#ff7b72'>lang: TypeScript │ target: React</span><br/><span
+  style='color:#484f58'>───────────────────────────</span><br/><br/><span style='color:#c9d1d9'>React integration
+  layer</span><br/><span style='color:#8b949e'>hooks · context · zustand</span><br/><span
+  style='color:#8b949e'>@miden-sdk/react-sdk</span><br/><br/><span
+  style='color:#484f58'>───────────────────────────</span><br/><span style='color:#ff7b72'>▸ React Frontends</span>"]
+
+      rust-sdk -- "cargo build --target wasm32" --> wasm-bridge
+      wasm-bridge -- "import * from '@miden'" --> ts-sdk
+      wasm-bridge -- "import * from '@miden'" --> react-sdk
+
+      style rust-sdk fill:#0d1117,stroke:#7ee787,stroke-width:1.5px,color:#c9d1d9,rx:4,ry:4
+      style wasm-bridge fill:#0d1117,stroke:#d2a8ff,stroke-width:1.5px,color:#c9d1d9,rx:4,ry:4
+      style ts-sdk fill:#0d1117,stroke:#79c0ff,stroke-width:1.5px,color:#c9d1d9,rx:4,ry:4
+      style react-sdk fill:#0d1117,stroke:#ff7b72,stroke-width:1.5px,color:#c9d1d9,rx:4,ry:4
+
+      linkStyle 0 stroke:#d2a8ff,stroke-width:1.5px,stroke-dasharray:5 5
+      linkStyle 1 stroke:#79c0ff,stroke-width:1.5px,stroke-dasharray:5 5
+      linkStyle 2 stroke:#ff7b72,stroke-width:1.5px,stroke-dasharray:5 5
+```
+
+### Layer Overview
+
+| Layer | Package | Language | Purpose |
+|-------|---------|----------|---------|
+| **rust-sdk** | `@miden-sdk/rust-sdk` | Rust | Core client library — account management, note handling, transaction building/execution/proving, state sync, node communication |
+| **wasm-bridge** | *(internal)* | Rust → WASM | Compiles the Rust core to WebAssembly via `wasm-bindgen`. Not published as a standalone package — serves as the compilation boundary between Rust and JavaScript |
+| **ts-sdk** | `@miden-sdk/ts-sdk` | TypeScript | Idiomatic TypeScript wrapper over the WASM bridge. Primary entry point for **Node.js backends** (indexers, bots, relayers, server-side services) and non-React frontends (Vue, Svelte, Angular, vanilla JS). Resource-based API, async helpers, and full type definitions |
+| **react-sdk** | `@miden-sdk/react-sdk` | TypeScript | React integration layer — hooks, context providers, Zustand state management, auto-sync, and external signer support |
+
+## Motivation
+
+### Why four layers?
+
+The Miden protocol is implemented in Rust and relies heavily on zero-knowledge proof generation, which is computationally intensive and deeply tied to the Rust/WASM ecosystem. At the same time, the majority of end-user applications — wallets, dApps, block explorers — are built with web technologies. This creates a fundamental tension: the core logic *must* be Rust, but the developer experience *must* be TypeScript-native.
+
+Rather than forcing one language to do everything, the SDK embraces the boundary between Rust and TypeScript as a first-class architectural concern and separates it into distinct layers, each with a clear responsibility.
+
+### `rust-sdk` — The Foundational Core
+
+**Package:** `@miden-sdk/rust-sdk` · **Crate:** `miden-client` · **Location:** [`crates/rust-client`](./crates/rust-client)
+
+The Rust SDK is the single source of truth for all Miden client logic. It is a `#![no_std]`-compatible library that implements:
+
+- **Account management** — creating, importing, tracking, and updating accounts (wallets and faucets) with support for both public and private storage modes.
+- **Note handling** — note screening, filtering, consumption, and export/import. Notes are Miden's UTXO-like primitive for transferring assets and encoding arbitrary logic.
+- **Transaction building and execution** — constructing transactions from note consumption and script execution, running them through the Miden VM, and generating zero-knowledge proofs (locally or via a remote prover).
+- **State synchronization** — maintaining a local partial view of the blockchain by syncing with a Miden node. The sync mechanism fetches new block headers, note inclusion proofs, nullifier updates, and account state changes, then applies them atomically to the local store.
+- **Node communication** — a `NodeRpcClient` trait with a gRPC implementation that handles all RPC interactions including state sync, transaction submission, and data retrieval. On native targets, this uses `tonic` with TLS; on WASM, it uses `tonic-web-wasm-client`.
+- **Key management** — a `Keystore` trait for managing signing keys, with a filesystem implementation for native and a Dexie-backed implementation for browsers.
+- **Private note transport** — an optional transport network for delivering encrypted notes directly between parties without broadcasting them on-chain.
+
+The Rust SDK is designed to be used directly by Rust backends, CLIs, and any native application. The `Client` struct is generic over an authenticator type (`Client<AUTH>`) and uses trait-based dependency injection for storage (`Store`), RPC (`NodeRpcClient`), proving (`TransactionProver`), and key management (`Keystore`), making every component swappable.
+
+**Why a separate package?** The Rust SDK is a crates.io-published library with its own versioning, feature flags, and dependency tree. It must remain independent of any JavaScript tooling so that pure-Rust consumers (backends, infrastructure, other Rust clients) can depend on it without pulling in web-related dependencies. The `no_std` compatibility ensures it can target embedded or constrained environments.
+
+### `wasm-bridge` — The Compilation Boundary
+
+**Location:** [`crates/web-client`](./crates/web-client)
+
+The WASM bridge is the layer that compiles the Rust core into WebAssembly and exposes it to JavaScript via `wasm-bindgen`. It is **not published as a standalone package** — it exists purely as an internal build artifact that both the TypeScript SDK and React SDK consume.
+
+This layer handles several concerns that are specific to the Rust-to-WASM boundary:
+
+- **Type marshalling** — Rust types are wrapped in `#[wasm_bindgen]` annotated structs that serialize/deserialize across the WASM boundary. Over 90 model wrapper types handle the translation between Rust's type system and JavaScript-compatible representations.
+- **Web Worker offloading** — computationally expensive operations (account creation, transaction execution, ZK proof generation) are automatically routed to a dedicated Web Worker so they don't block the main thread.
+- **IndexedDB storage** — the `idxdb-store` crate implements the `Store` trait using Dexie.js (an IndexedDB wrapper), with a TypeScript source layer compiled to JavaScript. The database schema includes separate "latest" and "historical" tables for account state, enabling efficient queries for current state while preserving full history.
+- **Sync locking** — an exclusive lock mechanism ensures that concurrent sync operations don't corrupt local state in the single-threaded browser environment.
+
+**Why is this internal?** The raw WASM bindings are not ergonomic for TypeScript developers. Method signatures use WASM-specific types, error handling follows Rust conventions, and the API surface mirrors the Rust struct layout rather than idiomatic JavaScript patterns. Exposing this layer directly would leak implementation details and create a brittle public API that breaks whenever the Rust internals change. By keeping it internal, the TypeScript and React SDKs can provide stable, idiomatic interfaces while the bridge evolves freely.
+
+### `ts-sdk` — The TypeScript Developer Experience
+
+**Package:** `@miden-sdk/ts-sdk` · **Location:** [`crates/web-client`](./crates/web-client) (JS layer)
+
+The TypeScript SDK is the **primary way to interact with the Miden network from JavaScript/TypeScript**. Its most important use case is **Node.js backend development** — building server-side services, indexers, bots, relayers, market makers, and any backend infrastructure that needs to read Miden state, submit transactions, or manage accounts programmatically. Think of it as the TypeScript equivalent of using the Rust SDK directly: full access to every client capability, but from Node.js with idiomatic async/await patterns and full type safety.
+
+Beyond Node.js backends, the TypeScript SDK also serves **non-React frontend environments** — Vue, Svelte, Angular, Solid, vanilla JavaScript, or any web framework that isn't React. If you're building a Miden-integrated application and don't want (or need) React, this is your entry point.
+
+The SDK wraps the WASM bridge in a resource-based API that feels native to TypeScript developers. Instead of calling raw WASM methods, developers interact with high-level resource objects:
+
+```typescript
+import { MidenClient } from "@miden-sdk/ts-sdk";
+
+// Node.js backend — e.g., a token distribution service
+const client = await MidenClient.create({ rpcUrl: "https://rpc.testnet.miden.io" });
+
+const faucet = await client.accounts.create({
+  type: AccountType.FungibleFaucet,
+  symbol: "TOKEN",
+  decimals: 8,
+  maxSupply: 1_000_000_000n,
+});
+
+// Mint and distribute tokens on a schedule
+for (const recipient of recipients) {
+  await client.transactions.mint({ account: faucet, to: recipient, amount: 1000n });
+}
+
+const balance = await client.accounts.getBalance(faucet, faucet);
+```
+
+```typescript
+// Non-React frontend — e.g., a Svelte or Vue wallet
+import { MidenClient } from "@miden-sdk/ts-sdk";
+
+const client = await MidenClient.create();
+const wallet = await client.accounts.create();
+await client.transactions.send({ account: wallet, to: recipient, token: faucet, amount: 100n });
+await client.notes.consumeAll({ account: wallet });
+```
+
+Key features of the TypeScript SDK:
+
+- **Node.js-first design** — the SDK is fully functional in Node.js environments, making it the go-to choice for building backend services that interact with Miden. Use it to build indexers that track on-chain state, bots that automate transaction flows, relayer services that submit transactions on behalf of users, or any server-side process that needs programmatic Miden access.
+- **Resource-based API** — operations are grouped under `client.accounts`, `client.transactions`, `client.notes`, `client.tags`, and `client.settings`, matching mental models from REST APIs and modern SDK design. This is the same API surface whether you're running on a Node.js server or in a browser tab.
+- **Factory methods** — `MidenClient.create()`, `MidenClient.createTestnet()`, and `MidenClient.createMock()` provide quick setup for different environments. A backend service connecting to a production node and a local development script use the same API, just different factory configurations.
+- **Full TypeScript type definitions** — comprehensive `.d.ts` declarations generated from both `wasm-bindgen` output and hand-authored type files, ensuring full IDE support and compile-time safety. Every account, note, transaction, and asset type is fully typed.
+- **Automatic resource management** — `client.terminate()` cleans up Web Workers (in browser contexts), with support for JavaScript's `using` syntax for automatic cleanup. In long-running Node.js processes, this ensures clean shutdown behavior.
+- **Transparent worker delegation** — in browser contexts, the client uses a `Proxy` to intercept method calls and route heavy operations (ZK proof generation, account creation) to a Web Worker automatically, without the developer needing to manage workers manually.
+
+**Why a separate package?** The TypeScript SDK exists because the JavaScript ecosystem extends far beyond React. Node.js is the most common runtime for backend services in the web3 space, and teams building on Miden need a first-class way to write backend infrastructure in TypeScript — not just frontends. A token distribution service, an automated market maker, a note relay, or a portfolio tracker all need the same core capabilities (accounts, transactions, sync) but have no use for React hooks or browser-specific APIs. The TypeScript SDK provides this framework-agnostic, runtime-agnostic foundation. It is also the building block for framework-specific integrations — the React SDK depends on it rather than reimplementing the WASM interaction, and future integrations for Vue, Svelte, or other frameworks would follow the same pattern.
+
+### `react-sdk` — The React Integration Layer
+
+**Package:** `@miden-sdk/react-sdk` · **Location:** [`packages/react-sdk`](./packages/react-sdk)
+
+The React SDK provides a complete React integration with hooks, context providers, and state management, following conventions established by libraries like TanStack Query and wagmi:
+
+```tsx
+import { MidenProvider, useAccounts, useCreateWallet, useSend } from "@miden-sdk/react-sdk";
+
+function App() {
+  return (
+    <MidenProvider config={{ rpcUrl: "testnet" }}>
+      <Wallet />
+    </MidenProvider>
+  );
+}
+
+function Wallet() {
+  const { wallets } = useAccounts();
+  const { mutate: createWallet, isLoading } = useCreateWallet();
+  const { mutate: send, stage } = useSend(); // stage: idle → executing → proving → submitting → complete
+
+  return (
+    <div>
+      <p>{wallets.length} wallets</p>
+      <button onClick={() => createWallet()}>New Wallet</button>
+      <p>Transaction: {stage}</p>
+    </div>
+  );
+}
+```
+
+Key features:
+
+- **`MidenProvider`** — a single provider component that handles WASM initialization, client construction, auto-sync (configurable interval, default 15s), and lifecycle management. Supports both local keystore and external signer modes.
+- **Query hooks** — `useAccounts()`, `useAccount(id)`, `useNotes()`, `useSyncState()`, `useAssetMetadata()`, `useTransactionHistory()`. All return `{ data, isLoading, error, refetch }`.
+- **Mutation hooks** — `useCreateWallet()`, `useCreateFaucet()`, `useSend()`, `useMultiSend()`, `useMint()`, `useConsume()`, `useSwap()`, `useTransaction()`. All return `{ mutate, data, isLoading, stage, error, reset }` with granular transaction stage tracking.
+- **Zustand state management** — a centralized store manages client state, cached data, loading states, and sync status, with optimized selector hooks to minimize unnecessary re-renders.
+- **External signer support** — a `SignerContext` enables integration with external key management services (Para, Turnkey, MidenFi wallet adapter) via a provider pattern, allowing wallets to use hardware keys, passkeys, or custodial signing services.
+- **Exclusive execution** — `runExclusive()` provides a mutex for operations that must not interleave, preventing race conditions in the single-threaded WASM environment.
+
+**Why a separate package?** React has its own paradigms — hooks, context, component lifecycle, state management — that don't belong in a general-purpose TypeScript SDK. By separating React-specific code, the core TypeScript SDK stays lean and framework-agnostic, while React developers get a first-class experience with hooks that handle loading states, error boundaries, caching, and re-render optimization automatically. This separation also allows the React SDK to evolve independently (e.g., adopting React Server Components or new React patterns) without affecting non-React consumers.
+
+## Supporting Components
+
+Beyond the four main SDK layers, the repository includes several supporting crates and packages:
+
+### Storage Backends
+
+| Crate | Target | Description |
+|-------|--------|-------------|
+| [`sqlite-store`](./crates/sqlite-store) | Native | SQLite-based persistence using `rusqlite` with connection pooling (`deadpool`). Maintains an in-memory Sparse Merkle Tree forest for efficient vault and storage proofs. Used by the CLI and Rust backends. |
+| [`idxdb-store`](./crates/idxdb-store) | Browser | IndexedDB-based persistence using Dexie.js. TypeScript source in `src/ts/` compiled to JavaScript in `src/js/` (both committed, CI verifies consistency). Supports multiple isolated databases per network via a registry pattern. |
+
+The `Store` trait abstracts all persistence operations (40+ async methods covering accounts, notes, transactions, chain data, sync state, and settings). Both backends implement atomic updates — if any part of a state sync or transaction application fails, the entire operation rolls back.
+
+### CLI
+
+[`bin/miden-cli`](./bin/miden-cli) — a `clap`-based command-line interface wrapping `Client<FilesystemKeyStore>` with SQLite storage. Supports account management, wallet creation, token minting/sending/swapping, note consumption, state sync, import/export, and direct program execution. Auto-discovers configuration from `.miden/miden-client.toml`.
+
+### Vite Plugin
+
+[`packages/vite-plugin`](./packages/vite-plugin) — a Vite plugin for applications consuming the WASM SDK. Handles proper WASM bundling, Web Worker configuration, and shared memory setup (required for WASM atomics).
+
+### Testing Infrastructure
+
+[`crates/testing`](./crates/testing) — shared test utilities, a test node builder for integration tests, and a remote prover server for testing delegated proving workflows.
+
+## Key Architectural Patterns
+
+### Trait-Based Dependency Injection
+
+The Rust core uses trait objects extensively to decouple components. The `Client` struct accepts any implementation of `Store`, `NodeRpcClient`, `TransactionProver`, `Keystore`, and `NoteTransportClient` via a builder pattern:
+
+```rust
+let client = ClientBuilder::for_testnet()
+    .store(my_store)
+    .authenticator(my_keystore)
+    .prover(RemoteTransactionProver::new(endpoint))
+    .build()
+    .await?;
+```
+
+This makes it possible to swap SQLite for IndexedDB, local proving for remote proving, or filesystem keys for hardware wallet signing — all without changing any client logic.
+
+### Atomic State Sync
+
+State synchronization is the most complex operation in the client. It must atomically apply a bundle of changes — new block headers, updated account states, committed/consumed notes, nullifier updates, MMR authentication nodes — to the local store. The `apply_state_sync()` method on the `Store` trait accepts a single `StateSyncUpdate` struct containing all changes, and implementations must apply them transactionally (SQLite uses a database transaction; IndexedDB uses a Dexie transaction spanning multiple object stores).
+
+### Web Worker Offloading
+
+Zero-knowledge proof generation and account creation are CPU-intensive operations that can take several seconds. The WASM bridge automatically offloads these to a dedicated Web Worker, preventing the main thread from freezing. The JavaScript layer uses a `Proxy` to transparently intercept method calls and route them to the worker, so consumers don't need to manage worker communication manually.
+
+### no_std Core with Platform-Specific Backends
+
+The Rust SDK is `#![no_std]` compatible, using `alloc` for heap allocations. Platform-specific functionality is provided through feature flags and conditional compilation:
+
+- **Native:** `std` feature enables `tonic` gRPC with TLS, filesystem keystore, and concurrent transaction execution.
+- **WASM:** `wasm32` target enables `tonic-web-wasm-client` for gRPC-Web, `getrandom/wasm_js` for browser entropy, and `web-sys` for Web API access.
+
+This design ensures the core logic compiles to any target Rust supports, while platform-specific integrations are cleanly separated.
+
+### Database Isolation by Network
+
+The IndexedDB store creates separate databases per network (`MidenClientDB_testnet`, `MidenClientDB_devnet`, etc.) via a JavaScript-side registry. This prevents testnet and devnet state from colliding in the same browser and allows external signer providers to create isolated databases per user (`mywallet_{address}`).
+
+## Repository Structure
+
+```
+bin/
+├── miden-cli/                # CLI binary (@miden-sdk/rust-sdk wrapper)
+├── integration-tests/        # End-to-end integration tests
+└── miden-bench/              # Benchmarks
+
+crates/
+├── rust-client/              # rust-sdk — core client library (miden-client)
+├── web-client/               # wasm-bridge + ts-sdk — WASM compilation and TS API
+├── idxdb-store/              # IndexedDB storage backend (browser)
+├── sqlite-store/             # SQLite storage backend (native)
+├── node-client/              # Node.js native module (N-API)
+└── testing/                  # Test infrastructure
+    ├── miden-client-tests/   # Shared test utilities
+    ├── node-builder/         # Test node builder
+    └── prover/               # Remote prover for testing
+
+packages/
+├── react-sdk/                # react-sdk — React hooks and providers
+└── vite-plugin/              # Vite plugin for WASM bundling
+```
+
+## Getting Started
+
+### For Rust developers
+
+Add the client as a dependency:
+
+```toml
+[dependencies]
+miden-client = { version = "0.14", features = ["std", "tonic"] }
+```
+
+See the [Rust SDK README](./crates/rust-client/README.md) for details on feature flags and store implementations.
+
+### For TypeScript / Node.js developers
+
+```bash
+npm install @miden-sdk/ts-sdk
+```
+
+```typescript
+import { MidenClient } from "@miden-sdk/ts-sdk";
+
+// Node.js backend service
+const client = await MidenClient.create({ rpcUrl: "https://rpc.testnet.miden.io" });
+const wallet = await client.accounts.create();
+await client.sync();
+
+// Also works in browser environments (Vue, Svelte, Angular, vanilla JS)
+```
+
+The TypeScript SDK is the primary choice for Node.js backends — indexers, bots, relayers, distribution services, and any server-side Miden integration. It also works in non-React browser environments. See the [TypeScript SDK README](./crates/web-client/README.md) for full API documentation and examples.
+
+### For React developers
+
+```bash
+npm install @miden-sdk/react-sdk @miden-sdk/ts-sdk
+```
+
+```tsx
+import { MidenProvider, useAccounts, useCreateWallet } from "@miden-sdk/react-sdk";
+
+function App() {
+  return (
+    <MidenProvider config={{ rpcUrl: "testnet" }}>
+      <Wallet />
+    </MidenProvider>
+  );
+}
+```
+
+See the [React SDK README](./packages/react-sdk/README.md) for hooks reference, signer integration, and usage patterns.
+
+### CLI
+
+```bash
+# Install
+cargo install miden-client-cli
+
+# Or build from source
+make install
+```
+
+See the [CLI README](./bin/miden-cli/README.md) for command reference and configuration.
+
+## Development
+
+### Prerequisites
+
+- Rust toolchain (see `rust-toolchain.toml`)
+- Node.js >= 18 + Yarn
+- `make` for build orchestration
+
+### Common Commands
+
+```bash
+make install-tools          # Install dev tools (nextest, taplo, typos, etc.)
+make build                  # Build all Rust crates
+make build-wasm             # Build WASM targets
+make build-react-sdk        # Build web-client + react-sdk
+make lint                   # Run all lints (format, clippy, typos, eslint)
+make format                 # Format all code (Rust, TS, TOML)
+make test                   # Run unit tests
+make test-docs              # Run documentation tests
+make integration-test       # Run integration tests (requires test node)
+make start-node-background  # Start local test node
+make stop-node              # Stop local test node
+```
+
+### Testing
+
+```bash
+# Unit tests
+make test
+
+# Integration tests (requires running node)
+make start-node-background
+make integration-test
+make stop-node
+
+# Web client integration tests (Playwright)
+make integration-test-web-client
+
+# React SDK tests
+cd packages/react-sdk && yarn test
+```
+
+## Resources
+
+- [Getting Started](https://0xMiden.github.io/miden-docs/miden-client/get-started/prerequisites.html)
 - [CLI Reference](https://0xMiden.github.io/miden-docs/miden-client/cli-reference.html)
 - [Configuration](https://0xMiden.github.io/miden-docs/miden-client/cli-config.html)
 - [Online Documentation](https://0xMiden.github.io/miden-docs/miden-client/index.html)
-
-## Workspace structure
-
-The workspace is organized as follows:
-- The `bin` folder contains crates that are meant to be compiled into binaries (like the CLI).
-- The `crates` folder contains the library crates that are meant to be used as dependencies (like the Rust client library).
-
-### Makefile
-
-We use `make` to encapsulate some tasks, such as running lints and tests. You can check out [Makefile](./Makefile) for all available tasks or just run the following command:
-
-```bash
-make
-```
-
-## Testing
-
-To test the project's code, we provide both unit tests (which can be run with `cargo test`) and integration tests. For more info on integration tests, refer to the [integration testing document](./bin/integration-tests/README.md)
 
 ## Contributing
 
 Interested in contributing? Check [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## License
+
 This project is [MIT licensed](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -193,8 +193,8 @@ function App() {
 
 function Wallet() {
   const { wallets } = useAccounts();
-  const { mutate: createWallet, isLoading } = useCreateWallet();
-  const { mutate: send, stage } = useSend(); // stage: idle → executing → proving → submitting → complete
+  const { createWallet, isCreating } = useCreateWallet();
+  const { send, stage } = useSend(); // stage: idle → executing → proving → submitting → complete
 
   return (
     <div>
@@ -210,7 +210,7 @@ Key features:
 
 - **`MidenProvider`** — a single provider component that handles WASM initialization, client construction, auto-sync (configurable interval, default 15s), and lifecycle management. Supports both local keystore and external signer modes.
 - **Query hooks** — `useAccounts()`, `useAccount(id)`, `useNotes()`, `useSyncState()`, `useAssetMetadata()`, `useTransactionHistory()`. All return `{ data, isLoading, error, refetch }`.
-- **Mutation hooks** — `useCreateWallet()`, `useCreateFaucet()`, `useSend()`, `useMultiSend()`, `useMint()`, `useConsume()`, `useSwap()`, `useTransaction()`. All return `{ mutate, data, isLoading, stage, error, reset }` with granular transaction stage tracking.
+- **Mutation hooks** — `useCreateWallet()`, `useCreateFaucet()`, `useSend()`, `useMultiSend()`, `useMint()`, `useConsume()`, `useSwap()`, `useTransaction()`. Each returns a named action function alongside `isLoading`, `stage`, `error`, and result state, with granular transaction stage tracking (`idle` → `executing` → `proving` → `submitting` → `complete`).
 - **Zustand state management** — a centralized store manages client state, cached data, loading states, and sync status, with optimized selector hooks to minimize unnecessary re-renders.
 - **External signer support** — a `SignerContext` enables integration with external key management services (Para, Turnkey, MidenFi wallet adapter) via a provider pattern, allowing wallets to use hardware keys, passkeys, or custodial signing services.
 - **Exclusive execution** — `runExclusive()` provides a mutex for operations that must not interleave, preventing race conditions in the single-threaded WASM environment.

--- a/README.md
+++ b/README.md
@@ -161,16 +161,7 @@ The `Store` trait abstracts all persistence operations. Implementations must app
 
 ### CLI
 
-**Crate:** `miden-client-cli`
-
-A command-line interface for interacting with the Miden network directly from a terminal. Wraps the Rust SDK with SQLite storage. See the [CLI README](./bin/miden-cli/README.md) for the full command reference and configuration.
-
-```bash
-miden-client init --network testnet
-miden-client sync
-miden-client new-wallet
-miden-client send --sender <wallet-id> --target <recipient-id> --faucet <faucet-id> --amount 100
-```
+**Crate:** `miden-client-cli` — a command-line interface wrapping the Rust SDK with SQLite storage. See the [CLI README](./bin/miden-cli/README.md) for the full command reference and configuration.
 
 ### Testing Infrastructure
 
@@ -282,9 +273,6 @@ See the [`react-sdk` repository](https://github.com/0xMiden/react-sdk) for hooks
 
 ```bash
 cargo install miden-client-cli --locked
-miden-client init --network testnet
-miden-client sync
-miden-client new-wallet
 ```
 
 See the [CLI README](./bin/miden-cli/README.md) for the full command reference and configuration.

--- a/README.md
+++ b/README.md
@@ -19,21 +19,21 @@ The SDK is organized as a layered stack. Each layer builds on the one below it, 
 ```mermaid
 graph TB
     subgraph rust-sdk-repo["rust-sdk repo"]
-        rust-sdk["rust-sdk · Rust · native + WASM\nCore client library\naccounts · notes · transactions"]
-        wasm-bridge["wasm-bridge · Rust → WASM · internal\nwasm-bindgen · idxdb-store · web-tonic"]
+        rust-sdk["<b>rust-sdk</b><br/>Core client library<br/>accounts · notes · transactions"]
+        wasm-bridge["<b>wasm-bridge</b><br/>Compiled via wasm-bindgen<br/>idxdb-store · web-tonic"]
     end
 
     subgraph ts-sdk-repo["ts-sdk repo"]
-        ts-sdk["ts-sdk · TypeScript · web + Node.js\nIdiomatic TS wrapper\ntyped API · async helpers"]
+        ts-sdk["<b>ts-sdk</b><br/>Idiomatic TS wrapper<br/>typed API · async helpers"]
     end
 
     subgraph react-sdk-repo["react-sdk repo"]
-        react-sdk["react-sdk · TypeScript · React\nReact integration layer\nhooks · context · zustand"]
+        react-sdk["<b>react-sdk</b><br/>React integration layer<br/>hooks · context · zustand"]
     end
 
     rust-sdk -- "cargo build --target wasm32" --> wasm-bridge
     wasm-bridge -- "imports" --> ts-sdk
-    ts-sdk -- "peer dependency" --> react-sdk
+    wasm-bridge -- "imports" --> react-sdk
 ```
 
 ### Layer Overview

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ graph TB
 | Layer | Published as | Language | Purpose |
 |-------|-------------|----------|---------|
 | **rust-sdk** | [`miden-client`](https://crates.io/crates/miden-client) (crates.io) | Rust | Core client library — account management, note handling, transaction building/execution/proving, state sync, node communication |
-| **wasm-bridge** | *(internal, not published separately)* | Rust → WASM | Compiles the Rust core to WebAssembly via `wasm-bindgen`. Serves as the compilation boundary between Rust and JavaScript |
+| **wasm-bridge** | `@miden-sdk/wasm-bridge` (npm, internal) | Rust → WASM | Compiles the Rust core to WebAssembly via `wasm-bindgen`. Serves as the compilation boundary between Rust and JavaScript |
 | **ts-sdk** | [`@miden-sdk/ts-sdk`](https://www.npmjs.com/package/@miden-sdk/ts-sdk) (npm) | TypeScript | Idiomatic TypeScript wrapper over the WASM bridge. Primary entry point for **Node.js backends** and non-React frontends |
 | **react-sdk** | [`@miden-sdk/react-sdk`](https://www.npmjs.com/package/@miden-sdk/react-sdk) (npm) | TypeScript | React integration layer — hooks, context providers, Zustand state management, auto-sync, and external signer support |
 

--- a/README.md
+++ b/README.md
@@ -120,33 +120,9 @@ const balance = await client.accounts.getBalance(faucet, faucet);
 
 **Package:** [`@miden-sdk/react-sdk`](https://www.npmjs.com/package/@miden-sdk/react-sdk)
 
-The React SDK provides hooks, context providers, and Zustand-based state management for React applications, following conventions established by libraries like TanStack Query and wagmi. See the [`react-sdk` repository](https://github.com/0xMiden/react-sdk) for the full hooks reference, signer integration, and usage patterns.
+The React SDK provides hooks, context providers, and Zustand-based state management for React applications, following conventions established by libraries like TanStack Query and wagmi. Includes hooks for account management (`useAccounts`, `useCreateWallet`), transactions (`useSend`, `useMint`, `useSwap`), note handling (`useNotes`, `useConsume`), and external signer integration (Para, Turnkey, MidenFi).
 
-```tsx
-import { MidenProvider, useAccounts, useCreateWallet, useSend } from "@miden-sdk/react-sdk";
-
-function App() {
-  return (
-    <MidenProvider config={{ rpcUrl: "testnet" }}>
-      <Wallet />
-    </MidenProvider>
-  );
-}
-
-function Wallet() {
-  const { wallets } = useAccounts();
-  const { createWallet, isCreating } = useCreateWallet();
-  const { send, stage } = useSend(); // stage: idle → executing → proving → submitting → complete
-
-  return (
-    <div>
-      <p>{wallets.length} wallets</p>
-      <button onClick={() => createWallet()}>New Wallet</button>
-      <p>Transaction: {stage}</p>
-    </div>
-  );
-}
-```
+See the [`react-sdk` repository](https://github.com/0xMiden/react-sdk) for the full hooks reference, usage patterns, and signer integration guide.
 
 ## Supporting Components
 

--- a/README.md
+++ b/README.md
@@ -343,24 +343,18 @@ The IndexedDB store creates separate databases per network (`MidenClientDB_testn
 
 ```
 bin/
-├── miden-cli/                # CLI binary (@miden-sdk/rust-sdk wrapper)
+├── miden-cli/                # CLI binary (rust-sdk wrapper)
 ├── integration-tests/        # End-to-end integration tests
 └── miden-bench/              # Benchmarks
 
 crates/
 ├── rust-client/              # rust-sdk — core client library (miden-client)
-├── web-client/               # wasm-bridge + ts-sdk — WASM compilation and TS API
 ├── idxdb-store/              # IndexedDB storage backend (browser)
 ├── sqlite-store/             # SQLite storage backend (native)
-├── node-client/              # Node.js native module (N-API)
 └── testing/                  # Test infrastructure
     ├── miden-client-tests/   # Shared test utilities
     ├── node-builder/         # Test node builder
     └── prover/               # Remote prover for testing
-
-packages/
-├── react-sdk/                # react-sdk — React hooks and providers
-└── vite-plugin/              # Vite plugin for WASM bundling
 ```
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -93,28 +93,7 @@ The TypeScript SDK is the **primary way to interact with the Miden network from 
 
 Beyond Node.js backends, the TypeScript SDK also serves **non-React frontend environments** — Vue, Svelte, Angular, Solid, vanilla JavaScript, or any web framework that isn't React. If you're building a Miden-integrated application and don't want (or need) React, this is your entry point.
 
-The SDK wraps the WASM bridge in a resource-based API that feels native to TypeScript developers:
-
-```typescript
-import { MidenClient, AccountType } from "@miden-sdk/ts-sdk";
-
-// Node.js backend — e.g., a token distribution service
-const client = await MidenClient.create({ rpcUrl: "https://rpc.testnet.miden.io" });
-
-const faucet = await client.accounts.create({
-  type: AccountType.FungibleFaucet,
-  symbol: "TOKEN",
-  decimals: 8,
-  maxSupply: 1_000_000_000n,
-});
-
-// Mint and distribute tokens on a schedule
-for (const recipient of recipients) {
-  await client.transactions.mint({ account: faucet, to: recipient, amount: 1000n });
-}
-
-const balance = await client.accounts.getBalance(faucet, faucet);
-```
+See the [`ts-sdk` repository](https://github.com/0xMiden/ts-sdk) for the full API reference and usage examples.
 
 ### `react-sdk` — The React Integration Layer
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Miden Client
+# Miden Rust SDK
 
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/0xMiden/miden-client/blob/main/LICENSE)
 [![test](https://github.com/0xMiden/miden-client/actions/workflows/test.yml/badge.svg)](https://github.com/0xMiden/miden-client/actions/workflows/test.yml)
@@ -6,7 +6,7 @@
 [![RUST_VERSION](https://img.shields.io/badge/rustc-1.90+-lightgray.svg)](https://www.rust-lang.org/tools/install)
 [![crates.io](https://img.shields.io/crates/v/miden-client)](https://crates.io/crates/miden-client)
 
-The official client SDK for the [Miden](https://miden.io) rollup. This monorepo provides everything needed to interact with the Miden network — from the low-level Rust core to high-level React hooks — across native and browser environments.
+The official client SDK for the [Miden](https://miden.io) protocol. This monorepo provides everything needed to interact with the Miden network — from the low-level Rust core to high-level React hooks — across native and browser environments.
 
 ### Status
 
@@ -17,71 +17,43 @@ The Miden client is under active development and should be considered *alpha*. A
 The SDK is organized as a layered stack. Each layer builds on the one below it, providing progressively higher-level abstractions while maintaining full access to the underlying capabilities when needed.
 
 ```mermaid
-%%{init: {
-    'theme': 'base',
-    'themeVariables': {
-      'primaryColor': '#0d1117',
-      'primaryTextColor': '#c9d1d9',
-      'primaryBorderColor': '#30363d',
-      'lineColor': '#484f58',
-      'fontFamily': 'JetBrains Mono, Fira Code, Consolas, monospace',
-      'fontSize': '13px'
-    }
-  }}%%
+graph TB
+    subgraph rust-sdk-repo["rust-sdk repo"]
+        rust-sdk["rust-sdk · Rust · native + WASM\nCore client library\naccounts · notes · transactions"]
+        wasm-bridge["wasm-bridge · Rust → WASM · internal\nwasm-bindgen · idxdb-store · web-tonic"]
+    end
 
-  graph TB
-      rust-sdk["<b>rust-sdk</b><br/><span style='color:#484f58'>───────────────────────────</span><br/><span
-  style='color:#7ee787'>lang: Rust │ target: native</span><br/><span
-  style='color:#484f58'>───────────────────────────</span><br/><br/><span style='color:#c9d1d9'>Core client
-  library</span><br/><span style='color:#8b949e'>accounts · notes · transactions</span><br/><span
-  style='color:#8b949e'>@miden-sdk/rust-sdk</span><br/><br/><span
-  style='color:#484f58'>───────────────────────────</span><br/><span style='color:#7ee787'>▸ Rust Backends</span>"]
+    subgraph ts-sdk-repo["ts-sdk repo"]
+        ts-sdk["ts-sdk · TypeScript · web + Node.js\nIdiomatic TS wrapper\ntyped API · async helpers"]
+    end
 
-      wasm-bridge["<b>wasm-bridge</b><br/><span style='color:#484f58'>───────────────────────────</span><br/><span
-  style='color:#d2a8ff'>lang: Rust → WASM │ internal</span><br/><span
-  style='color:#484f58'>───────────────────────────</span><br/><br/><span style='color:#c9d1d9'>Compiled via
-  wasm-bindgen</span><br/><span style='color:#8b949e'>wasm-pack · wasm-bindgen</span><br/><span
-  style='color:#8b949e'>idxdb-store · web-tonic</span><br/><br/><span
-  style='color:#484f58'>───────────────────────────</span><br/><span style='color:#d2a8ff'>▸ WASM Base Layer ·
-  Internal</span>"]
+    subgraph react-sdk-repo["react-sdk repo"]
+        react-sdk["react-sdk · TypeScript · React\nReact integration layer\nhooks · context · zustand"]
+    end
 
-      ts-sdk["<b>ts-sdk</b><br/><span style='color:#484f58'>───────────────────────────</span><br/><span
-  style='color:#79c0ff'>lang: TypeScript │ target: web</span><br/><span
-  style='color:#484f58'>───────────────────────────</span><br/><br/><span style='color:#c9d1d9'>Idiomatic TS
-  wrapper</span><br/><span style='color:#8b949e'>typed API · async helpers</span><br/><span
-  style='color:#8b949e'>@miden-sdk/ts-sdk</span><br/><br/><span
-  style='color:#484f58'>───────────────────────────</span><br/><span style='color:#79c0ff'>▸ TS Backends · non-React
-  FEs</span>"]
-
-      react-sdk["<b>react-sdk</b><br/><span style='color:#484f58'>───────────────────────────</span><br/><span
-  style='color:#ff7b72'>lang: TypeScript │ target: React</span><br/><span
-  style='color:#484f58'>───────────────────────────</span><br/><br/><span style='color:#c9d1d9'>React integration
-  layer</span><br/><span style='color:#8b949e'>hooks · context · zustand</span><br/><span
-  style='color:#8b949e'>@miden-sdk/react-sdk</span><br/><br/><span
-  style='color:#484f58'>───────────────────────────</span><br/><span style='color:#ff7b72'>▸ React Frontends</span>"]
-
-      rust-sdk -- "cargo build --target wasm32" --> wasm-bridge
-      wasm-bridge -- "import * from '@miden'" --> ts-sdk
-      wasm-bridge -- "import * from '@miden'" --> react-sdk
-
-      style rust-sdk fill:#0d1117,stroke:#7ee787,stroke-width:1.5px,color:#c9d1d9,rx:4,ry:4
-      style wasm-bridge fill:#0d1117,stroke:#d2a8ff,stroke-width:1.5px,color:#c9d1d9,rx:4,ry:4
-      style ts-sdk fill:#0d1117,stroke:#79c0ff,stroke-width:1.5px,color:#c9d1d9,rx:4,ry:4
-      style react-sdk fill:#0d1117,stroke:#ff7b72,stroke-width:1.5px,color:#c9d1d9,rx:4,ry:4
-
-      linkStyle 0 stroke:#d2a8ff,stroke-width:1.5px,stroke-dasharray:5 5
-      linkStyle 1 stroke:#79c0ff,stroke-width:1.5px,stroke-dasharray:5 5
-      linkStyle 2 stroke:#ff7b72,stroke-width:1.5px,stroke-dasharray:5 5
+    rust-sdk -- "cargo build --target wasm32" --> wasm-bridge
+    wasm-bridge -- "imports" --> ts-sdk
+    ts-sdk -- "peer dependency" --> react-sdk
 ```
 
 ### Layer Overview
 
-| Layer | Package | Language | Purpose |
-|-------|---------|----------|---------|
-| **rust-sdk** | `@miden-sdk/rust-sdk` | Rust | Core client library — account management, note handling, transaction building/execution/proving, state sync, node communication |
-| **wasm-bridge** | *(internal)* | Rust → WASM | Compiles the Rust core to WebAssembly via `wasm-bindgen`. Not published as a standalone package — serves as the compilation boundary between Rust and JavaScript |
-| **ts-sdk** | `@miden-sdk/ts-sdk` | TypeScript | Idiomatic TypeScript wrapper over the WASM bridge. Primary entry point for **Node.js backends** (indexers, bots, relayers, server-side services) and non-React frontends (Vue, Svelte, Angular, vanilla JS). Resource-based API, async helpers, and full type definitions |
-| **react-sdk** | `@miden-sdk/react-sdk` | TypeScript | React integration layer — hooks, context providers, Zustand state management, auto-sync, and external signer support |
+| Layer | Published as | Language | Purpose |
+|-------|-------------|----------|---------|
+| **rust-sdk** | [`miden-client`](https://crates.io/crates/miden-client) (crates.io) | Rust | Core client library — account management, note handling, transaction building/execution/proving, state sync, node communication |
+| **wasm-bridge** | *(internal, not published separately)* | Rust → WASM | Compiles the Rust core to WebAssembly via `wasm-bindgen`. Serves as the compilation boundary between Rust and JavaScript |
+| **ts-sdk** | [`@miden-sdk/ts-sdk`](https://www.npmjs.com/package/@miden-sdk/ts-sdk) (npm) | TypeScript | Idiomatic TypeScript wrapper over the WASM bridge. Primary entry point for **Node.js backends** and non-React frontends |
+| **react-sdk** | [`@miden-sdk/react-sdk`](https://www.npmjs.com/package/@miden-sdk/react-sdk) (npm) | TypeScript | React integration layer — hooks, context providers, Zustand state management, auto-sync, and external signer support |
+
+### Repository Split
+
+The codebase will be split across three repositories, each owning one boundary of the stack:
+
+| Repository | Contains | Rationale |
+|------------|----------|-----------|
+| **`rust-sdk`** | Rust core library + WASM bridge + CLI + storage backends (sqlite-store, idxdb-store) | The WASM bridge is a Rust crate compiled with `wasm-bindgen` — it belongs with the Rust code it wraps. Storage backends implement Rust traits and are tightly coupled to the core. |
+| **`ts-sdk`** | TypeScript API surface + JS worker layer + type definitions | The idiomatic TS wrapper, factory methods, resource-based API, and `.d.ts` declarations. Depends on `rust-sdk` as a build-time WASM dependency. |
+| **`react-sdk`** | React hooks, providers, Zustand store, signer integrations | Framework-specific code that depends on `ts-sdk` as a peer dependency. Evolves independently with React ecosystem changes. |
 
 ## Motivation
 
@@ -93,7 +65,7 @@ Rather than forcing one language to do everything, the SDK embraces the boundary
 
 ### `rust-sdk` — The Foundational Core
 
-**Package:** `@miden-sdk/rust-sdk` · **Crate:** `miden-client`
+**Crate:** [`miden-client`](https://crates.io/crates/miden-client)
 
 The Rust SDK is the single source of truth for all Miden client logic. It is a `#![no_std]`-compatible library that implements:
 
@@ -101,36 +73,27 @@ The Rust SDK is the single source of truth for all Miden client logic. It is a `
 - **Note handling** — note screening, filtering, consumption, and export/import. Notes are Miden's UTXO-like primitive for transferring assets and encoding arbitrary logic.
 - **Transaction building and execution** — constructing transactions from note consumption and script execution, running them through the Miden VM, and generating zero-knowledge proofs (locally or via a remote prover).
 - **State synchronization** — maintaining a local partial view of the blockchain by syncing with a Miden node. The sync mechanism fetches new block headers, note inclusion proofs, nullifier updates, and account state changes, then applies them atomically to the local store.
-- **Node communication** — a `NodeRpcClient` trait with a gRPC implementation that handles all RPC interactions including state sync, transaction submission, and data retrieval. On native targets, this uses `tonic` with TLS; on WASM, it uses `tonic-web-wasm-client`.
+- **Node communication** — a `NodeRpcClient` trait with a gRPC implementation that handles all RPC interactions including state sync, transaction submission, and data retrieval.
 - **Key management** — a `Keystore` trait for managing signing keys, with a filesystem implementation for native and a Dexie-backed implementation for browsers.
 - **Private note transport** — an optional transport network for delivering encrypted notes directly between parties without broadcasting them on-chain.
 
-The Rust SDK is designed to be used directly by Rust backends, CLIs, and any native application. The `Client` struct is generic over an authenticator type (`Client<AUTH>`) and uses trait-based dependency injection for storage (`Store`), RPC (`NodeRpcClient`), proving (`TransactionProver`), and key management (`Keystore`), making every component swappable.
-
-**Why a separate package?** The Rust SDK is a crates.io-published library with its own versioning, feature flags, and dependency tree. It must remain independent of any JavaScript tooling so that pure-Rust consumers (backends, infrastructure, other Rust clients) can depend on it without pulling in web-related dependencies. The `no_std` compatibility ensures it can target embedded or constrained environments.
+The `Client` struct is generic over an authenticator type (`Client<AUTH>`) and uses trait-based dependency injection for storage (`Store`), RPC (`NodeRpcClient`), proving (`TransactionProver`), and key management (`Keystore`), making every component swappable.
 
 ### `wasm-bridge` — The Compilation Boundary
 
-The WASM bridge is the layer that compiles the Rust core into WebAssembly and exposes it to JavaScript via `wasm-bindgen`. It is **not published as a standalone package** — it exists purely as an internal build artifact that both the TypeScript SDK and React SDK consume.
+The WASM bridge compiles the Rust core into WebAssembly and exposes it to JavaScript via `wasm-bindgen`. It is **not published as a standalone package** — it exists purely as an internal build artifact that the TypeScript and React SDKs consume.
 
-This layer handles several concerns that are specific to the Rust-to-WASM boundary:
-
-- **Type marshalling** — Rust types are wrapped in `#[wasm_bindgen]` annotated structs that serialize/deserialize across the WASM boundary. Over 90 model wrapper types handle the translation between Rust's type system and JavaScript-compatible representations.
-- **Web Worker offloading** — computationally expensive operations (account creation, transaction execution, ZK proof generation) are automatically routed to a dedicated Web Worker so they don't block the main thread.
-- **IndexedDB storage** — the `idxdb-store` crate implements the `Store` trait using Dexie.js (an IndexedDB wrapper), with a TypeScript source layer compiled to JavaScript. The database schema includes separate "latest" and "historical" tables for account state, enabling efficient queries for current state while preserving full history.
-- **Sync locking** — an exclusive lock mechanism ensures that concurrent sync operations don't corrupt local state in the single-threaded browser environment.
-
-**Why is this internal?** The raw WASM bindings are not ergonomic for TypeScript developers. Method signatures use WASM-specific types, error handling follows Rust conventions, and the API surface mirrors the Rust struct layout rather than idiomatic JavaScript patterns. Exposing this layer directly would leak implementation details and create a brittle public API that breaks whenever the Rust internals change. By keeping it internal, the TypeScript and React SDKs can provide stable, idiomatic interfaces while the bridge evolves freely.
+This layer handles type marshalling (90+ `#[wasm_bindgen]` wrapper types), Web Worker offloading for CPU-intensive operations (ZK proof generation, account creation), IndexedDB storage via `idxdb-store`, and sync locking to prevent state corruption in the browser environment.
 
 ### `ts-sdk` — The TypeScript Developer Experience
 
-**Package:** `@miden-sdk/ts-sdk`
+**Package:** [`@miden-sdk/ts-sdk`](https://www.npmjs.com/package/@miden-sdk/ts-sdk)
 
 The TypeScript SDK is the **primary way to interact with the Miden network from JavaScript/TypeScript**. Its most important use case is **Node.js backend development** — building server-side services, indexers, bots, relayers, market makers, and any backend infrastructure that needs to read Miden state, submit transactions, or manage accounts programmatically. Think of it as the TypeScript equivalent of using the Rust SDK directly: full access to every client capability, but from Node.js with idiomatic async/await patterns and full type safety.
 
 Beyond Node.js backends, the TypeScript SDK also serves **non-React frontend environments** — Vue, Svelte, Angular, Solid, vanilla JavaScript, or any web framework that isn't React. If you're building a Miden-integrated application and don't want (or need) React, this is your entry point.
 
-The SDK wraps the WASM bridge in a resource-based API that feels native to TypeScript developers. Instead of calling raw WASM methods, developers interact with high-level resource objects:
+The SDK wraps the WASM bridge in a resource-based API that feels native to TypeScript developers:
 
 ```typescript
 import { MidenClient, AccountType } from "@miden-sdk/ts-sdk";
@@ -153,32 +116,11 @@ for (const recipient of recipients) {
 const balance = await client.accounts.getBalance(faucet, faucet);
 ```
 
-```typescript
-// Non-React frontend — e.g., a Svelte or Vue wallet
-import { MidenClient } from "@miden-sdk/ts-sdk";
-
-const client = await MidenClient.create();
-const wallet = await client.accounts.create();
-await client.transactions.send({ account: wallet, to: recipient, token: faucet, amount: 100n });
-await client.notes.consumeAll({ account: wallet });
-```
-
-Key features of the TypeScript SDK:
-
-- **Node.js-first design** — the SDK is fully functional in Node.js environments, making it the go-to choice for building backend services that interact with Miden. Use it to build indexers that track on-chain state, bots that automate transaction flows, relayer services that submit transactions on behalf of users, or any server-side process that needs programmatic Miden access.
-- **Resource-based API** — operations are grouped under `client.accounts`, `client.transactions`, `client.notes`, `client.tags`, and `client.settings`, matching mental models from REST APIs and modern SDK design. This is the same API surface whether you're running on a Node.js server or in a browser tab.
-- **Factory methods** — `MidenClient.create()`, `MidenClient.createTestnet()`, and `MidenClient.createMock()` provide quick setup for different environments. A backend service connecting to a production node and a local development script use the same API, just different factory configurations.
-- **Full TypeScript type definitions** — comprehensive `.d.ts` declarations generated from both `wasm-bindgen` output and hand-authored type files, ensuring full IDE support and compile-time safety. Every account, note, transaction, and asset type is fully typed.
-- **Automatic resource management** — `client.terminate()` cleans up Web Workers (in browser contexts), with support for JavaScript's `using` syntax for automatic cleanup. In long-running Node.js processes, this ensures clean shutdown behavior.
-- **Transparent worker delegation** — in browser contexts, the client uses a `Proxy` to intercept method calls and route heavy operations (ZK proof generation, account creation) to a Web Worker automatically, without the developer needing to manage workers manually.
-
-**Why a separate package?** The TypeScript SDK exists because the JavaScript ecosystem extends far beyond React. Node.js is the most common runtime for backend services in the web3 space, and teams building on Miden need a first-class way to write backend infrastructure in TypeScript — not just frontends. A token distribution service, an automated market maker, a note relay, or a portfolio tracker all need the same core capabilities (accounts, transactions, sync) but have no use for React hooks or browser-specific APIs. The TypeScript SDK provides this framework-agnostic, runtime-agnostic foundation. It is also the building block for framework-specific integrations — the React SDK depends on it rather than reimplementing the WASM interaction, and future integrations for Vue, Svelte, or other frameworks would follow the same pattern.
-
 ### `react-sdk` — The React Integration Layer
 
-**Package:** `@miden-sdk/react-sdk`
+**Package:** [`@miden-sdk/react-sdk`](https://www.npmjs.com/package/@miden-sdk/react-sdk)
 
-The React SDK provides a complete React integration with hooks, context providers, and state management, following conventions established by libraries like TanStack Query and wagmi:
+The React SDK provides hooks, context providers, and Zustand-based state management for React applications, following conventions established by libraries like TanStack Query and wagmi. See the [React SDK README](./packages/react-sdk/README.md) for the full hooks reference, signer integration, and usage patterns.
 
 ```tsx
 import { MidenProvider, useAccounts, useCreateWallet, useSend } from "@miden-sdk/react-sdk";
@@ -206,96 +148,29 @@ function Wallet() {
 }
 ```
 
-Key features:
-
-- **`MidenProvider`** — a single provider component that handles WASM initialization, client construction, auto-sync (configurable interval, default 15s), and lifecycle management. Supports both local keystore and external signer modes.
-- **Query hooks** — `useAccounts()`, `useAccount(id)`, `useNotes()`, `useSyncState()`, `useAssetMetadata()`, `useTransactionHistory()`. Each returns domain-specific data alongside `isLoading` and `error` state.
-- **Mutation hooks** — `useCreateWallet()`, `useCreateFaucet()`, `useSend()`, `useMultiSend()`, `useMint()`, `useConsume()`, `useSwap()`, `useTransaction()`. Each returns a named action function alongside `isLoading`, `stage`, `error`, and result state, with granular transaction stage tracking (`idle` → `executing` → `proving` → `submitting` → `complete`).
-- **Zustand state management** — a centralized store manages client state, cached data, loading states, and sync status, with optimized selector hooks to minimize unnecessary re-renders.
-- **External signer support** — a `SignerContext` enables integration with external key management services (Para, Turnkey, MidenFi wallet adapter) via a provider pattern, allowing wallets to use hardware keys, passkeys, or custodial signing services.
-- **Exclusive execution** — `runExclusive()` provides a mutex for operations that must not interleave, preventing race conditions in the single-threaded WASM environment.
-
-**Why a separate package?** React has its own paradigms — hooks, context, component lifecycle, state management — that don't belong in a general-purpose TypeScript SDK. By separating React-specific code, the core TypeScript SDK stays lean and framework-agnostic, while React developers get a first-class experience with hooks that handle loading states, error boundaries, caching, and re-render optimization automatically. This separation also allows the React SDK to evolve independently (e.g., adopting React Server Components or new React patterns) without affecting non-React consumers.
-
 ## Supporting Components
-
-Beyond the four main SDK layers, the repository includes several supporting crates and packages:
 
 ### Storage Backends
 
 | Crate | Target | Description |
 |-------|--------|-------------|
-| [`sqlite-store`](./crates/sqlite-store) | Native | SQLite-based persistence using `rusqlite` with connection pooling (`deadpool`). Maintains an in-memory Sparse Merkle Tree forest for efficient vault and storage proofs. Used by the CLI and Rust backends. |
-| [`idxdb-store`](./crates/idxdb-store) | Browser | IndexedDB-based persistence using Dexie.js. TypeScript source in `src/ts/` compiled to JavaScript in `src/js/` (both committed, CI verifies consistency). Supports multiple isolated databases per network via a registry pattern. |
+| [`sqlite-store`](./crates/sqlite-store) | Native | SQLite-based persistence using `rusqlite` with connection pooling. Used by the CLI and Rust backends. |
+| [`idxdb-store`](./crates/idxdb-store) | Browser | IndexedDB-based persistence using Dexie.js. Supports multiple isolated databases per network. |
 
-The `Store` trait abstracts all persistence operations (40+ async methods covering accounts, notes, transactions, chain data, sync state, and settings). Both backends implement atomic updates — if any part of a state sync or transaction application fails, the entire operation rolls back.
+The `Store` trait abstracts all persistence operations. Both backends implement atomic updates — if any part of a state sync or transaction application fails, the entire operation rolls back.
 
-### CLI (`miden-client`)
+### CLI
 
 **Crate:** `miden-client-cli`
 
-The CLI is a full-featured command-line interface for interacting with the Miden network directly from a terminal. It wraps the Rust SDK (`Client<FilesystemKeyStore>`) with SQLite storage, providing a complete Miden experience without writing any code. It's the fastest way to explore the network, prototype transaction flows, and manage accounts during development.
-
-The CLI auto-discovers configuration from `.miden/miden-client.toml` (local project directory first, then `~/.miden/` global). Running `miden-client init` generates this file with RPC endpoint and database path settings.
-
-**Commands:**
-
-| Command | Description |
-|---------|-------------|
-| `init` | Initialize client configuration for a network (localhost, devnet, testnet, or custom endpoint) |
-| `sync` | Synchronize local state with the Miden node — fetches new blocks, note updates, and account changes |
-| `new-wallet` | Create a new wallet account (private/public storage, mutable/immutable, Falcon/ECDSA auth) |
-| `new-account` | Create a new account with advanced options |
-| `account` | List and inspect accounts — view IDs, balances, storage, vault contents |
-| `mint` | Mint tokens from a faucet account to a recipient |
-| `send` | Send tokens from one account to another (public or private notes) |
-| `swap` | Execute an atomic swap between two token types |
-| `consume-notes` | Consume available notes for an account, claiming their assets |
-| `notes` | List and inspect notes — filter by status (pending, committed, consumed) |
-| `tx` | View transaction history and details |
-| `exec` | Execute arbitrary Miden Assembly programs against an account |
-| `tags` | Manage note tags for filtering which notes the client tracks |
-| `address` | Display account addresses in hex and bech32 formats |
-| `import` / `export` | Import and export accounts and notes for backup or transfer between clients |
-| `info` | Display client state summary — sync height, account count, node connection status |
-
-**Example workflow:**
+A command-line interface for interacting with the Miden network directly from a terminal. Wraps the Rust SDK with SQLite storage. See the [CLI README](./bin/miden-cli/README.md) for the full command reference and configuration.
 
 ```bash
-# Initialize for testnet
 miden-client init --network testnet
-
-# Sync with the network
 miden-client sync
-
-# Create a wallet
 miden-client new-wallet
-
-# Create a faucet and mint tokens
-miden-client new-account -t fungible-faucet -s TOKEN -d 8 -m 1000000
-miden-client mint --faucet <faucet-id> --target <wallet-id> --amount 1000
-
-# Consume minted notes and check balance
-miden-client sync
-miden-client consume-notes --account <wallet-id>
-miden-client account -s <wallet-id>
-
-# Send tokens
 miden-client send --sender <wallet-id> --target <recipient-id> --faucet <faucet-id> --amount 100
 ```
-
-The `CliClient` struct is also available as a Rust library for projects that want CLI-style configuration discovery without building a full custom client:
-
-```rust
-use miden_client_cli::{CliClient, DebugMode};
-
-let mut client = CliClient::from_system_user_config(DebugMode::Disabled).await?;
-client.sync_state().await?;
-```
-
-### Vite Plugin
-
-[`packages/vite-plugin`](./packages/vite-plugin) — a Vite plugin for applications consuming the WASM SDK. Handles proper WASM bundling, Web Worker configuration, and shared memory setup (required for WASM atomics).
 
 ### Testing Infrastructure
 
@@ -305,7 +180,7 @@ client.sync_state().await?;
 
 ### Trait-Based Dependency Injection
 
-The Rust core uses trait objects extensively to decouple components. The `Client` struct accepts any implementation of `Store`, `NodeRpcClient`, `TransactionProver`, `Keystore`, and `NoteTransportClient` via a builder pattern:
+The Rust core uses trait objects to decouple components. The `Client` struct accepts any implementation of `Store`, `NodeRpcClient`, `TransactionProver`, `Keystore`, and `NoteTransportClient` via a builder pattern:
 
 ```rust
 let client = ClientBuilder::for_testnet()
@@ -320,24 +195,18 @@ This makes it possible to swap SQLite for IndexedDB, local proving for remote pr
 
 ### Atomic State Sync
 
-State synchronization is the most complex operation in the client. It must atomically apply a bundle of changes — new block headers, updated account states, committed/consumed notes, nullifier updates, MMR authentication nodes — to the local store. The `apply_state_sync()` method on the `Store` trait accepts a single `StateSyncUpdate` struct containing all changes, and implementations must apply them transactionally (SQLite uses a database transaction; IndexedDB uses a Dexie transaction spanning multiple object stores).
+State synchronization atomically applies a bundle of changes — new block headers, updated account states, committed/consumed notes, nullifier updates, MMR authentication nodes — to the local store. The `apply_state_sync()` method on the `Store` trait accepts a single `StateSyncUpdate` struct, and implementations must apply it transactionally.
 
 ### Web Worker Offloading
 
-Zero-knowledge proof generation and account creation are CPU-intensive operations that can take several seconds. The WASM bridge automatically offloads these to a dedicated Web Worker, preventing the main thread from freezing. The JavaScript layer uses a `Proxy` to transparently intercept method calls and route them to the worker, so consumers don't need to manage worker communication manually.
+ZK proof generation and account creation are CPU-intensive operations that can take several seconds. The WASM bridge automatically offloads these to a dedicated Web Worker, preventing the main thread from freezing.
 
 ### no_std Core with Platform-Specific Backends
 
-The Rust SDK is `#![no_std]` compatible, using `alloc` for heap allocations. Platform-specific functionality is provided through feature flags and conditional compilation:
+The Rust SDK is `#![no_std]` compatible. Platform-specific functionality is provided through feature flags:
 
-- **Native:** `std` feature enables `tonic` gRPC with TLS, filesystem keystore, and concurrent transaction execution.
-- **WASM:** `wasm32` target enables `tonic-web-wasm-client` for gRPC-Web, `getrandom/wasm_js` for browser entropy, and `web-sys` for Web API access.
-
-This design ensures the core logic compiles to any target Rust supports, while platform-specific integrations are cleanly separated.
-
-### Database Isolation by Network
-
-The IndexedDB store creates separate databases per network (`MidenClientDB_testnet`, `MidenClientDB_devnet`, etc.) via a JavaScript-side registry. This prevents testnet and devnet state from colliding in the same browser and allows external signer providers to create isolated databases per user (`mywallet_{address}`).
+- **Native:** `std` feature enables `tonic` gRPC with TLS, filesystem keystore, and concurrent execution.
+- **WASM:** `wasm32` target enables `tonic-web-wasm-client` for gRPC-Web and `web-sys` for browser APIs.
 
 ## Repository Structure
 
@@ -361,8 +230,6 @@ crates/
 
 ### For Rust developers
 
-Add the client as a dependency:
-
 ```toml
 [dependencies]
 miden-client = { version = "0.14", features = ["std", "tonic"] }
@@ -379,15 +246,12 @@ npm install @miden-sdk/ts-sdk
 ```typescript
 import { MidenClient } from "@miden-sdk/ts-sdk";
 
-// Node.js backend service
 const client = await MidenClient.create({ rpcUrl: "https://rpc.testnet.miden.io" });
 const wallet = await client.accounts.create();
 await client.sync();
-
-// Also works in browser environments (Vue, Svelte, Angular, vanilla JS)
 ```
 
-The TypeScript SDK is the primary choice for Node.js backends — indexers, bots, relayers, distribution services, and any server-side Miden integration. It also works in non-React browser environments. See the [TypeScript SDK README](./crates/web-client/README.md) for full API documentation and examples.
+The TypeScript SDK is the primary choice for Node.js backends — indexers, bots, relayers, distribution services — and non-React browser environments. See the [TypeScript SDK README](./crates/web-client/README.md) for full API documentation.
 
 ### For React developers
 
@@ -412,19 +276,13 @@ See the [React SDK README](./packages/react-sdk/README.md) for hooks reference, 
 ### CLI
 
 ```bash
-# Install from crates.io
 cargo install miden-client-cli --locked
-
-# Or build from source
-make install
-
-# Initialize and start using
 miden-client init --network testnet
 miden-client sync
 miden-client new-wallet
 ```
 
-The CLI is the quickest way to interact with Miden without writing code — create accounts, mint tokens, send transactions, and inspect state from your terminal. See the [CLI README](./bin/miden-cli/README.md) for the full command reference and configuration.
+See the [CLI README](./bin/miden-cli/README.md) for the full command reference and configuration.
 
 ## Development
 
@@ -440,32 +298,10 @@ The CLI is the quickest way to interact with Miden without writing code — crea
 make install-tools          # Install dev tools (nextest, taplo, typos, etc.)
 make build                  # Build all Rust crates
 make build-wasm             # Build WASM targets
-make build-react-sdk        # Build web-client + react-sdk
 make lint                   # Run all lints (format, clippy, typos, eslint)
 make format                 # Format all code (Rust, TS, TOML)
 make test                   # Run unit tests
-make test-docs              # Run documentation tests
 make integration-test       # Run integration tests (requires test node)
-make start-node-background  # Start local test node
-make stop-node              # Stop local test node
-```
-
-### Testing
-
-```bash
-# Unit tests
-make test
-
-# Integration tests (requires running node)
-make start-node-background
-make integration-test
-make stop-node
-
-# Web client integration tests (Playwright)
-make integration-test-web-client
-
-# React SDK tests
-cd packages/react-sdk && yarn test
 ```
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -24,16 +24,16 @@ graph TB
         rust-sdk -- "cargo build --target wasm32" --> wasm-bridge
     end
 
-    subgraph ts-sdk-repo["ts-sdk repo"]
-        ts-sdk["<b>ts-sdk</b><br/>Idiomatic TS wrapper<br/>typed API · async helpers"]
-    end
-
     subgraph react-sdk-repo["react-sdk repo"]
         react-sdk["<b>react-sdk</b><br/>React integration layer<br/>hooks · context · zustand"]
     end
 
-    wasm-bridge -- "npm package" --> ts-sdk
+    subgraph ts-sdk-repo["ts-sdk repo"]
+        ts-sdk["<b>ts-sdk</b><br/>Idiomatic TS wrapper<br/>typed API · async helpers"]
+    end
+
     wasm-bridge -- "npm package" --> react-sdk
+    wasm-bridge -- "npm package" --> ts-sdk
 ```
 
 ### Layer Overview

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Beyond Node.js backends, the TypeScript SDK also serves **non-React frontend env
 The SDK wraps the WASM bridge in a resource-based API that feels native to TypeScript developers. Instead of calling raw WASM methods, developers interact with high-level resource objects:
 
 ```typescript
-import { MidenClient } from "@miden-sdk/ts-sdk";
+import { MidenClient, AccountType } from "@miden-sdk/ts-sdk";
 
 // Node.js backend — e.g., a token distribution service
 const client = await MidenClient.create({ rpcUrl: "https://rpc.testnet.miden.io" });
@@ -209,7 +209,7 @@ function Wallet() {
 Key features:
 
 - **`MidenProvider`** — a single provider component that handles WASM initialization, client construction, auto-sync (configurable interval, default 15s), and lifecycle management. Supports both local keystore and external signer modes.
-- **Query hooks** — `useAccounts()`, `useAccount(id)`, `useNotes()`, `useSyncState()`, `useAssetMetadata()`, `useTransactionHistory()`. All return `{ data, isLoading, error, refetch }`.
+- **Query hooks** — `useAccounts()`, `useAccount(id)`, `useNotes()`, `useSyncState()`, `useAssetMetadata()`, `useTransactionHistory()`. Each returns domain-specific data alongside `isLoading` and `error` state.
 - **Mutation hooks** — `useCreateWallet()`, `useCreateFaucet()`, `useSend()`, `useMultiSend()`, `useMint()`, `useConsume()`, `useSwap()`, `useTransaction()`. Each returns a named action function alongside `isLoading`, `stage`, `error`, and result state, with granular transaction stage tracking (`idle` → `executing` → `proving` → `submitting` → `complete`).
 - **Zustand state management** — a centralized store manages client state, cached data, loading states, and sync status, with optimized selector hooks to minimize unnecessary re-renders.
 - **External signer support** — a `SignerContext` enables integration with external key management services (Para, Turnkey, MidenFi wallet adapter) via a provider pattern, allowing wallets to use hardware keys, passkeys, or custodial signing services.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Rather than forcing one language to do everything, the SDK embraces the boundary
 
 ### `rust-sdk` — The Foundational Core
 
-**Package:** `@miden-sdk/rust-sdk` · **Crate:** `miden-client` · **Location:** [`crates/rust-client`](./crates/rust-client)
+**Package:** `@miden-sdk/rust-sdk` · **Crate:** `miden-client`
 
 The Rust SDK is the single source of truth for all Miden client logic. It is a `#![no_std]`-compatible library that implements:
 
@@ -111,8 +111,6 @@ The Rust SDK is designed to be used directly by Rust backends, CLIs, and any nat
 
 ### `wasm-bridge` — The Compilation Boundary
 
-**Location:** [`crates/web-client`](./crates/web-client)
-
 The WASM bridge is the layer that compiles the Rust core into WebAssembly and exposes it to JavaScript via `wasm-bindgen`. It is **not published as a standalone package** — it exists purely as an internal build artifact that both the TypeScript SDK and React SDK consume.
 
 This layer handles several concerns that are specific to the Rust-to-WASM boundary:
@@ -126,7 +124,7 @@ This layer handles several concerns that are specific to the Rust-to-WASM bounda
 
 ### `ts-sdk` — The TypeScript Developer Experience
 
-**Package:** `@miden-sdk/ts-sdk` · **Location:** [`crates/web-client`](./crates/web-client) (JS layer)
+**Package:** `@miden-sdk/ts-sdk`
 
 The TypeScript SDK is the **primary way to interact with the Miden network from JavaScript/TypeScript**. Its most important use case is **Node.js backend development** — building server-side services, indexers, bots, relayers, market makers, and any backend infrastructure that needs to read Miden state, submit transactions, or manage accounts programmatically. Think of it as the TypeScript equivalent of using the Rust SDK directly: full access to every client capability, but from Node.js with idiomatic async/await patterns and full type safety.
 
@@ -178,7 +176,7 @@ Key features of the TypeScript SDK:
 
 ### `react-sdk` — The React Integration Layer
 
-**Package:** `@miden-sdk/react-sdk` · **Location:** [`packages/react-sdk`](./packages/react-sdk)
+**Package:** `@miden-sdk/react-sdk`
 
 The React SDK provides a complete React integration with hooks, context providers, and state management, following conventions established by libraries like TanStack Query and wagmi:
 
@@ -234,7 +232,7 @@ The `Store` trait abstracts all persistence operations (40+ async methods coveri
 
 ### CLI (`miden-client`)
 
-**Crate:** `miden-client-cli` · **Location:** [`bin/miden-cli`](./bin/miden-cli)
+**Crate:** `miden-client-cli`
 
 The CLI is a full-featured command-line interface for interacting with the Miden network directly from a terminal. It wraps the Rust SDK (`Client<FilesystemKeyStore>`) with SQLite storage, providing a complete Miden experience without writing any code. It's the fastest way to explore the network, prototype transaction flows, and manage accounts during development.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ graph TB
     end
 
     subgraph ts-sdk-repo["ts-sdk repo"]
-        wasm-bridge["<b>wasm-bridge</b><br/>Compiled via wasm-bindgen<br/>idxdb-store · web-tonic"]
+        wasm-bridge["<b>wasm-bridge</b> (internal)<br/>Compiled via wasm-bindgen<br/>idxdb-store · web-tonic"]
         ts-sdk["<b>ts-sdk</b><br/>Idiomatic TS wrapper<br/>typed API · async helpers"]
     end
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ graph TB
     end
 
     subgraph wasm-bridge-repo["wasm-bridge repo"]
-        wasm-bridge["<b>wasm-bridge</b><br/>Rust → WASM compilation boundary<br/>wasm-bindgen · idxdb-store · web workers"]
+        wasm-bridge["<b>wasm-bridge</b><br/>WASM runtime layer<br/>wasm-bindgen · idxdb-store · web workers"]
     end
 
     subgraph ts-sdk-repo["ts-sdk repo"]
@@ -44,7 +44,7 @@ graph TB
 | Layer | Published as | Language | Purpose |
 |-------|-------------|----------|---------|
 | **rust-sdk** | [`miden-client`](https://crates.io/crates/miden-client) (crates.io) | Rust | Core client library — account management, note handling, transaction building/execution/proving, state sync, node communication |
-| **wasm-bridge** | [`@miden-sdk/wasm-bridge`](https://www.npmjs.com/package/@miden-sdk/wasm-bridge) (npm) | Rust → WASM + JS | Compiles the Rust core to WebAssembly via `wasm-bindgen`. Owns the full build pipeline (Rollup, Web Workers, IndexedDB storage) and publishes the npm package consumed by downstream SDKs |
+| **wasm-bridge** | [`@miden-sdk/wasm-bridge`](https://www.npmjs.com/package/@miden-sdk/wasm-bridge) (npm) | Rust → WASM + JS | WASM runtime layer — compiles the Rust core to WebAssembly, manages Web Worker orchestration, IndexedDB persistence, and browser-specific infrastructure. Publishes the npm package consumed by downstream SDKs |
 | **ts-sdk** | [`@miden-sdk/ts-sdk`](https://www.npmjs.com/package/@miden-sdk/ts-sdk) (npm) | TypeScript | Idiomatic TypeScript wrapper over the WASM bridge. Primary entry point for **Node.js backends** and non-React frontends |
 | **react-sdk** | [`@miden-sdk/react-sdk`](https://www.npmjs.com/package/@miden-sdk/react-sdk) (npm) | TypeScript | React integration layer — hooks, context providers, Zustand state management, auto-sync, and external signer support |
 
@@ -55,7 +55,7 @@ The codebase is split across four repositories, each owning one boundary of the 
 | Repository | Contains | Rationale |
 |------------|----------|-----------|
 | **[`rust-sdk`](https://github.com/0xMiden/rust-sdk)** | Rust core library + sqlite-store + CLI | The foundational Rust crate and native tooling. Pure Rust — no WASM targets, no JS toolchain. Publishes to crates.io. |
-| **[`wasm-bridge`](https://github.com/0xMiden/wasm-bridge)** | WASM compilation boundary + idxdb-store + JS glue + Web Workers | Compiles the Rust core to WebAssembly and owns the full browser build pipeline (Rollup, wasm-bindgen, Web Workers, IndexedDB storage). Publishes to npm. Separating this from the Rust SDK eliminates mixed-target CI complexity and gives the bridge its own release cadence. |
+| **[`wasm-bridge`](https://github.com/0xMiden/wasm-bridge)** | WASM runtime layer + idxdb-store + JS glue + Web Workers | The browser runtime for the Rust SDK — WASM compilation, Web Worker orchestration, IndexedDB storage, and sync locking. Publishes to npm. |
 | **[`ts-sdk`](https://github.com/0xMiden/ts-sdk)** | TypeScript API surface + type definitions | Pure TypeScript wrapper over the WASM bridge. Consumes the npm package produced by `wasm-bridge` and provides an idiomatic async/await API. Published to npm. |
 | **[`react-sdk`](https://github.com/0xMiden/react-sdk)** | React hooks, providers, Zustand store, signer integrations | Framework-specific code that consumes the WASM bridge directly. Evolves independently with React ecosystem changes. |
 
@@ -83,11 +83,11 @@ The Rust SDK is the single source of truth for all Miden client logic. It is a `
 
 The `Client` struct is generic over an authenticator type (`Client<AUTH>`) and uses trait-based dependency injection for storage (`Store`), RPC (`NodeRpcClient`), proving (`TransactionProver`), and key management (`Keystore`), making every component swappable.
 
-### `wasm-bridge` — The Compilation Boundary
+### `wasm-bridge` — The WASM Runtime Layer
 
 **Repository:** [`wasm-bridge`](https://github.com/0xMiden/wasm-bridge) · **Package:** [`@miden-sdk/wasm-bridge`](https://www.npmjs.com/package/@miden-sdk/wasm-bridge)
 
-The WASM bridge compiles the Rust core into WebAssembly and exposes it to JavaScript. It lives in its own repository with its own Rust + JS build pipeline (Rollup, `wasm-bindgen`, TypeScript), and publishes the npm package consumed by both the TypeScript and React SDKs.
+The WASM bridge is the browser runtime for the Rust SDK. It compiles the Rust core into WebAssembly, but goes well beyond compilation — it owns the entire browser execution environment, including worker orchestration, persistent storage, and concurrency safety. It lives in its own repository with its own Rust + JS build pipeline (Rollup, `wasm-bindgen`, TypeScript), and publishes the npm package consumed by both the TypeScript and React SDKs.
 
 This is a substantial layer — ~150 files across Rust and JavaScript — that handles:
 
@@ -96,8 +96,6 @@ This is a substantial layer — ~150 files across Rust and JavaScript — that h
 - **IndexedDB storage** — the `idxdb-store` crate provides browser-compatible persistence via Dexie.js, supporting multiple isolated databases per network.
 - **Sync locking** — prevents concurrent state sync operations from corrupting the local store in the browser environment.
 - **External signer support** — callback-based keystore integration for third-party wallet providers (Para, Turnkey, MidenFi).
-
-Separating the bridge from the Rust SDK eliminates mixed-target CI complexity (`cargo publish --dry-run` no longer needs to exclude WASM crates), gives the bridge its own release cadence, and isolates the JS toolchain (Rollup, Node.js, Playwright) from the pure-Rust repository.
 
 See the [`wasm-bridge` repository](https://github.com/0xMiden/wasm-bridge) for build instructions, the full binding API, and Web Worker configuration.
 
@@ -186,7 +184,7 @@ crates/
     └── prover/               # Remote prover for testing
 ```
 
-See also: [`wasm-bridge`](https://github.com/0xMiden/wasm-bridge) (WASM compilation + browser runtime) · [`ts-sdk`](https://github.com/0xMiden/ts-sdk) (TypeScript API) · [`react-sdk`](https://github.com/0xMiden/react-sdk) (React hooks and providers)
+See also: [`wasm-bridge`](https://github.com/0xMiden/wasm-bridge) (WASM runtime layer) · [`ts-sdk`](https://github.com/0xMiden/ts-sdk) (TypeScript API) · [`react-sdk`](https://github.com/0xMiden/react-sdk) (React hooks and providers)
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![RUST_VERSION](https://img.shields.io/badge/rustc-1.90+-lightgray.svg)](https://www.rust-lang.org/tools/install)
 [![crates.io](https://img.shields.io/crates/v/miden-client)](https://crates.io/crates/miden-client)
 
-The Rust core of the [Miden](https://miden.io) client SDK. This repository contains the foundational Rust library that powers all Miden client interactions — account management, note handling, transaction building/proving, and state synchronization. It is part of a three-repo SDK architecture alongside [`ts-sdk`](https://github.com/0xMiden/ts-sdk) and [`react-sdk`](https://github.com/0xMiden/react-sdk).
+The Rust core of the [Miden](https://miden.io) client SDK. This repository contains the foundational Rust library that powers all Miden client interactions — account management, note handling, transaction building/proving, and state synchronization. It is part of a four-repo SDK architecture alongside [`wasm-bridge`](https://github.com/0xMiden/wasm-bridge), [`ts-sdk`](https://github.com/0xMiden/ts-sdk), and [`react-sdk`](https://github.com/0xMiden/react-sdk).
 
 ### Status
 
@@ -20,20 +20,23 @@ The SDK is organized as a layered stack. Each layer builds on the one below it, 
 graph TB
     subgraph rust-sdk-repo["rust-sdk repo"]
         rust-sdk["<b>rust-sdk</b><br/>Core client library<br/>accounts · notes · transactions"]
-        wasm-bridge["<b>wasm-bridge</b> (internal)<br/>Compiled via wasm-bindgen<br/>idxdb-store · web-tonic"]
-        rust-sdk -- "wasm-bindgen + Rollup" --> wasm-bridge
     end
 
-    subgraph react-sdk-repo["react-sdk repo"]
-        react-sdk["<b>react-sdk</b><br/>React integration layer<br/>hooks · context · zustand"]
+    subgraph wasm-bridge-repo["wasm-bridge repo"]
+        wasm-bridge["<b>wasm-bridge</b><br/>Rust → WASM compilation boundary<br/>wasm-bindgen · idxdb-store · web workers"]
     end
 
     subgraph ts-sdk-repo["ts-sdk repo"]
         ts-sdk["<b>ts-sdk</b><br/>Idiomatic TS wrapper<br/>typed API · async helpers"]
     end
 
-    wasm-bridge -- "npm package" --> react-sdk
+    subgraph react-sdk-repo["react-sdk repo"]
+        react-sdk["<b>react-sdk</b><br/>React integration layer<br/>hooks · context · zustand"]
+    end
+
+    rust-sdk -- "crates.io dependency" --> wasm-bridge
     wasm-bridge -- "npm package" --> ts-sdk
+    wasm-bridge -- "npm package" --> react-sdk
 ```
 
 ### Layer Overview
@@ -41,18 +44,19 @@ graph TB
 | Layer | Published as | Language | Purpose |
 |-------|-------------|----------|---------|
 | **rust-sdk** | [`miden-client`](https://crates.io/crates/miden-client) (crates.io) | Rust | Core client library — account management, note handling, transaction building/execution/proving, state sync, node communication |
-| **wasm-bridge** | `@miden-sdk/wasm-bridge` (npm, internal) | Rust → WASM | Compiles the Rust core to WebAssembly via `wasm-bindgen`. Serves as the compilation boundary between Rust and JavaScript |
+| **wasm-bridge** | [`@miden-sdk/wasm-bridge`](https://www.npmjs.com/package/@miden-sdk/wasm-bridge) (npm) | Rust → WASM + JS | Compiles the Rust core to WebAssembly via `wasm-bindgen`. Owns the full build pipeline (Rollup, Web Workers, IndexedDB storage) and publishes the npm package consumed by downstream SDKs |
 | **ts-sdk** | [`@miden-sdk/ts-sdk`](https://www.npmjs.com/package/@miden-sdk/ts-sdk) (npm) | TypeScript | Idiomatic TypeScript wrapper over the WASM bridge. Primary entry point for **Node.js backends** and non-React frontends |
 | **react-sdk** | [`@miden-sdk/react-sdk`](https://www.npmjs.com/package/@miden-sdk/react-sdk) (npm) | TypeScript | React integration layer — hooks, context providers, Zustand state management, auto-sync, and external signer support |
 
 ### Repository Split
 
-The codebase will be split across three repositories, each owning one boundary of the stack:
+The codebase is split across four repositories, each owning one boundary of the stack:
 
 | Repository | Contains | Rationale |
 |------------|----------|-----------|
-| **[`rust-sdk`](https://github.com/0xMiden/rust-sdk)** | Rust core library + WASM bridge + idxdb-store + sqlite-store + CLI | The foundational Rust crate and its WASM compilation boundary. Keeping the bridge in the same repo as the Rust core ensures API changes and their 90+ `wasm_bindgen` wrappers stay in sync. Publishes to crates.io and npm (internal WASM package). |
-| **[`ts-sdk`](https://github.com/0xMiden/ts-sdk)** | TypeScript API surface + type definitions | Pure TypeScript wrapper over the WASM bridge. Consumes the npm package produced by `rust-sdk` and provides an idiomatic async/await API. Published to npm. |
+| **[`rust-sdk`](https://github.com/0xMiden/rust-sdk)** | Rust core library + sqlite-store + CLI | The foundational Rust crate and native tooling. Pure Rust — no WASM targets, no JS toolchain. Publishes to crates.io. |
+| **[`wasm-bridge`](https://github.com/0xMiden/wasm-bridge)** | WASM compilation boundary + idxdb-store + JS glue + Web Workers | Compiles the Rust core to WebAssembly and owns the full browser build pipeline (Rollup, wasm-bindgen, Web Workers, IndexedDB storage). Publishes to npm. Separating this from the Rust SDK eliminates mixed-target CI complexity and gives the bridge its own release cadence. |
+| **[`ts-sdk`](https://github.com/0xMiden/ts-sdk)** | TypeScript API surface + type definitions | Pure TypeScript wrapper over the WASM bridge. Consumes the npm package produced by `wasm-bridge` and provides an idiomatic async/await API. Published to npm. |
 | **[`react-sdk`](https://github.com/0xMiden/react-sdk)** | React hooks, providers, Zustand store, signer integrations | Framework-specific code that consumes the WASM bridge directly. Evolves independently with React ecosystem changes. |
 
 ## Motivation
@@ -81,9 +85,21 @@ The `Client` struct is generic over an authenticator type (`Client<AUTH>`) and u
 
 ### `wasm-bridge` — The Compilation Boundary
 
-The WASM bridge compiles the Rust core into WebAssembly and exposes it to JavaScript via `wasm-bindgen`. It lives in this repository (`rust-sdk`) alongside the Rust core it wraps, and is published as an **internal npm package** consumed by the TypeScript and React SDKs. Keeping the bridge co-located with the Rust code ensures that API changes and their 90+ `wasm_bindgen` wrappers can evolve in a single PR.
+**Repository:** [`wasm-bridge`](https://github.com/0xMiden/wasm-bridge) · **Package:** [`@miden-sdk/wasm-bridge`](https://www.npmjs.com/package/@miden-sdk/wasm-bridge)
 
-This layer handles type marshalling (90+ `#[wasm_bindgen]` wrapper types), Web Worker offloading for CPU-intensive operations (ZK proof generation, account creation), IndexedDB storage via `idxdb-store`, and sync locking to prevent state corruption in the browser environment.
+The WASM bridge compiles the Rust core into WebAssembly and exposes it to JavaScript. It lives in its own repository with its own Rust + JS build pipeline (Rollup, `wasm-bindgen`, TypeScript), and publishes the npm package consumed by both the TypeScript and React SDKs.
+
+This is a substantial layer — ~150 files across Rust and JavaScript — that handles:
+
+- **Type marshalling** — 90+ `#[wasm_bindgen]` wrapper types that translate Rust structs into JavaScript-friendly objects.
+- **Web Worker offloading** — CPU-intensive operations (ZK proof generation, account creation) run in a dedicated Web Worker, preventing the main thread from freezing.
+- **IndexedDB storage** — the `idxdb-store` crate provides browser-compatible persistence via Dexie.js, supporting multiple isolated databases per network.
+- **Sync locking** — prevents concurrent state sync operations from corrupting the local store in the browser environment.
+- **External signer support** — callback-based keystore integration for third-party wallet providers (Para, Turnkey, MidenFi).
+
+Separating the bridge from the Rust SDK eliminates mixed-target CI complexity (`cargo publish --dry-run` no longer needs to exclude WASM crates), gives the bridge its own release cadence, and isolates the JS toolchain (Rollup, Node.js, Playwright) from the pure-Rust repository.
+
+See the [`wasm-bridge` repository](https://github.com/0xMiden/wasm-bridge) for build instructions, the full binding API, and Web Worker configuration.
 
 ### `ts-sdk` — The TypeScript Developer Experience
 
@@ -112,7 +128,7 @@ The `Store` trait abstracts all persistence operations. Implementations must app
 | Crate | Target | Repository | Description |
 |-------|--------|------------|-------------|
 | `sqlite-store` | Native | `rust-sdk` | SQLite-based persistence using `rusqlite` with connection pooling. Used by the CLI and Rust backends. |
-| `idxdb-store` | Browser | `rust-sdk` | IndexedDB-based persistence using Dexie.js. Supports multiple isolated databases per network. Lives alongside the WASM bridge it serves. |
+| `idxdb-store` | Browser | `wasm-bridge` | IndexedDB-based persistence using Dexie.js. Supports multiple isolated databases per network. Lives alongside the WASM bridge it serves. |
 
 ### CLI
 
@@ -147,16 +163,13 @@ State synchronization atomically applies a bundle of changes — new block heade
 
 ZK proof generation and account creation are CPU-intensive operations that can take several seconds. The WASM bridge automatically offloads these to a dedicated Web Worker, preventing the main thread from freezing.
 
-### no_std Core with Platform-Specific Backends
+### no_std Core
 
-The Rust SDK is `#![no_std]` compatible. Platform-specific functionality is provided through feature flags:
-
-- **Native:** `std` feature enables `tonic` gRPC with TLS, filesystem keystore, and concurrent execution.
-- **WASM:** `wasm32` target enables `tonic-web-wasm-client` for gRPC-Web and `web-sys` for browser APIs.
+The Rust SDK is `#![no_std]` compatible, with platform-specific functionality gated behind feature flags (`std` enables `tonic` gRPC with TLS, filesystem keystore, and concurrent execution). This makes the core library compilable to `wasm32` targets — a capability exercised by the [`wasm-bridge`](https://github.com/0xMiden/wasm-bridge) repository — while keeping this repository focused on a single native target with no WASM or JS toolchain required.
 
 ## Repository Structure
 
-This repository (`rust-sdk`) contains the Rust core, WASM bridge, storage backends, and CLI:
+This repository (`rust-sdk`) contains the Rust core library, native storage backend, CLI, and test infrastructure:
 
 ```
 bin/
@@ -166,16 +179,14 @@ bin/
 
 crates/
 ├── rust-client/              # Core client library (miden-client)
-├── web-client/               # WASM bridge (wasm-bindgen wrappers)
 ├── sqlite-store/             # SQLite storage backend (native)
-├── idxdb-store/              # IndexedDB storage backend (browser)
 └── testing/                  # Test infrastructure
     ├── miden-client-tests/   # Shared test utilities
     ├── node-builder/         # Test node builder
     └── prover/               # Remote prover for testing
 ```
 
-See also: [`ts-sdk`](https://github.com/0xMiden/ts-sdk) (TypeScript API) · [`react-sdk`](https://github.com/0xMiden/react-sdk) (React hooks and providers)
+See also: [`wasm-bridge`](https://github.com/0xMiden/wasm-bridge) (WASM compilation + browser runtime) · [`ts-sdk`](https://github.com/0xMiden/ts-sdk) (TypeScript API) · [`react-sdk`](https://github.com/0xMiden/react-sdk) (React hooks and providers)
 
 ## Getting Started
 
@@ -237,7 +248,6 @@ See the [CLI README](./bin/miden-cli/README.md) for the full command reference a
 ### Prerequisites
 
 - Rust toolchain (see `rust-toolchain.toml`)
-- Node.js >= 18 + Yarn
 - `make` for build orchestration
 
 ### Common Commands
@@ -245,9 +255,8 @@ See the [CLI README](./bin/miden-cli/README.md) for the full command reference a
 ```bash
 make install-tools          # Install dev tools (nextest, taplo, typos, etc.)
 make build                  # Build all Rust crates
-make build-wasm             # Build WASM targets
-make lint                   # Run all lints (format, clippy, typos, eslint)
-make format                 # Format all code (Rust, TS, TOML)
+make lint                   # Run all lints (format, clippy, typos)
+make format                 # Format all code (Rust, TOML)
 make test                   # Run unit tests
 make integration-test       # Run integration tests (requires test node)
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ graph TB
     subgraph rust-sdk-repo["rust-sdk repo"]
         rust-sdk["<b>rust-sdk</b><br/>Core client library<br/>accounts · notes · transactions"]
         wasm-bridge["<b>wasm-bridge</b> (internal)<br/>Compiled via wasm-bindgen<br/>idxdb-store · web-tonic"]
-        rust-sdk -- "cargo build --target wasm32" --> wasm-bridge
+        rust-sdk -- "wasm-bindgen + Rollup" --> wasm-bridge
     end
 
     subgraph react-sdk-repo["react-sdk repo"]

--- a/crates/rust-client/src/rpc/domain/account.rs
+++ b/crates/rust-client/src/rpc/domain/account.rs
@@ -671,8 +671,7 @@ impl From<AccountStorageRequirements> for Vec<account_detail_request::StorageMap
     fn from(
         value: AccountStorageRequirements,
     ) -> Vec<account_detail_request::StorageMapDetailRequest> {
-        use account_detail_request;
-        use account_detail_request::storage_map_detail_request;
+        use account_detail_request::{self, storage_map_detail_request};
         let request_map = value.0;
         let mut requests = Vec::with_capacity(request_map.len());
         for (slot_name, _map_keys) in request_map {

--- a/crates/rust-client/src/rpc/domain/account.rs
+++ b/crates/rust-client/src/rpc/domain/account.rs
@@ -671,7 +671,8 @@ impl From<AccountStorageRequirements> for Vec<account_detail_request::StorageMap
     fn from(
         value: AccountStorageRequirements,
     ) -> Vec<account_detail_request::StorageMapDetailRequest> {
-        use account_detail_request::{self, storage_map_detail_request};
+        use account_detail_request;
+        use account_detail_request::storage_map_detail_request;
         let request_map = value.0;
         let mut requests = Vec::with_capacity(request_map.len());
         for (slot_name, _map_keys) in request_map {


### PR DESCRIPTION
## Strategy: Three-Repo Split

The SDK will be split across three repositories. This section outlines the plan of action.

### Phase 1 — Agree on Architecture

- [ ] Finalize this README as the canonical description of the SDK stack and three-repo split
- [ ] Confirm: wasm-bridge + idxdb-store stay in `rust-sdk` repo
- [ ] Confirm: ts-sdk repo is pure TypeScript (no Rust/WASM compilation)
- [ ] Confirm: react-sdk repo consumes the wasm-bridge npm package directly

### Phase 2 — Isolate and Publish the WASM Bridge

The wasm-bridge (`crates/web-client`) is currently consumed via `file:` references. It needs to become a publishable npm package.

- [ ] Define the internal npm package name (e.g., `@miden-sdk/wasm-bridge` or `@miden-sdk/core-wasm`)
- [ ] Set up npm publish pipeline in this repo's CI: compile WASM → bundle JS glue + TS declarations → publish to npm
- [ ] Ensure the published package includes everything downstream consumers need: WASM binary, JS entry point, type declarations, Web Worker script
- [ ] Version the npm package in lockstep with the `miden-client` crate (semver-aligned)
- [ ] Validate by replacing `"@miden-sdk/miden-sdk": "file:../../crates/web-client"` in `packages/react-sdk/package.json` with the published package and confirming everything still works

### Phase 3 — Set Up ts-sdk and react-sdk Repos

**ts-sdk** (`github.com/0xMiden/ts-sdk`):
- [ ] Create the repo
- [ ] Extract any existing TypeScript wrapper code from this repo (utilities, type definitions, helpers)
- [ ] Build the idiomatic async/await API surface that wraps the wasm-bridge npm package
- [ ] Depend on `@miden-sdk/wasm-bridge` (or chosen name) as a dependency
- [ ] Set up CI: lint, typecheck, test, npm publish for `@miden-sdk/ts-sdk`
- [ ] Write getting-started docs targeting Node.js backend developers

**react-sdk** (`github.com/0xMiden/react-sdk`):
- [ ] Create the repo
- [ ] Move `packages/react-sdk` from this repo into the new react-sdk repo
- [ ] Update peer dependency from `@miden-sdk/miden-sdk` (file reference) to the published `@miden-sdk/wasm-bridge` package
- [ ] Set up CI: lint, typecheck, test, build, npm publish for `@miden-sdk/react-sdk`
- [ ] Verify Playwright integration tests still pass against the published wasm-bridge

### Phase 4 — Update Downstream Consumers

- [ ] Update any example apps, tutorials, or docs that reference old import paths
- [ ] Update `CLAUDE.md` files in each repo with repo-specific instructions
- [ ] Ensure all cross-repo links in READMEs resolve correctly
- [ ] Communicate the migration path to existing users (if any external consumers exist at this stage)

### Phase 5 — Clean Up This Repo

- [ ] Remove `packages/react-sdk` from this repo
- [ ] Remove any TS-only wrapper code that moved to ts-sdk
- [ ] Update CI to drop react-sdk checks (they move to the react-sdk repo)
- [ ] Final README update: "See also" links point to live repos, not planned ones

### Versioning

All three repos follow **semver alignment**: the wasm-bridge npm package, ts-sdk, and react-sdk share the same major.minor version as the `miden-client` Rust crate. Patch versions may diverge for repo-specific fixes. A compatibility matrix in each repo's README maps SDK versions to supported `miden-client` versions.

---

## Summary

- Rewrites the root README to describe the SDK architecture: **rust-sdk** → **wasm-bridge** (internal), with both **ts-sdk** and **react-sdk** consuming the wasm-bridge npm package independently
- Adds a Mermaid diagram showing the dependency flow between layers
- Documents the motivation behind each layer and its target audience
- Covers key architectural patterns (trait-based DI, atomic state sync, Web Worker offloading, `no_std` core, DB isolation)
- Updates getting started guides for Rust, TypeScript/Node.js, and React developers

## Test plan

- [ ] Verify Mermaid diagram renders correctly on GitHub
- [ ] Review architectural descriptions for accuracy
- [ ] Confirm all internal links resolve