### PR TITLE
refactor: remove SmtForest empty-root workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [BREAKING] Added `SyncStateInputs` to bundle the parameters needed to perform the sync state ([#1778](https://github.com/0xMiden/miden-client/pull/1778)).
 * [BREAKING][type][web] `AuthSecretKey.getRpoFalcon512SecretKeyAsFelts()` and `getEcdsaK256KeccakSecretKeyAsFelts()` now return `Result<Vec<Felt>, JsValue>` instead of panicking on key type mismatch ([#1833](https://github.com/0xMiden/miden-client/pull/1833)).
 * [BREAKING][rename][cli] Renamed `CliConfig::from_system()` to `CliConfig::load()` and `CliClient::from_system_user_config()` to `CliClient::new()` for better discoverability ([#1848](https://github.com/0xMiden/miden-client/pull/1848)).
+* Removed `SmtForest` empty-root workaround in `AccountSmtForest::safe_pop_smts`, now that the upstream fix has landed in miden-crypto v0.19.7 ([#1864](https://github.com/0xMiden/miden-client/pull/1864)).
 
 ### Features
 

--- a/crates/rust-client/src/store/smt_forest.rs
+++ b/crates/rust-client/src/store/smt_forest.rs
@@ -272,11 +272,9 @@ impl AccountSmtForest {
         roots
     }
 
-    /// Pops SMT roots from the forest, filtering out the empty tree root.
-    // TODO(#1834): remove this filter once the miden-crypto fix lands.
+    /// Pops SMT roots from the forest that are no longer referenced by any account.
     fn safe_pop_smts(&mut self, roots: impl IntoIterator<Item = Word>) {
-        let empty_tree_root = *EmptySubtreeRoots::entry(SMT_DEPTH, 0);
-        self.forest.pop_smts(roots.into_iter().filter(|r| *r != empty_tree_root));
+        self.forest.pop_smts(roots);
     }
 }
 


### PR DESCRIPTION
## Summary

Removes the empty-root filter workaround in `AccountSmtForest::pop_roots` that was guarding against a bug in miden-crypto's `SmtForest::batch_insert`, which incorrectly registered the empty tree root in `self.roots`.

The upstream fix landed in [crypto#853](https://github.com/0xMiden/crypto/pull/853) (included since miden-crypto v0.19.7), and miden-client already uses v0.19.8, so the workaround is no longer needed.

### Changes

- Removed the empty-root filter and `EmptySubtreeRoots` usage from `pop_roots`, now delegates directly to `forest.pop_smts(roots)`
- Removed the related doc comment explaining the workaround and `TODO(#1834)` marker

Closes #1834