### PR TITLE
fix(sqlite-store): handle RootNotInStore in get_account_asset fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,16 @@ To test the project's code, we provide both unit tests (which can be run with `c
 Interested in contributing? Check [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## License
-This project is [MIT licensed](./LICENSE).
+This project is [MIT licensed](./LICENSE). 
+  ### Common CLI Errors & Fixes
+
+This section lists frequent errors users encounter when using `miden-client-cli` and how to resolve them.
+
+- **MissingOutputRecipients** or **PublicNoteMissingDetails**  
+  **Cause**: The transaction request is missing expected output recipients.  
+  **Fix**: Add `.expected_output_recipients(vec![recipient])` to your `TransactionRequestBuilder`.  
+  Example:
+  ```rust
+  let request = TransactionRequestBuilder::new()
+      .expected_output_recipients(vec![recipient_tag])
+      .build()?;

--- a/README.md
+++ b/README.md
@@ -52,16 +52,4 @@ To test the project's code, we provide both unit tests (which can be run with `c
 Interested in contributing? Check [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## License
-This project is [MIT licensed](./LICENSE). 
-  ### Common CLI Errors & Fixes
-
-This section lists frequent errors users encounter when using `miden-client-cli` and how to resolve them.
-
-- **MissingOutputRecipients** or **PublicNoteMissingDetails**  
-  **Cause**: The transaction request is missing expected output recipients.  
-  **Fix**: Add `.expected_output_recipients(vec![recipient])` to your `TransactionRequestBuilder`.  
-  Example:
-  ```rust
-  let request = TransactionRequestBuilder::new()
-      .expected_output_recipients(vec![recipient_tag])
-      .build()?;
+This project is [MIT licensed](./LICENSE).

--- a/crates/sqlite-store/src/account/accounts.rs
+++ b/crates/sqlite-store/src/account/accounts.rs
@@ -249,7 +249,8 @@ impl SqliteStore {
         let smt_forest = smt_forest.read().expect("smt_forest read lock not poisoned");
         match smt_forest.get_asset_and_witness(header.vault_root(), vault_key) {
             Ok((asset, witness)) => Ok(Some((asset, witness))),
-            Err(StoreError::MerkleStoreError(MerkleError::UntrackedKey(_))) => Ok(None),
+            Err(StoreError::MerkleStoreError(MerkleError::UntrackedKey(_)))
+            | Err(StoreError::MerkleStoreError(MerkleError::RootNotInStore(_))) => Ok(None),
             Err(err) => Err(err),
         }
     }


### PR DESCRIPTION
## Summary

Fixes #1857

When consuming notes, the `get_account_asset()` function in `accounts.rs` failed with an unhandled `MerkleError::RootNotInStore` error when the in-memory `SmtForest` cache was missing a vault root. This happens in real-world scenarios such as:
- Partial account imports
- Interrupted sync operations  
- Schema migrations

## Root Cause

The `match` block in `accounts.rs` only caught `MerkleError::UntrackedKey` to return `Ok(None)` and trigger the existing DB fallback in `data_store.rs`. However, `MerkleError::RootNotInStore` was not handled — it fell through to `Err(err)` and propagated as a hard error, bypassing the fallback entirely.

```rust
// BEFORE (broken)
match smt_forest.get_asset_and_witness(header.vault_root(), vault_key) {
    Ok((asset, witness)) => Ok(Some((asset, witness))),
    Err(StoreError::MerkleStoreError(MerkleError::UntrackedKey(_))) => Ok(None), // triggers fallback
    Err(err) => Err(err), // RootNotInStore ends up here — fallback never runs ❌
}
```

## Fix

Added `RootNotInStore` to the same match arm as `UntrackedKey`, so both cache-miss scenarios correctly activate the existing DB fallback:

```rust
// AFTER (fixed)
match smt_forest.get_asset_and_witness(header.vault_root(), vault_key) {
    Ok((asset, witness)) => Ok(Some((asset, witness))),
    Err(StoreError::MerkleStoreError(MerkleError::UntrackedKey(_)))
    | Err(StoreError::MerkleStoreError(MerkleError::RootNotInStore(_))) => Ok(None), // ✅ both trigger fallback
    Err(err) => Err(err),
}
```

The existing fallback in `data_store.rs` already validates consistency via the `vault.root() != vault_root` check, so genuinely inconsistent DB state still produces an appropriate error — no regression risk.

## Testing

- The fix is minimal and targeted (one-line change)
- The existing fallback path in `data_store.rs:143-161` handles the `Ok(None)` return and validates vault root consistency
- No new logic is introduced; this simply wires an existing error variant to an existing fallback

## Pre-PR Checklist
- [x] Branch forked from `next`
- [x] Semantic commit message (`fix(sqlite-store): ...`)
- [x] Linked to assigned issue #1857
- [x] Minimal, reviewable change with clear reasoning
- [x] No new dependencies introduced
