### PR TITLE
chore: update note-transport to 0.3.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3381,9 +3381,9 @@ dependencies = [
 
 [[package]]
 name = "miden-note-transport-proto-build"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec23738a2eee393524a849a8dce982ad824050cc54abde145d4fb62b92c84198"
+checksum = "14b66412c3b7b9c6341410a67e2add82a0573c98b47bad166aa73e3c260066f6"
 dependencies = [
  "fs-err",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ miden-node-rpc                   = { version = "=0.14.0-alpha.9" }
 miden-node-store                 = { version = "=0.14.0-alpha.9" }
 miden-node-utils                 = { version = "=0.14.0-alpha.9" }
 miden-node-validator             = { version = "=0.14.0-alpha.9" }
-miden-note-transport-proto-build = { default-features = false, version = "0.2" }
+miden-note-transport-proto-build = { default-features = false, version = "0.3.0-alpha.1" }
 miden-remote-prover-client       = { default-features = false, features = ["tx-prover"], version = "=0.14.0-alpha.9" }
 
 # External dependencies


### PR DESCRIPTION
## Summary
- Bump `miden-note-transport-proto-build` dependency from `0.2` to `0.3.0-alpha.1`
- Install `miden-note-transport-node-bin` from crates.io instead of git in CI and scripts
- Update CI cache key to version-based instead of Cargo.lock hash

## Test plan
- [ ] CI integration tests pass with the new transport version
- [ ] `cargo check` passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)