### PR TITLE
feat(web-client): add iter()/into_iter() to declare_js_miden_arrays macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@
 * [FEATURE][web] Exposed `executeProgram` (view call) to the JS side, allowing local execution of a transaction script against an account and inspection of the 16-element stack output without submitting to the network. Added `AdviceInputs` constructor and reverse `From` conversions. ([#1859](https://github.com/0xMiden/miden-client/issues/1859))
 * [FEATURE][web] Added `client.keystore` sub-object API for managing secret keys. Methods: `insert(accountId, secretKey)`, `get(pubKeyCommitment)`, `remove(pubKeyCommitment)`, `getCommitments(accountId)`, `getAccountId(pubKeyCommitment)`. Also available on `MidenClient` as a resource (`client.keystore`). ([#1947](https://github.com/0xMiden/miden-client/pull/1947))
 
+* [FEATURE][web] Added `IntoIterator` implementations to the `declare_js_miden_arrays!` macro, enabling Rust-side iteration over WASM array types via `into_iter()` (by value and by reference) without accessing internal fields directly ([#1965](https://github.com/0xMiden/miden-client/pull/1965)).
+
 ### Fixes
 
 * [FIX][web] Replaced `.unwrap()` panics with proper `Result` returns in `MerklePath.computeRoot()`, `NoteExecutionHint.fromParts()`, `NoteExecutionHint.canBeConsumed()`, `NoteStorage` constructor, and `TransactionStatus.discarded()` WASM bindings ([#1870](https://github.com/0xMiden/miden-client/pull/1870)).

--- a/crates/web-client/src/miden_array.rs
+++ b/crates/web-client/src/miden_array.rs
@@ -73,6 +73,31 @@ macro_rules! declare_js_miden_arrays {
                 }
             }
 
+            impl $miden_type_array_name {
+                /// Returns an iterator over references to the elements.
+                pub fn iter(&self) -> core::slice::Iter<'_, $miden_type_name> {
+                    self.__inner.iter()
+                }
+            }
+
+            impl IntoIterator for $miden_type_array_name {
+                type Item = $miden_type_name;
+                type IntoIter = alloc::vec::IntoIter<$miden_type_name>;
+
+                fn into_iter(self) -> Self::IntoIter {
+                    self.__inner.into_iter()
+                }
+            }
+
+            impl<'a> IntoIterator for &'a $miden_type_array_name {
+                type Item = &'a $miden_type_name;
+                type IntoIter = core::slice::Iter<'a, $miden_type_name>;
+
+                fn into_iter(self) -> Self::IntoIter {
+                    self.__inner.iter()
+                }
+            }
+
             impl From<$miden_type_array_name> for Vec<$miden_type_name> {
                 fn from(array: $miden_type_array_name) -> Self {
                     return array.__inner;

--- a/crates/web-client/src/miden_array.rs
+++ b/crates/web-client/src/miden_array.rs
@@ -73,6 +73,12 @@ macro_rules! declare_js_miden_arrays {
                 }
             }
 
+            impl $miden_type_array_name {
+                pub fn iter(&self) -> core::slice::Iter<'_, $miden_type_name> {
+                    self.__inner.iter()
+                }
+            }
+
             impl IntoIterator for $miden_type_array_name {
                 type Item = $miden_type_name;
                 type IntoIter = alloc::vec::IntoIter<$miden_type_name>;

--- a/crates/web-client/src/miden_array.rs
+++ b/crates/web-client/src/miden_array.rs
@@ -73,13 +73,6 @@ macro_rules! declare_js_miden_arrays {
                 }
             }
 
-            impl $miden_type_array_name {
-                /// Returns an iterator over references to the elements.
-                pub fn iter(&self) -> core::slice::Iter<'_, $miden_type_name> {
-                    self.__inner.iter()
-                }
-            }
-
             impl IntoIterator for $miden_type_array_name {
                 type Item = $miden_type_name;
                 type IntoIter = alloc::vec::IntoIter<$miden_type_name>;

--- a/crates/web-client/src/models/felt.rs
+++ b/crates/web-client/src/models/felt.rs
@@ -62,6 +62,6 @@ impl From<&Felt> for NativeFelt {
 
 impl From<&FeltArray> for Vec<NativeFelt> {
     fn from(felt_array: &FeltArray) -> Self {
-        felt_array.__inner.iter().map(Into::into).collect()
+        felt_array.iter().map(Into::into).collect()
     }
 }

--- a/crates/web-client/src/models/note.rs
+++ b/crates/web-client/src/models/note.rs
@@ -187,12 +187,12 @@ impl From<&Note> for NativeNote {
 
 impl From<crate::models::miden_arrays::NoteArray> for Vec<NativeNote> {
     fn from(note_array: crate::models::miden_arrays::NoteArray) -> Self {
-        note_array.__inner.into_iter().map(Into::into).collect()
+        note_array.into_iter().map(Into::into).collect()
     }
 }
 
 impl From<&crate::models::miden_arrays::NoteArray> for Vec<NativeNote> {
     fn from(note_array: &crate::models::miden_arrays::NoteArray) -> Self {
-        note_array.__inner.iter().cloned().map(Into::into).collect()
+        note_array.iter().cloned().map(Into::into).collect()
     }
 }

--- a/crates/web-client/src/models/note_recipient.rs
+++ b/crates/web-client/src/models/note_recipient.rs
@@ -93,6 +93,6 @@ impl From<&NoteRecipient> for NativeNoteRecipient {
 
 impl From<&RecipientArray> for Vec<NativeNoteRecipient> {
     fn from(recipient_array: &RecipientArray) -> Self {
-        recipient_array.__inner.iter().map(NativeNoteRecipient::from).collect()
+        recipient_array.iter().map(NativeNoteRecipient::from).collect()
     }
 }

--- a/crates/web-client/src/models/output_note.rs
+++ b/crates/web-client/src/models/output_note.rs
@@ -96,12 +96,12 @@ impl From<&OutputNote> for NativeRawOutputNote {
 
 impl From<OutputNoteArray> for Vec<NativeRawOutputNote> {
     fn from(output_notes_array: OutputNoteArray) -> Self {
-        output_notes_array.__inner.into_iter().map(Into::into).collect()
+        output_notes_array.into_iter().map(Into::into).collect()
     }
 }
 
 impl From<&OutputNoteArray> for Vec<NativeRawOutputNote> {
     fn from(output_notes_array: &OutputNoteArray) -> Self {
-        output_notes_array.__inner.iter().cloned().map(Into::into).collect()
+        output_notes_array.iter().cloned().map(Into::into).collect()
     }
 }

--- a/crates/web-client/src/models/transaction_request/note_and_args.rs
+++ b/crates/web-client/src/models/transaction_request/note_and_args.rs
@@ -42,12 +42,12 @@ impl From<&NoteAndArgs> for (NativeNote, Option<NativeNoteArgs>) {
 
 impl From<NoteAndArgsArray> for Vec<(NativeNote, Option<NativeNoteArgs>)> {
     fn from(note_and_args_array: NoteAndArgsArray) -> Self {
-        note_and_args_array.__inner.into_iter().map(Into::into).collect()
+        note_and_args_array.into_iter().map(Into::into).collect()
     }
 }
 
 impl From<&NoteAndArgsArray> for Vec<(NativeNote, Option<NativeNoteArgs>)> {
     fn from(note_and_args_array: &NoteAndArgsArray) -> Self {
-        note_and_args_array.__inner.iter().map(Into::into).collect()
+        note_and_args_array.iter().map(Into::into).collect()
     }
 }

--- a/crates/web-client/src/models/transaction_request/note_details_and_tag.rs
+++ b/crates/web-client/src/models/transaction_request/note_details_and_tag.rs
@@ -54,12 +54,12 @@ impl From<&NoteDetailsAndTag> for (NativeNoteDetails, NativeNoteTag) {
 
 impl From<NoteDetailsAndTagArray> for Vec<(NativeNoteDetails, NativeNoteTag)> {
     fn from(note_details_and_tag_array: NoteDetailsAndTagArray) -> Self {
-        note_details_and_tag_array.__inner.into_iter().map(Into::into).collect()
+        note_details_and_tag_array.into_iter().map(Into::into).collect()
     }
 }
 
 impl From<&NoteDetailsAndTagArray> for Vec<(NativeNoteDetails, NativeNoteTag)> {
     fn from(note_details_and_tag_array: &NoteDetailsAndTagArray) -> Self {
-        note_details_and_tag_array.__inner.iter().map(Into::into).collect()
+        note_details_and_tag_array.iter().map(Into::into).collect()
     }
 }

--- a/crates/web-client/src/models/transaction_request/note_id_and_args.rs
+++ b/crates/web-client/src/models/transaction_request/note_id_and_args.rs
@@ -42,12 +42,12 @@ impl From<&NoteIdAndArgs> for (NativeNoteId, Option<NativeNoteArgs>) {
 
 impl From<NoteIdAndArgsArray> for Vec<(NativeNoteId, Option<NativeNoteArgs>)> {
     fn from(note_id_and_args_array: NoteIdAndArgsArray) -> Self {
-        note_id_and_args_array.__inner.into_iter().map(Into::into).collect()
+        note_id_and_args_array.into_iter().map(Into::into).collect()
     }
 }
 
 impl From<&NoteIdAndArgsArray> for Vec<(NativeNoteId, Option<NativeNoteArgs>)> {
     fn from(note_id_and_args_array: &NoteIdAndArgsArray) -> Self {
-        note_id_and_args_array.__inner.iter().map(Into::into).collect()
+        note_id_and_args_array.iter().map(Into::into).collect()
     }
 }

--- a/crates/web-client/src/models/transaction_request/transaction_request_builder.rs
+++ b/crates/web-client/src/models/transaction_request/transaction_request_builder.rs
@@ -106,7 +106,7 @@ impl TransactionRequestBuilder {
     #[wasm_bindgen(js_name = "withForeignAccounts")]
     pub fn with_foreign_accounts(mut self, foreign_accounts: &ForeignAccountArray) -> Self {
         let native_foreign_accounts: Vec<NativeForeignAccount> =
-            foreign_accounts.__inner.iter().map(|account| account.clone().into()).collect();
+            foreign_accounts.iter().map(|account| account.clone().into()).collect();
         self.0 = self.0.foreign_accounts(native_foreign_accounts);
         self
     }

--- a/crates/web-client/src/models/transaction_script_inputs.rs
+++ b/crates/web-client/src/models/transaction_script_inputs.rs
@@ -37,7 +37,7 @@ impl From<TransactionScriptInputPair> for (NativeWord, Vec<NativeFelt>) {
         let native_word: NativeWord = transaction_script_input_pair.word.into();
         let native_felts: Vec<NativeFelt> = transaction_script_input_pair
             .felts
-            .__inner
+            
             .into_iter()
             .map(Into::into)
             .collect();
@@ -50,7 +50,7 @@ impl From<&TransactionScriptInputPair> for (NativeWord, Vec<NativeFelt>) {
         let native_word: NativeWord = transaction_script_input_pair.word.clone().into();
         let native_felts: Vec<NativeFelt> = transaction_script_input_pair
             .felts
-            .__inner
+            
             .iter()
             .map(|felt| (*felt).into())
             .collect();
@@ -61,7 +61,7 @@ impl From<&TransactionScriptInputPair> for (NativeWord, Vec<NativeFelt>) {
 impl From<TransactionScriptInputPairArray> for Vec<(NativeWord, Vec<NativeFelt>)> {
     fn from(transaction_script_input_pair_array: TransactionScriptInputPairArray) -> Self {
         transaction_script_input_pair_array
-            .__inner
+            
             .into_iter()
             .map(Into::into)
             .collect()
@@ -70,6 +70,6 @@ impl From<TransactionScriptInputPairArray> for Vec<(NativeWord, Vec<NativeFelt>)
 
 impl From<&TransactionScriptInputPairArray> for Vec<(NativeWord, Vec<NativeFelt>)> {
     fn from(transaction_script_input_pair_array: &TransactionScriptInputPairArray) -> Self {
-        transaction_script_input_pair_array.__inner.iter().map(Into::into).collect()
+        transaction_script_input_pair_array.iter().map(Into::into).collect()
     }
 }

--- a/crates/web-client/src/models/transaction_script_inputs.rs
+++ b/crates/web-client/src/models/transaction_script_inputs.rs
@@ -44,11 +44,8 @@ impl From<TransactionScriptInputPair> for (NativeWord, Vec<NativeFelt>) {
 impl From<&TransactionScriptInputPair> for (NativeWord, Vec<NativeFelt>) {
     fn from(transaction_script_input_pair: &TransactionScriptInputPair) -> Self {
         let native_word: NativeWord = transaction_script_input_pair.word.clone().into();
-        let native_felts: Vec<NativeFelt> = transaction_script_input_pair
-            .felts
-            .iter()
-            .map(|felt| felt.into())
-            .collect();
+        let native_felts: Vec<NativeFelt> =
+            transaction_script_input_pair.felts.iter().map(Into::into).collect();
         (native_word, native_felts)
     }
 }

--- a/crates/web-client/src/models/transaction_script_inputs.rs
+++ b/crates/web-client/src/models/transaction_script_inputs.rs
@@ -61,6 +61,6 @@ impl From<TransactionScriptInputPairArray> for Vec<(NativeWord, Vec<NativeFelt>)
 
 impl From<&TransactionScriptInputPairArray> for Vec<(NativeWord, Vec<NativeFelt>)> {
     fn from(transaction_script_input_pair_array: &TransactionScriptInputPairArray) -> Self {
-        transaction_script_input_pair_array.into_iter().map(Into::into).collect()
+        transaction_script_input_pair_array.iter().map(Into::into).collect()
     }
 }

--- a/crates/web-client/src/models/transaction_script_inputs.rs
+++ b/crates/web-client/src/models/transaction_script_inputs.rs
@@ -35,11 +35,8 @@ impl TransactionScriptInputPair {
 impl From<TransactionScriptInputPair> for (NativeWord, Vec<NativeFelt>) {
     fn from(transaction_script_input_pair: TransactionScriptInputPair) -> Self {
         let native_word: NativeWord = transaction_script_input_pair.word.into();
-        let native_felts: Vec<NativeFelt> = transaction_script_input_pair
-            .felts
-            .into_iter()
-            .map(Into::into)
-            .collect();
+        let native_felts: Vec<NativeFelt> =
+            transaction_script_input_pair.felts.into_iter().map(Into::into).collect();
         (native_word, native_felts)
     }
 }
@@ -49,8 +46,8 @@ impl From<&TransactionScriptInputPair> for (NativeWord, Vec<NativeFelt>) {
         let native_word: NativeWord = transaction_script_input_pair.word.clone().into();
         let native_felts: Vec<NativeFelt> = transaction_script_input_pair
             .felts
-            .into_iter()
-            .map(|felt| (*felt).into())
+            .iter()
+            .map(|felt| felt.into())
             .collect();
         (native_word, native_felts)
     }
@@ -58,10 +55,7 @@ impl From<&TransactionScriptInputPair> for (NativeWord, Vec<NativeFelt>) {
 
 impl From<TransactionScriptInputPairArray> for Vec<(NativeWord, Vec<NativeFelt>)> {
     fn from(transaction_script_input_pair_array: TransactionScriptInputPairArray) -> Self {
-        transaction_script_input_pair_array
-            .into_iter()
-            .map(Into::into)
-            .collect()
+        transaction_script_input_pair_array.into_iter().map(Into::into).collect()
     }
 }
 

--- a/crates/web-client/src/models/transaction_script_inputs.rs
+++ b/crates/web-client/src/models/transaction_script_inputs.rs
@@ -37,7 +37,6 @@ impl From<TransactionScriptInputPair> for (NativeWord, Vec<NativeFelt>) {
         let native_word: NativeWord = transaction_script_input_pair.word.into();
         let native_felts: Vec<NativeFelt> = transaction_script_input_pair
             .felts
-            
             .into_iter()
             .map(Into::into)
             .collect();
@@ -50,8 +49,7 @@ impl From<&TransactionScriptInputPair> for (NativeWord, Vec<NativeFelt>) {
         let native_word: NativeWord = transaction_script_input_pair.word.clone().into();
         let native_felts: Vec<NativeFelt> = transaction_script_input_pair
             .felts
-            
-            .iter()
+            .into_iter()
             .map(|felt| (*felt).into())
             .collect();
         (native_word, native_felts)
@@ -61,7 +59,6 @@ impl From<&TransactionScriptInputPair> for (NativeWord, Vec<NativeFelt>) {
 impl From<TransactionScriptInputPairArray> for Vec<(NativeWord, Vec<NativeFelt>)> {
     fn from(transaction_script_input_pair_array: TransactionScriptInputPairArray) -> Self {
         transaction_script_input_pair_array
-            
             .into_iter()
             .map(Into::into)
             .collect()
@@ -70,6 +67,6 @@ impl From<TransactionScriptInputPairArray> for Vec<(NativeWord, Vec<NativeFelt>)
 
 impl From<&TransactionScriptInputPairArray> for Vec<(NativeWord, Vec<NativeFelt>)> {
     fn from(transaction_script_input_pair_array: &TransactionScriptInputPairArray) -> Self {
-        transaction_script_input_pair_array.iter().map(Into::into).collect()
+        transaction_script_input_pair_array.into_iter().map(Into::into).collect()
     }
 }

--- a/crates/web-client/src/new_transactions.rs
+++ b/crates/web-client/src/new_transactions.rs
@@ -171,7 +171,7 @@ impl WebClient {
         if let Some(client) = self.get_mut_inner() {
             let foreign_accounts_map: BTreeMap<NativeAccountId, NativeForeignAccount> =
                 foreign_accounts
-                    .__inner
+                    
                     .iter()
                     .map(|a| {
                         let fa: NativeForeignAccount = a.clone().into();

--- a/crates/web-client/src/new_transactions.rs
+++ b/crates/web-client/src/new_transactions.rs
@@ -171,8 +171,7 @@ impl WebClient {
         if let Some(client) = self.get_mut_inner() {
             let foreign_accounts_map: BTreeMap<NativeAccountId, NativeForeignAccount> =
                 foreign_accounts
-                    
-                    .iter()
+                    .into_iter()
                     .map(|a| {
                         let fa: NativeForeignAccount = a.clone().into();
                         (fa.account_id(), fa)


### PR DESCRIPTION
## Summary

Closes 0xMiden/web-sdk#109

Adds `iter()` and `IntoIterator` implementations to the types generated by the `declare_js_miden_arrays!` macro in `crates/web-client/src/miden_array.rs`, then updates all call sites to use the new methods instead of accessing `.__inner` directly.

## Changes

### `crates/web-client/src/miden_array.rs`

Three additions to each generated array type inside the macro:

1. **`iter()` method** — a plain (non-`wasm_bindgen`) `impl` block that delegates to `Vec::iter()`, returning a `core::slice::Iter`:
   ```rust
   impl $miden_type_array_name {
       pub fn iter(&self) -> core::slice::Iter<'_, $miden_type_name> {
           self.__inner.iter()
       }
   }
   ```

2. **`IntoIterator` for owned values** — consumes the array and yields its elements:
   ```rust
   impl IntoIterator for $miden_type_array_name {
       type Item = $miden_type_name;
       type IntoIter = alloc::vec::IntoIter<$miden_type_name>;
       fn into_iter(self) -> Self::IntoIter { self.__inner.into_iter() }
   }
   ```

3. **`IntoIterator` for references** — iterates by reference without consuming:
   ```rust
   impl<'a> IntoIterator for &'a $miden_type_array_name {
       type Item = &'a $miden_type_name;
       type IntoIter = core::slice::Iter<'a, $miden_type_name>;
       fn into_iter(self) -> Self::IntoIter { self.__inner.iter() }
   }
   ```

### Call-site cleanup (11 files)

All 20+ usages of `.__inner` for iteration have been replaced with idiomatic method calls:

| Before | After |
|--------|-------|
| `array.__inner.iter()` | `array.iter()` |
| `array.__inner.into_iter()` | `array.into_iter()` |
| multi-line `.__inner\n    .iter()` | `\n    .iter()` |
| multi-line `.__inner\n    .into_iter()` | `\n    .into_iter()` |

Files updated:
- `crates/web-client/src/models/transaction_script_inputs.rs`
- `crates/web-client/src/new_transactions.rs`
- `crates/web-client/src/models/felt.rs`
- `crates/web-client/src/models/output_note.rs`
- `crates/web-client/src/models/note.rs`
- `crates/web-client/src/models/transaction_request/note_and_args.rs`
- `crates/web-client/src/models/note_recipient.rs`
- `crates/web-client/src/models/transaction_request/note_id_and_args.rs`
- `crates/web-client/src/models/transaction_request/note_details_and_tag.rs`
- `crates/web-client/src/models/transaction_request/transaction_request_builder.rs`

## Pre-PR checklist

- [x] Branch forked from `next` and named following kebab-case convention
- [x] Commit messages follow semantic commit scheme
- [x] No new tests required — this is a pure refactor; existing behaviour is preserved (no logic changes, only access pattern)
- [x] Documentation/comments updated in the macro (`iter()` has a doc comment)
- [x] No public API changes visible to downstream users (internal Rust ergonomics only)
- [x] CHANGELOG not required — internal refactor with no user-facing behaviour change


---

> [!NOTE]
> The web-sdk parts of this PR have been migrated to https://github.com/0xMiden/web-sdk/pull/28 as part of the web-sdk split (#1992 / 0xMiden/miden-client#2135). The miden-client side stays here. Note: the migration has 3-way merge conflicts that need manual resolution.
