### PR TITLE
chore: add conditional access to the CI cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,14 +145,15 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - name: Install Rust
-        run: rustup update --no-self-update
       - name: Restore note-transport binary
         id: cache-note-transport
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin/miden-note-transport-node-bin
           key: ${{ runner.os }}-note-transport-${{ hashFiles('Cargo.lock') }}
+      - name: Install Rust
+        if: steps.cache-note-transport.outputs.cache-hit != 'true'
+        run: rustup update --no-self-update
       - name: Install note-transport
         if: steps.cache-note-transport.outputs.cache-hit != 'true'
         run: cargo install --git https://github.com/0xMiden/miden-note-transport --locked


### PR DESCRIPTION
Slight improvement on the CI to avoid the Rust setup if the binary cache gets a hit. This improves the CI time on the happy path, with no downside.