### PR TITLE
feat(note): generalize note readers beyond consumed input notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [FEATURE][web] Added `getAccountProof` method to the web client's `RpcClient`, allowing lightweight retrieval of account header, storage slot values, and code via a single RPC call. Refactored the `NodeRpcClient::get_account_proof` signature to allow requesting just private account proofs ([#1794](https://github.com/0xMiden/miden-client/pull/1794), [#1814](https://github.com/0xMiden/miden-client/pull/1814)).
 * Added `getAccountByKeyCommitment` method to `WebClient` for retrieving accounts by public key commitment ([#1729](https://github.com/0xMiden/miden-client/pull/1729)).
 * Added automatic registration of note scripts required by network transactions (NTX). The client now checks the node's script registry before submitting a transaction and registers any missing scripts via a separate registration transaction ([#1840](https://github.com/0xMiden/miden-client/pull/1840)).
+* Generalized note readers by adding a shared `NoteReader`, configurable `InputNoteReader` filters, and an `OutputNoteReader` for lazy note iteration.
 
 ### Changes
 

--- a/crates/idxdb-store/src/js/notes.js
+++ b/crates/idxdb-store/src/js/notes.js
@@ -140,31 +140,6 @@ export async function upsertInputNote(dbId, noteId, assets, serialNumber, inputs
         return doWork(tx);
     return db.dexie.transaction("rw", db.inputNotes, db.notesScripts, doWork);
 }
-// Compares two input notes by consumption order: first by consumed block height (ascending,
-// nulls last), then by per-account consumed tx order (ascending, nulls last), then by note ID.
-function compareNotesByConsumptionOrder(a, b) {
-    const aH = a.consumedBlockHeight;
-    const bH = b.consumedBlockHeight;
-    if (aH == null && bH != null)
-        return 1;
-    if (aH != null && bH == null)
-        return -1;
-    if (aH != null && bH != null && aH !== bH)
-        return aH - bH;
-    const aO = a.consumedTxOrder;
-    const bO = b.consumedTxOrder;
-    if (aO == null && bO != null)
-        return 1;
-    if (aO != null && bO == null)
-        return -1;
-    if (aO != null && bO != null && aO !== bO)
-        return aO - bO;
-    if (a.noteId < b.noteId)
-        return -1;
-    if (a.noteId > b.noteId)
-        return 1;
-    return 0;
-}
 // When a consumer is set, uses the [consumedBlockHeight+consumedTxOrder+noteId] compound
 // index for cursor-based iteration.
 export async function getInputNoteByOffset(dbId, states, consumerAccountId, blockStart, blockEnd, offset) {
@@ -212,7 +187,29 @@ export async function getInputNoteByOffset(dbId, states, consumerAccountId, bloc
         if (blockEnd != null) {
             notes = notes.filter((n) => n.consumedBlockHeight != null && n.consumedBlockHeight <= blockEnd);
         }
-        notes.sort(compareNotesByConsumptionOrder);
+        notes.sort((a, b) => {
+            const aH = a.consumedBlockHeight;
+            const bH = b.consumedBlockHeight;
+            if (aH == null && bH != null)
+                return 1;
+            if (aH != null && bH == null)
+                return -1;
+            if (aH != null && bH != null && aH !== bH)
+                return aH - bH;
+            const aO = a.consumedTxOrder;
+            const bO = b.consumedTxOrder;
+            if (aO == null && bO != null)
+                return 1;
+            if (aO != null && bO == null)
+                return -1;
+            if (aO != null && bO != null && aO !== bO)
+                return aO - bO;
+            if (a.noteId < b.noteId)
+                return -1;
+            if (a.noteId > b.noteId)
+                return 1;
+            return 0;
+        });
         const note = notes[offset];
         if (!note)
             return [];

--- a/crates/idxdb-store/src/js/notes.js
+++ b/crates/idxdb-store/src/js/notes.js
@@ -140,6 +140,31 @@ export async function upsertInputNote(dbId, noteId, assets, serialNumber, inputs
         return doWork(tx);
     return db.dexie.transaction("rw", db.inputNotes, db.notesScripts, doWork);
 }
+// Compares two input notes by consumption order: first by consumed block height (ascending,
+// nulls last), then by per-account consumed tx order (ascending, nulls last), then by note ID.
+function compareNotesByConsumptionOrder(a, b) {
+    const aH = a.consumedBlockHeight;
+    const bH = b.consumedBlockHeight;
+    if (aH == null && bH != null)
+        return 1;
+    if (aH != null && bH == null)
+        return -1;
+    if (aH != null && bH != null && aH !== bH)
+        return aH - bH;
+    const aO = a.consumedTxOrder;
+    const bO = b.consumedTxOrder;
+    if (aO == null && bO != null)
+        return 1;
+    if (aO != null && bO == null)
+        return -1;
+    if (aO != null && bO != null && aO !== bO)
+        return aO - bO;
+    if (a.noteId < b.noteId)
+        return -1;
+    if (a.noteId > b.noteId)
+        return 1;
+    return 0;
+}
 // When a consumer is set, uses the [consumedBlockHeight+consumedTxOrder+noteId] compound
 // index for cursor-based iteration.
 export async function getInputNoteByOffset(dbId, states, consumerAccountId, blockStart, blockEnd, offset) {
@@ -187,29 +212,7 @@ export async function getInputNoteByOffset(dbId, states, consumerAccountId, bloc
         if (blockEnd != null) {
             notes = notes.filter((n) => n.consumedBlockHeight != null && n.consumedBlockHeight <= blockEnd);
         }
-        notes.sort((a, b) => {
-            const aH = a.consumedBlockHeight;
-            const bH = b.consumedBlockHeight;
-            if (aH == null && bH != null)
-                return 1;
-            if (aH != null && bH == null)
-                return -1;
-            if (aH != null && bH != null && aH !== bH)
-                return aH - bH;
-            const aO = a.consumedTxOrder;
-            const bO = b.consumedTxOrder;
-            if (aO == null && bO != null)
-                return 1;
-            if (aO != null && bO == null)
-                return -1;
-            if (aO != null && bO != null && aO !== bO)
-                return aO - bO;
-            if (a.noteId < b.noteId)
-                return -1;
-            if (a.noteId > b.noteId)
-                return 1;
-            return 0;
-        });
+        notes.sort(compareNotesByConsumptionOrder);
         const note = notes[offset];
         if (!note)
             return [];

--- a/crates/idxdb-store/src/note/js_bindings.rs
+++ b/crates/idxdb-store/src/note/js_bindings.rs
@@ -58,7 +58,7 @@ extern "C" {
         state_discriminant: u8,
         state: Vec<u8>,
         consumed_block_height: Option<u32>,
-        consumed_tx_order: Option<u16>,
+        consumed_tx_order: Option<u32>,
         consumer_account_id: Option<String>,
     ) -> js_sys::Promise;
 

--- a/crates/idxdb-store/src/note/utils.rs
+++ b/crates/idxdb-store/src/note/utils.rs
@@ -58,7 +58,7 @@ pub struct SerializedInputNoteData {
     #[wasm_bindgen(js_name = "consumedBlockHeight")]
     pub consumed_block_height: Option<u32>,
     #[wasm_bindgen(js_name = "consumedTxOrder")]
-    pub consumed_tx_order: Option<u16>,
+    pub consumed_tx_order: Option<u32>,
     #[wasm_bindgen(js_name = "consumerAccountId")]
     pub consumer_account_id: Option<String>,
 }
@@ -85,7 +85,7 @@ pub struct SerializedOutputNoteData {
 
 pub(crate) fn serialize_input_note(
     note: &InputNoteRecord,
-    consumed_tx_order: Option<u16>,
+    consumed_tx_order: Option<u32>,
 ) -> SerializedInputNoteData {
     let note_id = note.id().to_hex().clone();
     let note_assets = note.assets().to_bytes();
@@ -103,12 +103,7 @@ pub(crate) fn serialize_input_note(
     let state = note.state().to_bytes();
     let created_at = Utc::now().timestamp().to_string();
 
-    let consumed_block_height = match note.state() {
-        InputNoteState::ConsumedAuthenticatedLocal(s) => Some(s.nullifier_block_height.as_u32()),
-        InputNoteState::ConsumedUnauthenticatedLocal(s) => Some(s.nullifier_block_height.as_u32()),
-        InputNoteState::ConsumedExternal(s) => Some(s.nullifier_block_height.as_u32()),
-        _ => None,
-    };
+    let consumed_block_height = note.state().nullifier_block_height().map(|h| h.as_u32());
 
     let consumer_account_id = note.consumer_account().map(AccountId::to_hex);
 
@@ -132,7 +127,7 @@ pub(crate) fn serialize_input_note(
 pub async fn upsert_input_note_tx(
     db_id: &str,
     note: &InputNoteRecord,
-    consumed_tx_order: Option<u16>,
+    consumed_tx_order: Option<u32>,
 ) -> Result<(), StoreError> {
     let serialized_data = serialize_input_note(note, consumed_tx_order);
 

--- a/crates/rust-client/src/note/mod.rs
+++ b/crates/rust-client/src/note/mod.rs
@@ -76,44 +76,22 @@ mod note_update_tracker;
 pub use miden_protocol::block::BlockNumber;
 pub use miden_protocol::errors::NoteError;
 pub use miden_protocol::note::{
-    Note,
-    NoteAssets,
-    NoteAttachment,
-    NoteAttachmentKind,
-    NoteAttachmentScheme,
-    NoteDetails,
-    NoteFile,
-    NoteHeader,
-    NoteId,
-    NoteInclusionProof,
-    NoteLocation,
-    NoteMetadata,
-    NoteRecipient,
-    NoteScript,
-    NoteStorage,
-    NoteTag,
-    NoteType,
-    Nullifier,
-    PartialNote,
+    Note, NoteAssets, NoteAttachment, NoteAttachmentKind, NoteAttachmentScheme, NoteDetails,
+    NoteFile, NoteHeader, NoteId, NoteInclusionProof, NoteLocation, NoteMetadata, NoteRecipient,
+    NoteScript, NoteStorage, NoteTag, NoteType, Nullifier, PartialNote,
 };
 pub use miden_protocol::transaction::ToInputNoteCommitments;
 pub use miden_standards::note::{
-    NetworkAccountTarget,
-    NoteConsumptionStatus,
-    NoteExecutionHint,
-    P2idNote,
-    P2idNoteStorage,
-    StandardNote,
-    SwapNote,
+    NetworkAccountTarget, NoteConsumptionStatus, NoteExecutionHint, P2idNote, P2idNoteStorage,
+    StandardNote, SwapNote,
 };
 pub use miden_tx::{FailedNote, NoteConsumptionInfo};
-pub use note_reader::InputNoteReader;
+pub use note_reader::{
+    InputNoteReader, NoteReader, NoteReaderSource, NoteRecord, OutputNoteReader,
+};
 pub use note_screener::{NoteConsumability, NoteScreener, NoteScreenerError};
 pub use note_update_tracker::{
-    InputNoteUpdate,
-    NoteUpdateTracker,
-    NoteUpdateType,
-    OutputNoteUpdate,
+    InputNoteUpdate, NoteUpdateTracker, NoteUpdateType, OutputNoteUpdate,
 };
 /// Note retrieval methods.
 impl<AUTH> Client<AUTH>
@@ -217,6 +195,15 @@ where
         Ok(self.store.get_output_notes(NoteFilter::Unique(note_id)).await?.pop())
     }
 
+    /// Returns a [`NoteReader`] for the requested note source.
+    ///
+    /// Input readers default to [`NoteFilter::Consumed`] to preserve the behavior of the
+    /// specialized [`Client::input_note_reader`] convenience method. Output readers default to
+    /// [`NoteFilter::All`]. Use [`NoteReader::with_filter`] to override the base filter.
+    pub fn note_reader(&self, source: NoteReaderSource) -> NoteReader {
+        NoteReader::new(self.store.clone(), source)
+    }
+
     /// Returns an [`InputNoteReader`] that lazily iterates over consumed input notes.
     ///
     /// Use the builder methods on [`InputNoteReader`] to further refine the query before
@@ -235,6 +222,14 @@ where
     /// ```
     pub fn input_note_reader(&self) -> InputNoteReader {
         InputNoteReader::new(self.store.clone())
+    }
+
+    /// Returns an [`OutputNoteReader`] that lazily iterates over output notes.
+    ///
+    /// Output readers default to [`NoteFilter::All`]. Use the builder methods on
+    /// [`OutputNoteReader`] to refine the query before iterating.
+    pub fn output_note_reader(&self) -> OutputNoteReader {
+        OutputNoteReader::new(self.store.clone())
     }
 }
 

--- a/crates/rust-client/src/note/mod.rs
+++ b/crates/rust-client/src/note/mod.rs
@@ -76,22 +76,50 @@ mod note_update_tracker;
 pub use miden_protocol::block::BlockNumber;
 pub use miden_protocol::errors::NoteError;
 pub use miden_protocol::note::{
-    Note, NoteAssets, NoteAttachment, NoteAttachmentKind, NoteAttachmentScheme, NoteDetails,
-    NoteFile, NoteHeader, NoteId, NoteInclusionProof, NoteLocation, NoteMetadata, NoteRecipient,
-    NoteScript, NoteStorage, NoteTag, NoteType, Nullifier, PartialNote,
+    Note,
+    NoteAssets,
+    NoteAttachment,
+    NoteAttachmentKind,
+    NoteAttachmentScheme,
+    NoteDetails,
+    NoteFile,
+    NoteHeader,
+    NoteId,
+    NoteInclusionProof,
+    NoteLocation,
+    NoteMetadata,
+    NoteRecipient,
+    NoteScript,
+    NoteStorage,
+    NoteTag,
+    NoteType,
+    Nullifier,
+    PartialNote,
 };
 pub use miden_protocol::transaction::ToInputNoteCommitments;
 pub use miden_standards::note::{
-    NetworkAccountTarget, NoteConsumptionStatus, NoteExecutionHint, P2idNote, P2idNoteStorage,
-    StandardNote, SwapNote,
+    NetworkAccountTarget,
+    NoteConsumptionStatus,
+    NoteExecutionHint,
+    P2idNote,
+    P2idNoteStorage,
+    StandardNote,
+    SwapNote,
 };
 pub use miden_tx::{FailedNote, NoteConsumptionInfo};
 pub use note_reader::{
-    InputNoteReader, NoteReader, NoteReaderSource, NoteRecord, OutputNoteReader,
+    InputNoteReader,
+    NoteReader,
+    NoteReaderSource,
+    NoteRecord,
+    OutputNoteReader,
 };
 pub use note_screener::{NoteConsumability, NoteScreener, NoteScreenerError};
 pub use note_update_tracker::{
-    InputNoteUpdate, NoteUpdateTracker, NoteUpdateType, OutputNoteUpdate,
+    InputNoteUpdate,
+    NoteUpdateTracker,
+    NoteUpdateType,
+    OutputNoteUpdate,
 };
 /// Note retrieval methods.
 impl<AUTH> Client<AUTH>

--- a/crates/rust-client/src/note/note_reader.rs
+++ b/crates/rust-client/src/note/note_reader.rs
@@ -183,7 +183,7 @@ impl NoteReader {
         notes.retain(|note| self.matches_input_note(note));
 
         if !matches!(self.filter, NoteFilter::Consumed) {
-            notes.sort_by_key(|note| input_note_sort_key(note));
+            notes.sort_by_key(input_note_sort_key);
         }
 
         Ok(notes.into_iter().map(NoteRecord::Input).collect())
@@ -197,7 +197,7 @@ impl NoteReader {
             .map_err(ClientError::StoreError)?;
 
         notes.retain(|note| self.matches_output_note(note));
-        notes.sort_by_key(|note| output_note_sort_key(note));
+        notes.sort_by_key(output_note_sort_key);
 
         Ok(notes.into_iter().map(NoteRecord::Output).collect())
     }
@@ -213,7 +213,7 @@ impl NoteReader {
     }
 
     fn matches_output_note(&self, note: &OutputNoteRecord) -> bool {
-        block_matches_range(output_note_block_num(note), self.block_range)
+        block_matches_range(Some(output_note_block_num(note)), self.block_range)
     }
 }
 
@@ -326,16 +326,16 @@ fn input_note_block_num(note: &InputNoteRecord) -> Option<BlockNumber> {
     }
 }
 
-fn output_note_block_num(note: &OutputNoteRecord) -> Option<BlockNumber> {
+fn output_note_block_num(note: &OutputNoteRecord) -> BlockNumber {
     match note.state() {
         OutputNoteState::ExpectedPartial | OutputNoteState::ExpectedFull { .. } => {
-            Some(note.expected_height())
+            note.expected_height()
         },
         OutputNoteState::CommittedPartial { inclusion_proof }
         | OutputNoteState::CommittedFull { inclusion_proof, .. } => {
-            Some(inclusion_proof.location().block_num())
+            inclusion_proof.location().block_num()
         },
-        OutputNoteState::Consumed { block_height, .. } => Some(*block_height),
+        OutputNoteState::Consumed { block_height, .. } => *block_height,
     }
 }
 
@@ -349,10 +349,10 @@ fn input_note_sort_key(note: &InputNoteRecord) -> (bool, u32, String) {
 }
 
 fn output_note_sort_key(note: &OutputNoteRecord) -> (bool, u32, String) {
-    let block_num = output_note_block_num(note).map(|block_num| block_num.as_u32());
+    let block_num = output_note_block_num(note).as_u32();
     (
-        block_num.is_none(),
-        block_num.unwrap_or_default(),
+        false,
+        block_num,
         note.id().as_word().to_string(),
     )
 }

--- a/crates/rust-client/src/note/note_reader.rs
+++ b/crates/rust-client/src/note/note_reader.rs
@@ -9,7 +9,12 @@ use miden_protocol::block::BlockNumber;
 
 use crate::ClientError;
 use crate::store::{
-    InputNoteRecord, InputNoteState, NoteFilter, OutputNoteRecord, OutputNoteState, Store,
+    InputNoteRecord,
+    InputNoteState,
+    NoteFilter,
+    OutputNoteRecord,
+    OutputNoteState,
+    Store,
 };
 
 /// Selects which kind of notes a [`NoteReader`] iterates over.

--- a/crates/rust-client/src/note/note_reader.rs
+++ b/crates/rust-client/src/note/note_reader.rs
@@ -317,9 +317,7 @@ fn input_note_block_num(note: &InputNoteRecord) -> Option<BlockNumber> {
             Some(state.inclusion_proof.location().block_num())
         },
         InputNoteState::ProcessingUnauthenticated(state) => Some(state.after_block_num),
-        InputNoteState::ConsumedAuthenticatedLocal(state) => Some(state.nullifier_block_height),
-        InputNoteState::ConsumedUnauthenticatedLocal(state) => Some(state.nullifier_block_height),
-        InputNoteState::ConsumedExternal(state) => Some(state.nullifier_block_height),
+        _ => note.state().nullifier_block_height(),
     }
 }
 

--- a/crates/rust-client/src/note/note_reader.rs
+++ b/crates/rust-client/src/note/note_reader.rs
@@ -1,76 +1,151 @@
-//! Provides a lazy iterator over consumed input notes.
+//! Provides lazy readers over input and output notes.
 
+use alloc::string::{String, ToString};
 use alloc::sync::Arc;
+use alloc::vec::Vec;
 
 use miden_protocol::account::AccountId;
 use miden_protocol::block::BlockNumber;
 
 use crate::ClientError;
-use crate::store::{InputNoteRecord, NoteFilter, Store};
+use crate::store::{
+    InputNoteRecord, InputNoteState, NoteFilter, OutputNoteRecord, OutputNoteState, Store,
+};
 
-/// A lazy iterator over consumed input notes.
+/// Selects which kind of notes a [`NoteReader`] iterates over.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NoteReaderSource {
+    Input,
+    Output,
+}
+
+/// A note returned by a [`NoteReader`].
+#[derive(Clone, Debug, PartialEq)]
+pub enum NoteRecord {
+    Input(InputNoteRecord),
+    Output(OutputNoteRecord),
+}
+
+impl NoteRecord {
+    /// Returns the note ID regardless of whether it is an input or output note.
+    pub fn id(&self) -> crate::note::NoteId {
+        match self {
+            Self::Input(note) => note.id(),
+            Self::Output(note) => note.id(),
+        }
+    }
+}
+
+/// A lazy reader over notes managed by the client's store.
 ///
-/// Each call to [`InputNoteReader::next`] executes a store query and returns the
-/// next matching note. Use builder methods to configure filters before iterating.
-///
-/// # Ordering
-///
-/// Notes are returned in on-chain consumption order: first by block number, then by
-/// transaction order within the block. Within a block, ordering is only guaranteed
-/// among notes consumed by the same account; ordering across different accounts is
-/// not guaranteed.
-pub struct InputNoteReader {
+/// `NoteReader` can iterate over either input notes or output notes. For consumed input notes it
+/// uses store-level offset queries so records are streamed one by one in consumption order.
+/// Other input filters and all output-note queries are materialized once and then iterated in
+/// memory.
+pub struct NoteReader {
     store: Arc<dyn Store>,
+    source: NoteReaderSource,
+    filter: NoteFilter,
     consumer: Option<AccountId>,
     block_range: Option<(BlockNumber, BlockNumber)>,
     offset: u32,
+    buffered_notes: Option<Vec<NoteRecord>>,
 }
 
-impl InputNoteReader {
-    /// Creates a new `InputNoteReader` that iterates over consumed input notes.
-    pub fn new(store: Arc<dyn Store>) -> Self {
+impl NoteReader {
+    /// Creates a new reader for the requested note source.
+    pub fn new(store: Arc<dyn Store>, source: NoteReaderSource) -> Self {
+        let filter = match source {
+            NoteReaderSource::Input => NoteFilter::Consumed,
+            NoteReaderSource::Output => NoteFilter::All,
+        };
+
         Self {
             store,
+            source,
+            filter,
             consumer: None,
             block_range: None,
             offset: 0,
+            buffered_notes: None,
         }
     }
 
-    /// Filters notes by consumer account ID.
+    /// Filters the reader by note state.
+    #[must_use]
+    pub fn with_filter(mut self, filter: NoteFilter) -> Self {
+        self.filter = filter;
+        self.reset();
+        self
+    }
+
+    /// Filters input-note readers by consumer account ID.
+    ///
+    /// This filter is ignored for output-note readers.
     #[must_use]
     pub fn for_consumer(mut self, account_id: AccountId) -> Self {
         self.consumer = Some(account_id);
+        self.reset();
         self
     }
 
-    /// Restricts iteration to notes consumed within the given block range (inclusive).
+    /// Restricts iteration to notes whose relevant block number falls within the given range.
+    ///
+    /// For consumed input notes and consumed output notes this uses the nullifier block height.
+    /// For committed notes it uses the inclusion-proof block height. For expected output notes it
+    /// uses `expected_height`. For expected or processing unauthenticated input notes it uses
+    /// `after_block_num`. Notes without an applicable block number are excluded when a block range
+    /// is set.
     #[must_use]
     pub fn in_block_range(mut self, from: BlockNumber, to: BlockNumber) -> Self {
         self.block_range = Some((from, to));
+        self.reset();
         self
     }
 
-    /// Resets the iterator to the beginning.
+    /// Resets the reader to the beginning.
     pub fn reset(&mut self) {
         self.offset = 0;
+        self.buffered_notes = None;
     }
 
-    /// Returns the next consumed input note, or `None` when all matching notes have been
-    /// returned.
-    ///
-    /// Each call executes a single store query.
-    pub async fn next(&mut self) -> Result<Option<InputNoteRecord>, ClientError> {
+    /// Returns the next matching note, or `None` when all matching notes have been returned.
+    pub async fn next(&mut self) -> Result<Option<NoteRecord>, ClientError> {
+        if self.should_stream_input_notes() {
+            return self.next_streamed_input_note().await;
+        }
+
+        if self.buffered_notes.is_none() {
+            self.buffered_notes = Some(self.load_buffered_notes().await?);
+        }
+
+        let note = self
+            .buffered_notes
+            .as_ref()
+            .and_then(|notes| notes.get(self.offset as usize))
+            .cloned();
+
+        if note.is_some() {
+            self.offset += 1;
+        }
+
+        Ok(note)
+    }
+
+    fn should_stream_input_notes(&self) -> bool {
+        self.source == NoteReaderSource::Input && matches!(self.filter, NoteFilter::Consumed)
+    }
+
+    async fn next_streamed_input_note(&mut self) -> Result<Option<NoteRecord>, ClientError> {
         let (block_start, block_end) = match self.block_range {
             Some((from, to)) => (Some(from), Some(to)),
             None => (None, None),
         };
 
-        // TODO: The note filter should be configurable instead of hardcoding `NoteFilter::Consumed`
         let note = self
             .store
             .get_input_note_by_offset(
-                NoteFilter::Consumed,
+                self.filter.clone(),
                 self.consumer,
                 block_start,
                 block_end,
@@ -82,6 +157,199 @@ impl InputNoteReader {
         if note.is_some() {
             self.offset += 1;
         }
-        Ok(note)
+
+        Ok(note.map(NoteRecord::Input))
     }
+
+    async fn load_buffered_notes(&self) -> Result<Vec<NoteRecord>, ClientError> {
+        match self.source {
+            NoteReaderSource::Input => self.load_input_notes().await,
+            NoteReaderSource::Output => self.load_output_notes().await,
+        }
+    }
+
+    async fn load_input_notes(&self) -> Result<Vec<NoteRecord>, ClientError> {
+        let mut notes = self
+            .store
+            .get_input_notes(self.filter.clone())
+            .await
+            .map_err(ClientError::StoreError)?;
+
+        notes.retain(|note| self.matches_input_note(note));
+
+        if !matches!(self.filter, NoteFilter::Consumed) {
+            notes.sort_by_key(|note| input_note_sort_key(note));
+        }
+
+        Ok(notes.into_iter().map(NoteRecord::Input).collect())
+    }
+
+    async fn load_output_notes(&self) -> Result<Vec<NoteRecord>, ClientError> {
+        let mut notes = self
+            .store
+            .get_output_notes(self.filter.clone())
+            .await
+            .map_err(ClientError::StoreError)?;
+
+        notes.retain(|note| self.matches_output_note(note));
+        notes.sort_by_key(|note| output_note_sort_key(note));
+
+        Ok(notes.into_iter().map(NoteRecord::Output).collect())
+    }
+
+    fn matches_input_note(&self, note: &InputNoteRecord) -> bool {
+        if let Some(consumer) = self.consumer
+            && note.consumer_account() != Some(consumer)
+        {
+            return false;
+        }
+
+        block_matches_range(input_note_block_num(note), self.block_range)
+    }
+
+    fn matches_output_note(&self, note: &OutputNoteRecord) -> bool {
+        block_matches_range(output_note_block_num(note), self.block_range)
+    }
+}
+
+/// Backwards-compatible reader for input notes.
+pub struct InputNoteReader(NoteReader);
+
+impl InputNoteReader {
+    /// Creates a new `InputNoteReader` that iterates over consumed input notes.
+    pub fn new(store: Arc<dyn Store>) -> Self {
+        Self(NoteReader::new(store, NoteReaderSource::Input))
+    }
+
+    /// Filters the reader by input-note state.
+    #[must_use]
+    pub fn with_filter(mut self, filter: NoteFilter) -> Self {
+        self.0 = self.0.with_filter(filter);
+        self
+    }
+
+    /// Filters notes by consumer account ID.
+    #[must_use]
+    pub fn for_consumer(mut self, account_id: AccountId) -> Self {
+        self.0 = self.0.for_consumer(account_id);
+        self
+    }
+
+    /// Restricts iteration to notes whose relevant block number falls within the given range.
+    #[must_use]
+    pub fn in_block_range(mut self, from: BlockNumber, to: BlockNumber) -> Self {
+        self.0 = self.0.in_block_range(from, to);
+        self
+    }
+
+    /// Resets the iterator to the beginning.
+    pub fn reset(&mut self) {
+        self.0.reset();
+    }
+
+    /// Returns the next matching input note.
+    pub async fn next(&mut self) -> Result<Option<InputNoteRecord>, ClientError> {
+        match self.0.next().await? {
+            Some(NoteRecord::Input(note)) => Ok(Some(note)),
+            Some(NoteRecord::Output(_)) => unreachable!("input readers never yield output notes"),
+            None => Ok(None),
+        }
+    }
+}
+
+/// Reader for output notes.
+pub struct OutputNoteReader(NoteReader);
+
+impl OutputNoteReader {
+    /// Creates a new `OutputNoteReader` that iterates over all output notes.
+    pub fn new(store: Arc<dyn Store>) -> Self {
+        Self(NoteReader::new(store, NoteReaderSource::Output))
+    }
+
+    /// Filters the reader by output-note state.
+    #[must_use]
+    pub fn with_filter(mut self, filter: NoteFilter) -> Self {
+        self.0 = self.0.with_filter(filter);
+        self
+    }
+
+    /// Restricts iteration to notes whose relevant block number falls within the given range.
+    #[must_use]
+    pub fn in_block_range(mut self, from: BlockNumber, to: BlockNumber) -> Self {
+        self.0 = self.0.in_block_range(from, to);
+        self
+    }
+
+    /// Resets the iterator to the beginning.
+    pub fn reset(&mut self) {
+        self.0.reset();
+    }
+
+    /// Returns the next matching output note.
+    pub async fn next(&mut self) -> Result<Option<OutputNoteRecord>, ClientError> {
+        match self.0.next().await? {
+            Some(NoteRecord::Output(note)) => Ok(Some(note)),
+            Some(NoteRecord::Input(_)) => unreachable!("output readers never yield input notes"),
+            None => Ok(None),
+        }
+    }
+}
+
+fn block_matches_range(
+    block_num: Option<BlockNumber>,
+    block_range: Option<(BlockNumber, BlockNumber)>,
+) -> bool {
+    match block_range {
+        Some((from, to)) => block_num.is_some_and(|block_num| block_num >= from && block_num <= to),
+        None => true,
+    }
+}
+
+fn input_note_block_num(note: &InputNoteRecord) -> Option<BlockNumber> {
+    match note.state() {
+        InputNoteState::Expected(state) => Some(state.after_block_num),
+        InputNoteState::Unverified(state) => Some(state.inclusion_proof.location().block_num()),
+        InputNoteState::Committed(state) => Some(state.inclusion_proof.location().block_num()),
+        InputNoteState::Invalid(state) => {
+            Some(state.invalid_inclusion_proof.location().block_num())
+        },
+        InputNoteState::ProcessingAuthenticated(state) => {
+            Some(state.inclusion_proof.location().block_num())
+        },
+        InputNoteState::ProcessingUnauthenticated(state) => Some(state.after_block_num),
+        InputNoteState::ConsumedAuthenticatedLocal(state) => Some(state.nullifier_block_height),
+        InputNoteState::ConsumedUnauthenticatedLocal(state) => Some(state.nullifier_block_height),
+        InputNoteState::ConsumedExternal(state) => Some(state.nullifier_block_height),
+    }
+}
+
+fn output_note_block_num(note: &OutputNoteRecord) -> Option<BlockNumber> {
+    match note.state() {
+        OutputNoteState::ExpectedPartial | OutputNoteState::ExpectedFull { .. } => {
+            Some(note.expected_height())
+        },
+        OutputNoteState::CommittedPartial { inclusion_proof }
+        | OutputNoteState::CommittedFull { inclusion_proof, .. } => {
+            Some(inclusion_proof.location().block_num())
+        },
+        OutputNoteState::Consumed { block_height, .. } => Some(*block_height),
+    }
+}
+
+fn input_note_sort_key(note: &InputNoteRecord) -> (bool, u32, String) {
+    let block_num = input_note_block_num(note).map(|block_num| block_num.as_u32());
+    (
+        block_num.is_none(),
+        block_num.unwrap_or_default(),
+        note.id().as_word().to_string(),
+    )
+}
+
+fn output_note_sort_key(note: &OutputNoteRecord) -> (bool, u32, String) {
+    let block_num = output_note_block_num(note).map(|block_num| block_num.as_u32());
+    (
+        block_num.is_none(),
+        block_num.unwrap_or_default(),
+        note.id().as_word().to_string(),
+    )
 }

--- a/crates/rust-client/src/note/note_reader.rs
+++ b/crates/rust-client/src/note/note_reader.rs
@@ -350,9 +350,5 @@ fn input_note_sort_key(note: &InputNoteRecord) -> (bool, u32, String) {
 
 fn output_note_sort_key(note: &OutputNoteRecord) -> (bool, u32, String) {
     let block_num = output_note_block_num(note).as_u32();
-    (
-        false,
-        block_num,
-        note.id().as_word().to_string(),
-    )
+    (false, block_num, note.id().as_word().to_string())
 }

--- a/crates/rust-client/src/note/note_update_tracker.rs
+++ b/crates/rust-client/src/note/note_update_tracker.rs
@@ -34,7 +34,7 @@ pub struct InputNoteUpdate {
     /// Position of the consuming transaction within the account's execution chain for the block.
     /// Ordering across different accounts is not guaranteed. `None` for non-consumed notes or
     /// notes consumed by external (non-client) transactions.
-    consumed_tx_order: Option<u16>,
+    consumed_tx_order: Option<u32>,
 }
 
 impl InputNoteUpdate {
@@ -94,12 +94,12 @@ impl InputNoteUpdate {
     /// Returns the position of the consuming transaction within the account's execution chain for
     /// the block. Ordering across different accounts is not guaranteed. `None` for non-consumed
     /// notes or notes consumed by external transactions.
-    pub fn consumed_tx_order(&self) -> Option<u16> {
+    pub fn consumed_tx_order(&self) -> Option<u32> {
         self.consumed_tx_order
     }
 
     /// Sets the consumed transaction order for this note update.
-    fn set_consumed_tx_order(&mut self, order: Option<u16>) {
+    fn set_consumed_tx_order(&mut self, order: Option<u32>) {
         self.consumed_tx_order = order;
     }
 }
@@ -180,10 +180,10 @@ pub struct NoteUpdateTracker {
     input_notes_by_nullifier: BTreeMap<Nullifier, NoteId>,
     /// Fast lookup map from nullifier to output note id.
     output_notes_by_nullifier: BTreeMap<Nullifier, NoteId>,
-    /// Map from nullifier to its position in the consuming transaction order. Nullifiers from
-    /// the same account are in execution order; ordering across different accounts is not
-    /// guaranteed.
-    nullifier_order: BTreeMap<Nullifier, u16>,
+    /// Map from nullifier to its position in the consuming transaction order per account.
+    /// Nullifiers from the same account are in execution order; ordering across different
+    /// accounts is not guaranteed.
+    nullifier_order: BTreeMap<Nullifier, u32>,
 }
 
 impl NoteUpdateTracker {
@@ -286,7 +286,7 @@ impl NoteUpdateTracker {
     pub fn extend_nullifiers(&mut self, nullifiers: impl IntoIterator<Item = Nullifier>) {
         for nullifier in nullifiers {
             let next_pos =
-                u16::try_from(self.nullifier_order.len()).expect("nullifier count exceeds u16");
+                u32::try_from(self.nullifier_order.len()).expect("nullifier count exceeds u32");
             self.nullifier_order.entry(nullifier).or_insert(next_pos);
         }
     }
@@ -392,7 +392,7 @@ impl NoteUpdateTracker {
 
     /// Returns the position of the given nullifier in the consuming transaction order, or `None`
     /// if it is not present.
-    fn get_nullifier_order(&self, nullifier: Nullifier) -> Option<u16> {
+    fn get_nullifier_order(&self, nullifier: Nullifier) -> Option<u32> {
         self.nullifier_order.get(&nullifier).copied()
     }
 

--- a/crates/rust-client/src/store/note_record/input_note_record/states/mod.rs
+++ b/crates/rust-client/src/store/note_record/input_note_record/states/mod.rs
@@ -118,6 +118,20 @@ impl InputNoteState {
         self.inner().consumer_transaction_id()
     }
 
+    /// Returns the block height at which this note was nullified (consumed), if applicable.
+    ///
+    /// This returns `Some` for notes in any consumed state
+    /// (`ConsumedAuthenticatedLocal`, `ConsumedUnauthenticatedLocal`, `ConsumedExternal`),
+    /// and `None` for all other states.
+    pub fn nullifier_block_height(&self) -> Option<BlockNumber> {
+        match self {
+            InputNoteState::ConsumedAuthenticatedLocal(s) => Some(s.nullifier_block_height),
+            InputNoteState::ConsumedUnauthenticatedLocal(s) => Some(s.nullifier_block_height),
+            InputNoteState::ConsumedExternal(s) => Some(s.nullifier_block_height),
+            _ => None,
+        }
+    }
+
     /// Returns a new state to reflect that the note has received an inclusion proof. The proof is
     /// assumed to be unverified until the block header information is received. If the note state
     /// doesn't change, `None` is returned.

--- a/crates/rust-client/src/sync/state_sync.rs
+++ b/crates/rust-client/src/sync/state_sync.rs
@@ -683,10 +683,10 @@ fn compute_ordered_nullifiers(transaction_records: &[RpcTransactionRecord]) -> V
 
     for txs in groups.values() {
         // Build a lookup from initial_state_commitment -> transaction record.
-        let mut init_to_tx: BTreeMap<Word, &RpcTransactionRecord> = BTreeMap::new();
-        for tx in txs {
-            init_to_tx.insert(tx.transaction_header.initial_state_commitment(), tx);
-        }
+        let mut init_to_tx: BTreeMap<Word, &RpcTransactionRecord> = txs
+            .iter()
+            .map(|tx| (tx.transaction_header.initial_state_commitment(), *tx))
+            .collect();
 
         // Build a set of all final states to find the chain start.
         let final_states: BTreeSet<Word> =
@@ -703,6 +703,7 @@ fn compute_ordered_nullifiers(transaction_records: &[RpcTransactionRecord]) -> V
         };
 
         // Follow the chain: current.final_state_commitment == next.initial_state_commitment.
+        // We remove visited entries to avoid infinite loops.
         let mut current = *start_tx;
 
         loop {
@@ -714,11 +715,11 @@ fn compute_ordered_nullifiers(transaction_records: &[RpcTransactionRecord]) -> V
                 }
             }
 
-            // Follow the chain.
+            // Follow the chain by removing the next tx from the map.
             if let Some(next_tx) =
-                init_to_tx.get(&current.transaction_header.final_state_commitment())
+                init_to_tx.remove(&current.transaction_header.final_state_commitment())
             {
-                if core::ptr::eq(*next_tx, current) {
+                if core::ptr::eq(next_tx, current) {
                     break;
                 }
                 current = next_tx;
@@ -1020,7 +1021,7 @@ mod tests {
 
         let updated_notes: Vec<_> = update.note_updates.updated_input_notes().collect();
 
-        let find_order = |note_id: NoteId| -> Option<u16> {
+        let find_order = |note_id: NoteId| -> Option<u32> {
             updated_notes
                 .iter()
                 .find(|n| n.id() == note_id)

--- a/crates/sqlite-store/src/note/mod.rs
+++ b/crates/sqlite-store/src/note/mod.rs
@@ -56,7 +56,7 @@ struct SerializedInputNoteData {
     pub state: Vec<u8>,
     pub created_at: u64,
     pub consumed_block_height: Option<u32>,
-    pub consumed_tx_order: Option<u16>,
+    pub consumed_tx_order: Option<u32>,
     pub consumer_account_id: Option<String>,
 }
 
@@ -250,7 +250,7 @@ impl SqliteStore {
 pub(super) fn upsert_input_note_tx(
     tx: &Transaction<'_>,
     note: &InputNoteRecord,
-    consumed_tx_order: Option<u16>,
+    consumed_tx_order: Option<u32>,
 ) -> Result<(), StoreError> {
     let SerializedInputNoteData {
         id,
@@ -408,7 +408,7 @@ fn parse_input_note(
 /// Serialize the provided input note into database compatible types.
 fn serialize_input_note(
     note: &InputNoteRecord,
-    consumed_tx_order: Option<u16>,
+    consumed_tx_order: Option<u32>,
 ) -> SerializedInputNoteData {
     let id = note.id().as_word().to_string();
     let nullifier = note.nullifier().to_hex();
@@ -427,12 +427,7 @@ fn serialize_input_note(
     let state_discriminant = note.state().discriminant();
     let state = note.state().to_bytes();
 
-    let consumed_block_height = match note.state() {
-        InputNoteState::ConsumedAuthenticatedLocal(s) => Some(s.nullifier_block_height.as_u32()),
-        InputNoteState::ConsumedUnauthenticatedLocal(s) => Some(s.nullifier_block_height.as_u32()),
-        InputNoteState::ConsumedExternal(s) => Some(s.nullifier_block_height.as_u32()),
-        _ => None,
-    };
+    let consumed_block_height = note.state().nullifier_block_height().map(|h| h.as_u32());
 
     let consumer_account_id = note.consumer_account().map(AccountId::to_hex);
 

--- a/crates/sqlite-store/src/note/tests.rs
+++ b/crates/sqlite-store/src/note/tests.rs
@@ -1,29 +1,21 @@
 use std::sync::Arc;
 
 use miden_client::note::{
-    InputNoteReader,
-    NoteAssets,
-    NoteMetadata,
-    NoteRecipient,
-    NoteStorage,
-    NoteTag,
-    NoteType,
+    InputNoteReader, NoteAssets, NoteMetadata, NoteReader, NoteReaderSource, NoteRecipient,
+    NoteRecord, NoteStorage, NoteTag, NoteType, OutputNoteReader,
 };
 use miden_client::store::input_note_states::{
-    ConsumedExternalNoteState,
-    ConsumedUnauthenticatedLocalNoteState,
-    ExpectedNoteState,
+    ConsumedExternalNoteState, ConsumedUnauthenticatedLocalNoteState, ExpectedNoteState,
     NoteSubmissionData,
 };
-use miden_client::store::{InputNoteRecord, NoteFilter, Store};
+use miden_client::store::{InputNoteRecord, NoteFilter, OutputNoteRecord, OutputNoteState, Store};
 use miden_client::{Felt, ZERO};
 use miden_protocol::Word;
 use miden_protocol::account::AccountId;
 use miden_protocol::block::BlockNumber;
 use miden_protocol::note::NoteDetails;
 use miden_protocol::testing::account_id::{
-    ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
-    ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE,
+    ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET, ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE,
 };
 use miden_protocol::transaction::TransactionId;
 use miden_standards::note::StandardNote;
@@ -123,6 +115,43 @@ async fn insert_input_notes_with_tx_order(
         .unwrap();
 }
 
+fn create_expected_output_note(index: u32, expected_height: u32) -> OutputNoteRecord {
+    let serial_number: Word = [Felt::new(u64::from(index) + 7000), ZERO, ZERO, ZERO].into();
+    let assets = NoteAssets::new(vec![]).unwrap();
+    let recipient = NoteRecipient::new(
+        serial_number,
+        StandardNote::SWAP.script(),
+        NoteStorage::new(vec![]).unwrap(),
+    );
+    let sender = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET).unwrap();
+    let metadata = NoteMetadata::new(sender, NoteType::Public).with_tag(NoteTag::from(index));
+
+    OutputNoteRecord::new(
+        recipient.digest(),
+        assets,
+        metadata,
+        OutputNoteState::ExpectedFull { recipient },
+        BlockNumber::from(expected_height),
+    )
+}
+
+async fn insert_output_notes(store: &crate::SqliteStore, notes: &[OutputNoteRecord]) {
+    let notes = notes.to_vec();
+    store
+        .interact_with_connection(move |conn| {
+            let tx = conn
+                .transaction()
+                .map_err(|e| miden_client::store::StoreError::QueryError(e.to_string()))?;
+            for note in &notes {
+                super::upsert_output_note_tx(&tx, note)?;
+            }
+            tx.commit()
+                .map_err(|e| miden_client::store::StoreError::QueryError(e.to_string()))
+        })
+        .await
+        .unwrap();
+}
+
 // INPUT NOTE READER TESTS
 // ================================================================================================
 
@@ -175,6 +204,69 @@ async fn input_note_reader_skips_non_consumed_notes() {
 
     // Only the 2 consumed notes should be returned.
     assert_eq!(collected.len(), 2);
+}
+
+#[tokio::test]
+async fn input_note_reader_with_filter_iterates_expected_notes() {
+    let store = create_test_store().await;
+
+    let consumed = create_consumed_external_input_note(0, 1);
+    let expected_a = create_expected_input_note(1);
+    let expected_b = create_expected_input_note(2);
+
+    store
+        .upsert_input_notes(&[consumed, expected_a.clone(), expected_b.clone()])
+        .await
+        .unwrap();
+
+    let store: Arc<dyn Store> = Arc::new(store);
+    let mut reader = InputNoteReader::new(store).with_filter(NoteFilter::Expected);
+
+    let mut collected = Vec::new();
+    while let Some(note) = reader.next().await.unwrap() {
+        collected.push(note);
+    }
+
+    assert_eq!(collected.len(), 2);
+    assert_eq!(collected[0].id(), expected_a.id());
+    assert_eq!(collected[1].id(), expected_b.id());
+}
+
+#[tokio::test]
+async fn output_note_reader_iterates_expected_output_notes() {
+    let store = create_test_store().await;
+
+    let note_a = create_expected_output_note(0, 5);
+    let note_b = create_expected_output_note(1, 7);
+    insert_output_notes(&store, &[note_a.clone(), note_b.clone()]).await;
+
+    let store: Arc<dyn Store> = Arc::new(store);
+    let mut reader = OutputNoteReader::new(store).with_filter(NoteFilter::Expected);
+
+    let mut collected = Vec::new();
+    while let Some(note) = reader.next().await.unwrap() {
+        collected.push(note);
+    }
+
+    assert_eq!(collected.len(), 2);
+    assert_eq!(collected[0].id(), note_a.id());
+    assert_eq!(collected[1].id(), note_b.id());
+}
+
+#[tokio::test]
+async fn generic_note_reader_yields_output_record_variants() {
+    let store = create_test_store().await;
+
+    let note = create_expected_output_note(0, 9);
+    insert_output_notes(&store, core::slice::from_ref(&note)).await;
+
+    let store: Arc<dyn Store> = Arc::new(store);
+    let mut reader =
+        NoteReader::new(store, NoteReaderSource::Output).with_filter(NoteFilter::Expected);
+
+    let next = reader.next().await.unwrap();
+
+    assert!(matches!(next, Some(NoteRecord::Output(output)) if output.id() == note.id()));
 }
 
 #[tokio::test]

--- a/crates/sqlite-store/src/note/tests.rs
+++ b/crates/sqlite-store/src/note/tests.rs
@@ -97,7 +97,7 @@ fn create_consumed_input_note_with_consumer(
 async fn insert_input_notes_with_tx_order(
     store: &crate::SqliteStore,
     notes: &[InputNoteRecord],
-    consumed_tx_order: Option<u16>,
+    consumed_tx_order: Option<u32>,
 ) {
     let notes = notes.to_vec();
     store

--- a/crates/sqlite-store/src/note/tests.rs
+++ b/crates/sqlite-store/src/note/tests.rs
@@ -1,11 +1,22 @@
 use std::sync::Arc;
 
 use miden_client::note::{
-    InputNoteReader, NoteAssets, NoteMetadata, NoteReader, NoteReaderSource, NoteRecipient,
-    NoteRecord, NoteStorage, NoteTag, NoteType, OutputNoteReader,
+    InputNoteReader,
+    NoteAssets,
+    NoteMetadata,
+    NoteReader,
+    NoteReaderSource,
+    NoteRecipient,
+    NoteRecord,
+    NoteStorage,
+    NoteTag,
+    NoteType,
+    OutputNoteReader,
 };
 use miden_client::store::input_note_states::{
-    ConsumedExternalNoteState, ConsumedUnauthenticatedLocalNoteState, ExpectedNoteState,
+    ConsumedExternalNoteState,
+    ConsumedUnauthenticatedLocalNoteState,
+    ExpectedNoteState,
     NoteSubmissionData,
 };
 use miden_client::store::{InputNoteRecord, NoteFilter, OutputNoteRecord, OutputNoteState, Store};
@@ -15,7 +26,8 @@ use miden_protocol::account::AccountId;
 use miden_protocol::block::BlockNumber;
 use miden_protocol::note::NoteDetails;
 use miden_protocol::testing::account_id::{
-    ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET, ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE,
+    ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
+    ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE,
 };
 use miden_protocol::transaction::TransactionId;
 use miden_standards::note::StandardNote;

--- a/crates/sqlite-store/src/store.sql
+++ b/crates/sqlite-store/src/store.sql
@@ -158,7 +158,7 @@ CREATE TABLE input_notes (
     state BLOB NOT NULL,                                    -- serialized note state
     created_at UNSIGNED BIG INT NOT NULL,                   -- timestamp of the note creation/import
     consumed_block_height INTEGER NULL,                     -- block height at which the note was consumed; NULL for non-consumed notes
-    consumed_tx_order INTEGER NULL,                         -- position of the consuming tx in the account's state chain within the block; NULL for external consumption or non-consumed notes
+    consumed_tx_order INTEGER NULL,                         -- per-account position of the consuming tx in the account's state chain within the block; NULL for external consumption or non-consumed notes
     consumer_account_id TEXT NULL,                          -- account ID that consumed this note; NULL for non-consumed or externally consumed notes
 
     PRIMARY KEY (note_id),


### PR DESCRIPTION
## Summary

Closes #1923.

This PR completes the main follow-up from #1843 by generalizing the note reader API beyond consumed input notes.

The original `InputNoteReader` introduced in #1843 was intentionally narrow: it only supported lazily iterating consumed input notes in execution order. This PR extends that model so clients can also iterate non-consumed input notes and output notes through a shared reader abstraction, while preserving the existing `InputNoteReader` API for backwards compatibility.

## What changed

### 1. Generalized note readers

Added a shared `NoteReader` abstraction in `rust-client` with:

- `NoteReader`
- `NoteReaderSource`
- `NoteRecord`
- `OutputNoteReader`

`InputNoteReader` is now a thin compatibility wrapper over the shared implementation.

This allows the client to lazily iterate:

- consumed input notes
- non-consumed input notes via `with_filter(...)`
- output notes

### 2. Preserved existing behavior for `InputNoteReader`

To avoid breaking existing callers, `client.input_note_reader()` still defaults to `NoteFilter::Consumed`.

New behavior is opt-in through filters, for example:

```rust
let mut reader = client
    .input_note_reader()
    .with_filter(NoteFilter::Unspent);
```

A new convenience API was also added:

```rust
client.note_reader(NoteReaderSource::Input)
client.note_reader(NoteReaderSource::Output)
client.output_note_reader()
```

### 3. Reader execution model

The shared reader uses two internal strategies:

- Consumed input notes continue to use store-level offset queries, preserving the lazy ordered iteration introduced in #1843.
- Non-consumed input notes and output notes are loaded, filtered/sorted in memory, and then iterated lazily from the buffered result set.

This keeps the consumed-input path efficient without requiring a larger store/query redesign for every note category.

### 4. Supporting metadata and ordering cleanup

This PR also updates the supporting note metadata flow needed by the readers:

- `consumed_tx_order` was widened from `u16` to `u32`
- per-account ordering semantics were clarified in comments/docs
- `nullifier_block_height` is now used as a shared getter instead of duplicating state matches
- note update tracking and sync plumbing were updated to carry the consumed ordering metadata consistently

### 5. Store-specific updates

The SQLite and IndexedDB paths were updated so the generalized readers work consistently across stores.

__SQLite__

- updated note serialization / persistence plumbing
- clarified schema comment for `consumed_tx_order` as a per-account ordering field
- added/updated note reader tests

__IndexedDB__

- updated JS bindings / serialization for consumed ordering metadata
- extracted the consumed-order comparator helper in `notes.js`
- kept the cursor-based consumed-note path and in-memory fallback path aligned with the new reader behavior

### 6. Tests

Added/updated coverage for:

- filtered input note iteration
- output note iteration
- shared `NoteReader` output variants
- existing consumed-note reader behavior