### PR TITLE
feat(react-sdk): accept number in addition to bigint for token amounts

### DIFF
--- a/packages/react-sdk/CHANGELOG.md
+++ b/packages/react-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.13.4 (TBD)
+
+### Features
+* [FEATURE][web] All user-facing amount fields (`amount`, `maxSupply`, `offeredAmount`, `requestedAmount`) now accept `number` in addition to `bigint`, removing the need for `n` suffixes or `BigInt()` wrappers. Values are coerced to `bigint` internally before passing to WASM. Output types (balances, note assets) remain `bigint`.
+* [FEATURE][web] `formatAssetAmount()` now accepts `number | bigint` for convenience.
+
 ## 0.13.3 (2026-02-25)
 
 ### Features

--- a/packages/react-sdk/src/hooks/useCreateFaucet.ts
+++ b/packages/react-sdk/src/hooks/useCreateFaucet.ts
@@ -80,7 +80,7 @@ export function useCreateFaucet(): UseCreateFaucetResult {
             false, // nonFungible - currently only fungible faucets supported
             options.tokenSymbol,
             decimals,
-            options.maxSupply,
+            BigInt(options.maxSupply),
             authScheme
           );
           const accounts = await client.getAccounts();

--- a/packages/react-sdk/src/hooks/useInternalTransfer.ts
+++ b/packages/react-sdk/src/hooks/useInternalTransfer.ts
@@ -94,7 +94,7 @@ export function useInternalTransfer(): UseInternalTransferResult {
       const assetId = parseAccountId(options.assetId);
 
       const assets = new NoteAssets([
-        new FungibleAsset(assetId, options.amount),
+        new FungibleAsset(assetId, BigInt(options.amount)),
       ]);
       const note = Note.createP2IDNote(
         senderId,

--- a/packages/react-sdk/src/hooks/useMint.ts
+++ b/packages/react-sdk/src/hooks/useMint.ts
@@ -86,7 +86,7 @@ export function useMint(): UseMintResult {
             targetAccountIdObj,
             faucetIdObj,
             noteType,
-            options.amount
+            BigInt(options.amount)
           );
 
           const txId = prover

--- a/packages/react-sdk/src/hooks/useMultiSend.ts
+++ b/packages/react-sdk/src/hooks/useMultiSend.ts
@@ -113,7 +113,7 @@ export function useMultiSend(): UseMultiSendResult {
             const iterAssetId = parseAccountId(options.assetId);
             const receiverId = parseAccountId(to);
             const assets = new NoteAssets([
-              new FungibleAsset(iterAssetId, amount),
+              new FungibleAsset(iterAssetId, BigInt(amount)),
             ]);
             const resolvedNoteType = recipientNoteType
               ? getNoteType(recipientNoteType)

--- a/packages/react-sdk/src/hooks/useSend.ts
+++ b/packages/react-sdk/src/hooks/useSend.ts
@@ -127,6 +127,7 @@ export function useSend(): UseSendResult {
         if (amount === undefined || amount === null) {
           throw new Error("Amount is required (provide amount or sendAll)");
         }
+        amount = BigInt(amount);
 
         const assetId =
           options.assetId ??

--- a/packages/react-sdk/src/hooks/useSwap.ts
+++ b/packages/react-sdk/src/hooks/useSwap.ts
@@ -91,9 +91,9 @@ export function useSwap(): UseSwapResult {
           const txRequest = client.newSwapTransactionRequest(
             accountIdObj,
             offeredFaucetIdObj,
-            options.offeredAmount,
+            BigInt(options.offeredAmount),
             requestedFaucetIdObj,
-            options.requestedAmount,
+            BigInt(options.requestedAmount),
             noteType,
             paybackNoteType
           );

--- a/packages/react-sdk/src/types/index.ts
+++ b/packages/react-sdk/src/types/index.ts
@@ -229,7 +229,7 @@ export interface CreateFaucetOptions {
   /** Number of decimals. Default: 8 */
   decimals?: number;
   /** Maximum supply */
-  maxSupply: bigint;
+  maxSupply: bigint | number;
   /** Storage mode. Default: private */
   storageMode?: "private" | "public" | "network";
   /** Auth scheme: 0 = RpoFalcon512, 1 = EcdsaK256Keccak. Default: 0 */
@@ -262,7 +262,7 @@ export interface SendOptions {
   /** Asset ID to send (token id) */
   assetId: string;
   /** Amount to send (ignored when sendAll is true) */
-  amount?: bigint;
+  amount?: bigint | number;
   /** Note type. Default: private */
   noteType?: "private" | "public";
   /** Block height after which sender can reclaim note */
@@ -281,7 +281,7 @@ export interface MultiSendRecipient {
   /** Recipient account ID */
   to: string;
   /** Amount to send */
-  amount: bigint;
+  amount: bigint | number;
   /** Per-recipient note type override */
   noteType?: "private" | "public";
   /** Per-recipient attachment */
@@ -309,7 +309,7 @@ export interface InternalTransferOptions {
   /** Asset ID to send (token id) */
   assetId: string;
   /** Amount to transfer */
-  amount: bigint;
+  amount: bigint | number;
   /** Note type. Default: private */
   noteType?: "private" | "public";
 }
@@ -322,7 +322,7 @@ export interface InternalTransferChainOptions {
   /** Asset ID to send (token id) */
   assetId: string;
   /** Amount to transfer per hop */
-  amount: bigint;
+  amount: bigint | number;
   /** Note type. Default: private */
   noteType?: "private" | "public";
 }
@@ -358,7 +358,7 @@ export interface MintOptions {
   /** Faucet account to mint from */
   faucetId: string;
   /** Amount to mint */
-  amount: bigint;
+  amount: bigint | number;
   /** Note type. Default: private */
   noteType?: "private" | "public";
 }
@@ -378,11 +378,11 @@ export interface SwapOptions {
   /** Faucet ID of the offered asset */
   offeredFaucetId: string;
   /** Amount being offered */
-  offeredAmount: bigint;
+  offeredAmount: bigint | number;
   /** Faucet ID of the requested asset */
   requestedFaucetId: string;
   /** Amount being requested */
-  requestedAmount: bigint;
+  requestedAmount: bigint | number;
   /** Note type for swap note. Default: private */
   noteType?: "private" | "public";
   /** Note type for payback note. Default: private */

--- a/packages/react-sdk/src/utils/amounts.ts
+++ b/packages/react-sdk/src/utils/amounts.ts
@@ -1,14 +1,15 @@
 export const formatAssetAmount = (
-  amount: bigint,
+  amount: bigint | number,
   decimals?: number
 ): string => {
+  const amt = BigInt(amount);
   if (!decimals || decimals <= 0) {
-    return amount.toString();
+    return amt.toString();
   }
 
   const factor = 10n ** BigInt(decimals);
-  const whole = amount / factor;
-  const fraction = amount % factor;
+  const whole = amt / factor;
+  const fraction = amt % factor;
 
   if (fraction === 0n) {
     return whole.toString();


### PR DESCRIPTION
## Summary
- All user-facing amount fields (`amount`, `maxSupply`, `offeredAmount`, `requestedAmount`) now accept `number | bigint`, so users no longer need `n` suffixes or `BigInt()` wrappers
- Values are coerced to `bigint` internally before passing to WASM; output types remain `bigint`
- `formatAssetAmount()` also accepts `number | bigint`

Closes #1873

## Test plan
- [ ] Verify `useSend` works with `amount: 1000` (number) and `amount: 1000n` (bigint)
- [ ] Verify `useCreateFaucet` works with `maxSupply: 1000000` (number)
- [ ] Verify `useMint`, `useSwap`, `useMultiSend`, `useInternalTransfer` accept number amounts
- [ ] Verify `formatAssetAmount(1000, 8)` works without error
- [ ] Confirm output types (`AssetBalance.amount`, `getBalance()`) still return `bigint`