### PR TITLE
chore: unify Makefile build and clippy into single cargo invocations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,8 @@ NOTE_TRANSPORT_ENDPOINT=http://127.0.0.1:57292
 # --- Linting -------------------------------------------------------------------------------------
 
 .PHONY: clippy
-clippy: ## Run Clippy with configs. We need two separate commands because the `testing-remote-prover` cannot be built along with the rest of the workspace. This is because they use different versions of the `miden-tx` crate which aren't compatible with each other.
-	cargo clippy --workspace $(EXCLUDE_WASM_PACKAGES) --exclude testing-remote-prover --all-targets -- -D warnings
-	cargo clippy --package testing-remote-prover --all-targets -- -D warnings
+clippy: ## Run Clippy with configs
+	cargo clippy --workspace $(EXCLUDE_WASM_PACKAGES) --all-targets -- -D warnings
 
 .PHONY: clippy-wasm
 clippy-wasm: rust-client-ts-build ## Run Clippy for the wasm packages (web client and idxdb store)
@@ -196,9 +195,7 @@ install-tests: ## Install the tests binary
 # --- Building ------------------------------------------------------------------------------------
 
 build: ## Build the CLI binary, client library and tests binary in release mode
-	cargo build --workspace $(EXCLUDE_WASM_PACKAGES) --exclude testing-remote-prover --release
-	cargo build --package testing-remote-prover --release --locked
-	cargo build --package miden-client-integration-tests --release --locked
+	cargo build --workspace $(EXCLUDE_WASM_PACKAGES) --release --locked
 
 build-wasm: rust-client-ts-build ## Build the wasm packages (web client and idxdb store)
 	CODEGEN=1 cargo build --package miden-client-web --target wasm32-unknown-unknown --locked


### PR DESCRIPTION
The `build` and `clippy` targets split `testing-remote-prover` into a separate `cargo` command because it used a different `miden-tx` version. That's no longer the case, there's a single version in `Cargo.lock`, so everything can run in one invocation.

Running separate commands causes cargo to re-resolve features between invocations, invalidating cached artifacts and recompiling shared dependencies. Of 503 unique crates, 116 get compiled twice and 45 get compiled three times, adding 206 redundant compilations (116 + 45*2).

**Benchmarks** (M4 Max, same commit, sequential, `cargo clean` before each):

| | Before (3 commands) | After (1 command) | Improvement |
|---|---|---|---|
| Total compilations | 709 | 503 | -29% |
| Redundant compilations | 206 | 0 | -100% |
| Wall time | 4m 14s | 2m 50s | -33% |