### PR TITLE
chore: pin cargo MSRV

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -28,8 +28,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Ensure stable toolchain is installed
         run: rustup toolchain install stable --profile minimal
+      - name: Install binstall
+        uses: cargo-bins/cargo-binstall@main
       - name: Install cargo-msrv
-        run: cargo install cargo-msrv --locked
+        run: cargo binstall --no-confirm cargo-msrv
       - name: Check MSRV for each workspace member
         run: |
           ./scripts/check-msrv.sh


### PR DESCRIPTION
Changes MSRV action to use `cargo binstall` as done on `next` for `cargo-msrv`, so that the Rust version does not go out of sync