### PR TITLE
feat: track consumer on notes consumed externally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Added automatic registration of note scripts required by network transactions (NTX). The client now checks the node's script registry before submitting a transaction and registers any missing scripts via a separate registration transaction ([#1840](https://github.com/0xMiden/miden-client/pull/1840)).
 * Added automatic retry for rate-limited (`ResourceExhausted`) and transiently unavailable RPC calls in `GrpcClient`, with up to 5 attempts and `retry-after` header support ([#1928](https://github.com/0xMiden/miden-client/pull/1928)).
 * Added client methods to prune account history (commitments of previous nonces, alongside its orphaned account code) ([#1886](https://github.com/0xMiden/miden-client/pull/1886)).
+* Changed the sync state to track the consumer account on externally-consumed notes, so the `InputNoteReader` can return notes even if the transaction was not locally executed ([#1973](https://github.com/0xMiden/miden-client/pull/1973)).
 
 ### Changes
 

--- a/crates/rust-client/src/note/import.rs
+++ b/crates/rust-client/src/note/import.rs
@@ -256,7 +256,7 @@ where
 
             if let Some(Some(block_height)) = nullifier_commit_heights.get(&note_record.nullifier())
             {
-                if note_record.consumed_externally(note_record.nullifier(), *block_height)? {
+                if note_record.consumed_externally(note_record.nullifier(), *block_height, None)? {
                     note_records.push(Some(note_record));
                 }
 

--- a/crates/rust-client/src/note/note_update_tracker.rs
+++ b/crates/rust-client/src/note/note_update_tracker.rs
@@ -1,5 +1,6 @@
 use alloc::collections::BTreeMap;
 
+use miden_protocol::account::AccountId;
 use miden_protocol::block::BlockHeader;
 use miden_protocol::note::{NoteId, NoteInclusionProof, Nullifier};
 
@@ -359,12 +360,15 @@ impl NoteUpdateTracker {
     ///
     /// For input note records two possible scenarios are considered:
     /// 1. The note was being processed by a local transaction that just got committed.
-    /// 2. The note was consumed by an external transaction. If a local transaction was processing
-    ///    the note and it didn't get committed, the transaction should be discarded.
+    /// 2. The note was consumed by a transaction not submitted by this client. This includes
+    ///    consumption by untracked accounts as well as consumption by tracked accounts whose
+    ///    transactions were submitted by other client instances. If a local transaction was
+    ///    processing the note and it didn't get committed, the transaction should be discarded.
     pub(crate) fn apply_nullifiers_state_transitions<'a>(
         &mut self,
         nullifier_update: &NullifierUpdate,
         mut committed_transactions: impl Iterator<Item = &'a TransactionRecord>,
+        external_consumer_account: Option<AccountId>,
     ) -> Result<(), ClientError> {
         let order = self.get_nullifier_order(nullifier_update.nullifier);
 
@@ -383,10 +387,13 @@ impl NoteUpdateTracker {
                         .transaction_committed(consumer_transaction.id, block_number)?;
                 }
             } else {
-                // The note was consumed by an external transaction
-                input_note_update
-                    .inner_mut()
-                    .consumed_externally(nullifier_update.nullifier, nullifier_update.block_num)?;
+                // The note was consumed by a transaction not submitted by this client.
+                // If the consuming account is tracked, external_consumer_account will be Some.
+                input_note_update.inner_mut().consumed_externally(
+                    nullifier_update.nullifier,
+                    nullifier_update.block_num,
+                    external_consumer_account,
+                )?;
             }
             input_note_update.inner_mut().set_consumed_tx_order(order);
         }

--- a/crates/rust-client/src/rpc/domain/transaction.rs
+++ b/crates/rust-client/src/rpc/domain/transaction.rs
@@ -66,6 +66,8 @@ pub struct TransactionInclusion {
     pub account_id: AccountId,
     /// The initial account state commitment before the transaction was executed.
     pub initial_state_commitment: Word,
+    /// The nullifiers of the input notes consumed by this transaction.
+    pub nullifiers: Vec<Nullifier>,
     /// Output notes from this transaction, with inclusion proofs.
     pub output_notes: Vec<CommittedNote>,
 }

--- a/crates/rust-client/src/store/note_record/input_note_record/mod.rs
+++ b/crates/rust-client/src/store/note_record/input_note_record/mod.rs
@@ -135,10 +135,10 @@ impl InputNoteRecord {
 
     /// Returns the account ID that consumed this note, if available.
     ///
-    /// This is available for notes in processing or consumed-local states, where the
-    /// submission data contains the consumer account. Returns `None` for externally
-    /// consumed notes, invalid notes, or notes that haven't been submitted for
-    /// consumption.
+    /// This is available for notes in processing, consumed-local, or consumed-external
+    /// states. For externally consumed notes, the account is only known when it is tracked
+    /// by this client. Returns `None` for notes that haven't been submitted for consumption,
+    /// invalid notes, or externally consumed notes where the consuming account is unknown.
     pub fn consumer_account(&self) -> Option<AccountId> {
         match &self.state {
             InputNoteState::ProcessingAuthenticated(s) => Some(s.submission_data.consumer_account),
@@ -151,6 +151,7 @@ impl InputNoteRecord {
             InputNoteState::ConsumedUnauthenticatedLocal(s) => {
                 Some(s.submission_data.consumer_account)
             },
+            InputNoteState::ConsumedExternal(s) => s.consumer_account,
             _ => None,
         }
     }
@@ -233,8 +234,11 @@ impl InputNoteRecord {
         }
     }
 
-    /// Modifies the state of the note record to reflect that the note has been consumed by an
-    /// external transaction. Returns `true` if the state was changed.
+    /// Modifies the state of the note record to reflect that the note has been consumed by a
+    /// transaction not submitted by this client. Returns `true` if the state was changed.
+    ///
+    /// `consumer_account` is `Some` when the consuming account is tracked by this client
+    /// (derived from `sync_transactions` data). It is `None` for untracked accounts.
     ///
     /// Errors:
     /// - If the nullifier doesn't match the expected value.
@@ -242,6 +246,7 @@ impl InputNoteRecord {
         &mut self,
         nullifier: Nullifier,
         nullifier_block_height: BlockNumber,
+        consumer_account: Option<AccountId>,
     ) -> Result<bool, NoteRecordError> {
         if self.nullifier() != nullifier {
             return Err(NoteRecordError::StateTransitionError(
@@ -249,7 +254,7 @@ impl InputNoteRecord {
             ));
         }
 
-        let new_state = self.state.consumed_externally(nullifier_block_height)?;
+        let new_state = self.state.consumed_externally(nullifier_block_height, consumer_account)?;
         if let Some(new_state) = new_state {
             self.state = new_state;
             Ok(true)

--- a/crates/rust-client/src/store/note_record/input_note_record/states/committed.rs
+++ b/crates/rust-client/src/store/note_record/input_note_record/states/committed.rs
@@ -1,6 +1,7 @@
 use alloc::string::ToString;
 
 use miden_protocol::Word;
+use miden_protocol::account::AccountId;
 use miden_protocol::block::{BlockHeader, BlockNumber};
 use miden_protocol::note::{NoteId, NoteInclusionProof, NoteMetadata};
 use miden_protocol::transaction::TransactionId;
@@ -43,10 +44,12 @@ impl NoteStateHandler for CommittedNoteState {
     fn consumed_externally(
         &self,
         nullifier_block_height: BlockNumber,
+        consumer_account: Option<AccountId>,
     ) -> Result<Option<InputNoteState>, NoteRecordError> {
         Ok(Some(
             ConsumedExternalNoteState {
                 nullifier_block_height,
+                consumer_account,
                 consumed_tx_order: None,
             }
             .into(),

--- a/crates/rust-client/src/store/note_record/input_note_record/states/consumed_authenticated_local.rs
+++ b/crates/rust-client/src/store/note_record/input_note_record/states/consumed_authenticated_local.rs
@@ -1,6 +1,7 @@
 use alloc::string::ToString;
 
 use miden_protocol::Word;
+use miden_protocol::account::AccountId;
 use miden_protocol::block::{BlockHeader, BlockNumber};
 use miden_protocol::note::{NoteId, NoteInclusionProof, NoteMetadata};
 use miden_protocol::transaction::TransactionId;
@@ -39,6 +40,7 @@ impl NoteStateHandler for ConsumedAuthenticatedLocalNoteState {
     fn consumed_externally(
         &self,
         _nullifier_block_height: BlockNumber,
+        _consumer_account: Option<AccountId>,
     ) -> Result<Option<InputNoteState>, NoteRecordError> {
         Ok(None)
     }

--- a/crates/rust-client/src/store/note_record/input_note_record/states/consumed_external.rs
+++ b/crates/rust-client/src/store/note_record/input_note_record/states/consumed_external.rs
@@ -1,5 +1,6 @@
 use alloc::string::ToString;
 
+use miden_protocol::account::AccountId;
 use miden_protocol::block::{BlockHeader, BlockNumber};
 use miden_protocol::note::{NoteId, NoteInclusionProof, NoteMetadata};
 use miden_protocol::transaction::TransactionId;
@@ -8,10 +9,15 @@ use super::{InputNoteState, NoteStateHandler};
 use crate::store::NoteRecordError;
 
 /// Information related to notes in the [`InputNoteState::ConsumedExternal`] state.
+///
+/// A note enters this state when its nullifier appears on-chain but the consuming transaction was
+/// not submitted by this client.
 #[derive(Clone, Debug, PartialEq)]
 pub struct ConsumedExternalNoteState {
     /// Block height at which the note was nullified.
     pub nullifier_block_height: BlockNumber,
+    /// The account that consumed the note, if it is tracked by this client.
+    pub consumer_account: Option<AccountId>,
     /// Per-account position of the consuming transaction within the account's execution chain
     /// for the block. `None` if the order has not been determined yet.
     pub consumed_tx_order: Option<u32>,
@@ -29,6 +35,7 @@ impl NoteStateHandler for ConsumedExternalNoteState {
     fn consumed_externally(
         &self,
         _nullifier_block_height: BlockNumber,
+        _consumer_account: Option<AccountId>,
     ) -> Result<Option<InputNoteState>, NoteRecordError> {
         Ok(None)
     }
@@ -76,6 +83,7 @@ impl NoteStateHandler for ConsumedExternalNoteState {
 impl miden_tx::utils::serde::Serializable for ConsumedExternalNoteState {
     fn write_into<W: miden_tx::utils::serde::ByteWriter>(&self, target: &mut W) {
         self.nullifier_block_height.write_into(target);
+        self.consumer_account.write_into(target);
         self.consumed_tx_order.write_into(target);
     }
 }
@@ -85,9 +93,11 @@ impl miden_tx::utils::serde::Deserializable for ConsumedExternalNoteState {
         source: &mut R,
     ) -> Result<Self, miden_tx::utils::serde::DeserializationError> {
         let nullifier_block_height = BlockNumber::read_from(source)?;
+        let consumer_account = Option::<AccountId>::read_from(source)?;
         let consumed_tx_order = Option::<u32>::read_from(source)?;
         Ok(ConsumedExternalNoteState {
             nullifier_block_height,
+            consumer_account,
             consumed_tx_order,
         })
     }

--- a/crates/rust-client/src/store/note_record/input_note_record/states/consumed_unauthenticated_local.rs
+++ b/crates/rust-client/src/store/note_record/input_note_record/states/consumed_unauthenticated_local.rs
@@ -1,5 +1,6 @@
 use alloc::string::ToString;
 
+use miden_protocol::account::AccountId;
 use miden_protocol::block::{BlockHeader, BlockNumber};
 use miden_protocol::note::{NoteId, NoteInclusionProof, NoteMetadata};
 use miden_protocol::transaction::TransactionId;
@@ -34,6 +35,7 @@ impl NoteStateHandler for ConsumedUnauthenticatedLocalNoteState {
     fn consumed_externally(
         &self,
         _nullifier_block_height: BlockNumber,
+        _consumer_account: Option<AccountId>,
     ) -> Result<Option<InputNoteState>, NoteRecordError> {
         Ok(None)
     }

--- a/crates/rust-client/src/store/note_record/input_note_record/states/expected.rs
+++ b/crates/rust-client/src/store/note_record/input_note_record/states/expected.rs
@@ -41,10 +41,12 @@ impl NoteStateHandler for ExpectedNoteState {
     fn consumed_externally(
         &self,
         nullifier_block_height: BlockNumber,
+        consumer_account: Option<AccountId>,
     ) -> Result<Option<InputNoteState>, NoteRecordError> {
         Ok(Some(
             ConsumedExternalNoteState {
                 nullifier_block_height,
+                consumer_account,
                 consumed_tx_order: None,
             }
             .into(),

--- a/crates/rust-client/src/store/note_record/input_note_record/states/invalid.rs
+++ b/crates/rust-client/src/store/note_record/input_note_record/states/invalid.rs
@@ -1,6 +1,7 @@
 use alloc::string::ToString;
 
 use miden_protocol::Word;
+use miden_protocol::account::AccountId;
 use miden_protocol::block::{BlockHeader, BlockNumber};
 use miden_protocol::note::{NoteId, NoteInclusionProof, NoteMetadata, compute_note_commitment};
 use miden_protocol::transaction::TransactionId;
@@ -38,10 +39,12 @@ impl NoteStateHandler for InvalidNoteState {
     fn consumed_externally(
         &self,
         nullifier_block_height: BlockNumber,
+        consumer_account: Option<AccountId>,
     ) -> Result<Option<InputNoteState>, NoteRecordError> {
         Ok(Some(
             ConsumedExternalNoteState {
                 nullifier_block_height,
+                consumer_account,
                 consumed_tx_order: None,
             }
             .into(),

--- a/crates/rust-client/src/store/note_record/input_note_record/states/mod.rs
+++ b/crates/rust-client/src/store/note_record/input_note_record/states/mod.rs
@@ -56,8 +56,7 @@ pub enum InputNoteState {
     ConsumedAuthenticatedLocal(ConsumedAuthenticatedLocalNoteState),
     /// Unauthenticated note consumed locally by the client and confirmed by the network.
     ConsumedUnauthenticatedLocal(ConsumedUnauthenticatedLocalNoteState),
-    /// Note consumed by an external account (e.g. an account not tracked by the client) and
-    /// confirmed by the network.
+    /// Note consumed by a transaction not submitted by this client and confirmed by the network.
     ConsumedExternal(ConsumedExternalNoteState),
 }
 
@@ -161,13 +160,14 @@ impl InputNoteState {
         self.inner().inclusion_proof_received(inclusion_proof, metadata)
     }
 
-    /// Returns a new state to reflect that the note has been consumed by an external transaction.
-    /// If the note state doesn't change, `None` is returned.
+    /// Returns a new state to reflect that the note has been consumed by a transaction not
+    /// submitted by this client. If the note state doesn't change, `None` is returned.
     pub(crate) fn consumed_externally(
         &self,
         nullifier_block_height: BlockNumber,
+        consumer_account: Option<AccountId>,
     ) -> Result<Option<InputNoteState>, NoteRecordError> {
-        self.inner().consumed_externally(nullifier_block_height)
+        self.inner().consumed_externally(nullifier_block_height, consumer_account)
     }
 
     /// Returns a new state to reflect that the note has received a block header.
@@ -322,7 +322,15 @@ impl Display for InputNoteState {
                 )
             },
             InputNoteState::ConsumedExternal(state) => {
-                write!(f, "Consumed (at block {})", state.nullifier_block_height)
+                if let Some(account) = state.consumer_account {
+                    write!(
+                        f,
+                        "Consumed (at block {} by tracked account {})",
+                        state.nullifier_block_height, account
+                    )
+                } else {
+                    write!(f, "Consumed (at block {})", state.nullifier_block_height)
+                }
             },
         }
     }
@@ -344,6 +352,7 @@ pub trait NoteStateHandler {
     fn consumed_externally(
         &self,
         nullifier_block_height: BlockNumber,
+        consumer_account: Option<AccountId>,
     ) -> Result<Option<InputNoteState>, NoteRecordError>;
 
     fn block_header_received(

--- a/crates/rust-client/src/store/note_record/input_note_record/states/processing_authenticated.rs
+++ b/crates/rust-client/src/store/note_record/input_note_record/states/processing_authenticated.rs
@@ -46,10 +46,12 @@ impl NoteStateHandler for ProcessingAuthenticatedNoteState {
     fn consumed_externally(
         &self,
         nullifier_block_height: BlockNumber,
+        consumer_account: Option<AccountId>,
     ) -> Result<Option<InputNoteState>, NoteRecordError> {
         Ok(Some(
             ConsumedExternalNoteState {
                 nullifier_block_height,
+                consumer_account,
                 consumed_tx_order: None,
             }
             .into(),

--- a/crates/rust-client/src/store/note_record/input_note_record/states/processing_unauthenticated.rs
+++ b/crates/rust-client/src/store/note_record/input_note_record/states/processing_unauthenticated.rs
@@ -1,5 +1,6 @@
 use alloc::string::ToString;
 
+use miden_protocol::account::AccountId;
 use miden_protocol::block::{BlockHeader, BlockNumber};
 use miden_protocol::note::{NoteId, NoteInclusionProof, NoteMetadata};
 use miden_protocol::transaction::TransactionId;
@@ -37,10 +38,12 @@ impl NoteStateHandler for ProcessingUnauthenticatedNoteState {
     fn consumed_externally(
         &self,
         nullifier_block_height: BlockNumber,
+        consumer_account: Option<AccountId>,
     ) -> Result<Option<InputNoteState>, NoteRecordError> {
         Ok(Some(
             ConsumedExternalNoteState {
                 nullifier_block_height,
+                consumer_account,
                 consumed_tx_order: None,
             }
             .into(),

--- a/crates/rust-client/src/store/note_record/input_note_record/states/unverified.rs
+++ b/crates/rust-client/src/store/note_record/input_note_record/states/unverified.rs
@@ -1,5 +1,6 @@
 use alloc::string::ToString;
 
+use miden_protocol::account::AccountId;
 use miden_protocol::block::{BlockHeader, BlockNumber};
 use miden_protocol::note::{NoteId, NoteInclusionProof, NoteMetadata, compute_note_commitment};
 use miden_protocol::transaction::TransactionId;
@@ -37,10 +38,12 @@ impl NoteStateHandler for UnverifiedNoteState {
     fn consumed_externally(
         &self,
         nullifier_block_height: BlockNumber,
+        consumer_account: Option<AccountId>,
     ) -> Result<Option<InputNoteState>, NoteRecordError> {
         Ok(Some(
             ConsumedExternalNoteState {
                 nullifier_block_height,
+                consumer_account,
                 consumed_tx_order: None,
             }
             .into(),

--- a/crates/rust-client/src/sync/state_sync.rs
+++ b/crates/rust-client/src/sync/state_sync.rs
@@ -9,6 +9,7 @@ use miden_protocol::account::{Account, AccountHeader, AccountId};
 use miden_protocol::block::{BlockHeader, BlockNumber};
 use miden_protocol::crypto::merkle::mmr::{MmrDelta, PartialMmr};
 use miden_protocol::note::{Note, NoteId, NoteTag, NoteType, Nullifier};
+use miden_protocol::transaction::InputNoteCommitment;
 use tracing::info;
 
 use super::state_sync_update::TransactionUpdateTracker;
@@ -355,12 +356,21 @@ impl StateSync {
 
         let tx_inclusions = transaction_records
             .into_iter()
-            .map(|r| TransactionInclusion {
-                transaction_id: r.transaction_header.id(),
-                block_num: r.block_num,
-                account_id: r.transaction_header.account_id(),
-                initial_state_commitment: r.transaction_header.initial_state_commitment(),
-                output_notes: r.output_notes,
+            .map(|r| {
+                let nullifiers = r
+                    .transaction_header
+                    .input_notes()
+                    .iter()
+                    .map(InputNoteCommitment::nullifier)
+                    .collect();
+                TransactionInclusion {
+                    transaction_id: r.transaction_header.id(),
+                    block_num: r.block_num,
+                    account_id: r.transaction_header.account_id(),
+                    initial_state_commitment: r.transaction_header.initial_state_commitment(),
+                    nullifiers,
+                    output_notes: r.output_notes,
+                }
             })
             .collect();
 
@@ -613,9 +623,14 @@ impl StateSync {
         new_nullifiers.retain(|update| update.block_num <= state_sync_update.block_num);
 
         for nullifier_update in new_nullifiers {
+            let external_consumer_account = state_sync_update
+                .transaction_updates
+                .external_nullifier_account(&nullifier_update.nullifier);
+
             state_sync_update.note_updates.apply_nullifiers_state_transitions(
                 &nullifier_update,
                 state_sync_update.transaction_updates.committed_transactions(),
+                external_consumer_account,
             )?;
 
             // Process nullifiers and track the updates of local tracked transactions that were
@@ -1024,6 +1039,7 @@ mod tests {
         let note_tags: BTreeSet<NoteTag> =
             input_notes.iter().filter_map(|n| n.metadata().map(NoteMetadata::tag)).collect();
 
+        let account_id = account.id();
         let sync_input = StateSyncInput {
             accounts: vec![account.into()],
             note_tags,
@@ -1046,6 +1062,18 @@ mod tests {
         assert_eq!(find_order(note1.id()), Some(0), "note1 should have tx_order 0");
         assert_eq!(find_order(note2.id()), Some(1), "note2 should have tx_order 1");
         assert_eq!(find_order(note3.id()), Some(2), "note3 should have tx_order 2");
+
+        // Since there are no uncommitted_transactions, these notes were consumed by a tracked
+        // account via external transactions. Verify that consumer_account is populated.
+        for note in &updated_notes {
+            let record = note.inner();
+            assert!(record.is_consumed(), "note should be in a consumed state");
+            assert_eq!(
+                record.consumer_account(),
+                Some(account_id),
+                "externally-consumed notes by a tracked account should have consumer_account set",
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/rust-client/src/sync/state_sync_update.rs
+++ b/crates/rust-client/src/sync/state_sync_update.rs
@@ -155,7 +155,10 @@ impl BlockUpdates {
 /// Contains transaction changes to apply to the store.
 #[derive(Default)]
 pub struct TransactionUpdateTracker {
+    /// Transactions that were committed in the block.
     transactions: BTreeMap<TransactionId, TransactionRecord>,
+    /// Nullifier-to-account mappings from external transactions by tracked accounts.
+    external_nullifier_accounts: BTreeMap<Nullifier, AccountId>,
 }
 
 impl TransactionUpdateTracker {
@@ -164,7 +167,10 @@ impl TransactionUpdateTracker {
         let transactions =
             transactions.into_iter().map(|tx| (tx.id, tx)).collect::<BTreeMap<_, _>>();
 
-        Self { transactions }
+        Self {
+            transactions,
+            external_nullifier_accounts: BTreeMap::new(),
+        }
     }
 
     /// Returns a reference to committed transactions.
@@ -195,6 +201,12 @@ impl TransactionUpdateTracker {
             .map(|tx| tx.id)
     }
 
+    /// Returns the account ID that consumed the given nullifier in an external transaction, if
+    /// available.
+    pub fn external_nullifier_account(&self, nullifier: &Nullifier) -> Option<AccountId> {
+        self.external_nullifier_accounts.get(nullifier).copied()
+    }
+
     /// Applies the necessary state transitions to the [`TransactionUpdateTracker`] when a
     /// transaction is included in a block.
     pub fn apply_transaction_inclusion(
@@ -216,6 +228,15 @@ impl TransactionUpdateTracker {
                 && tx.details.init_account_state == transaction_inclusion.initial_state_commitment
         }) {
             transaction.commit_transaction(transaction_inclusion.block_num, timestamp);
+            return;
+        }
+
+        // No local transaction matched. This is an external transaction by a tracked account.
+        // Record the nullifier→account mappings so we can attribute note consumption to tracked
+        // accounts during nullifier processing.
+        for nullifier in &transaction_inclusion.nullifiers {
+            self.external_nullifier_accounts
+                .insert(*nullifier, transaction_inclusion.account_id);
         }
     }
 

--- a/crates/sqlite-store/src/note/tests.rs
+++ b/crates/sqlite-store/src/note/tests.rs
@@ -33,8 +33,12 @@ use crate::tests::create_test_store;
 // HELPERS
 // ================================================================================================
 
-/// Helper to create a consumed-external input note (no consumer account).
-fn create_consumed_external_input_note(index: u32, block_height: u32) -> InputNoteRecord {
+/// Helper to create a consumed-external input note with an optional consumer account.
+fn create_consumed_external_input_note(
+    index: u32,
+    block_height: u32,
+    consumer_account: Option<AccountId>,
+) -> InputNoteRecord {
     let serial_number: Word = [Felt::new(u64::from(index) + 2000), ZERO, ZERO, ZERO].into();
     let assets = NoteAssets::new(vec![]).unwrap();
     let recipient = NoteRecipient::new(
@@ -46,6 +50,7 @@ fn create_consumed_external_input_note(index: u32, block_height: u32) -> InputNo
 
     let state = ConsumedExternalNoteState {
         nullifier_block_height: BlockNumber::from(block_height),
+        consumer_account,
         consumed_tx_order: None,
     };
 
@@ -288,6 +293,44 @@ async fn input_note_reader_filters_by_consumer_and_block_range() {
     }
 }
 
+#[tokio::test]
+async fn input_note_reader_finds_externally_consumed_notes() {
+    let store = create_test_store().await;
+    let consumer = AccountId::try_from(ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE).unwrap();
+
+    let mut tracked_note = create_consumed_external_input_note(0, 1, Some(consumer));
+    tracked_note.set_consumed_tx_order(Some(0));
+
+    let mut untracked_note = create_consumed_external_input_note(1, 2, None);
+    untracked_note.set_consumed_tx_order(Some(0));
+
+    store
+        .upsert_input_notes(&[tracked_note.clone(), untracked_note.clone()])
+        .await
+        .unwrap();
+
+    // Sanity: both notes are in the store as Consumed.
+    let in_store = store.get_input_notes(NoteFilter::Consumed).await.unwrap();
+    assert_eq!(in_store.len(), 2);
+
+    // The reader keyed by the consumer should find the tracked note but not the untracked one.
+    let store: Arc<dyn Store> = Arc::new(store);
+    let mut reader = InputNoteReader::new(store, consumer);
+
+    let mut collected = Vec::new();
+    while let Some(n) = reader.next().await.unwrap() {
+        collected.push(n);
+    }
+
+    assert_eq!(
+        collected.len(),
+        1,
+        "InputNoteReader should return externally-consumed notes when the consumer account is tracked",
+    );
+    assert_eq!(collected[0].id(), tracked_note.id());
+    assert_eq!(collected[0].consumer_account(), Some(consumer));
+}
+
 // ORDERING TESTS (INPUT NOTES)
 // ================================================================================================
 
@@ -296,9 +339,9 @@ async fn consumed_input_notes_ordered_by_block_height_then_tx_order() {
     let store = create_test_store().await;
 
     // Create consumed notes at different block heights with tx_order set.
-    let mut note_block3 = create_consumed_external_input_note(0, 3);
-    let mut note_block1 = create_consumed_external_input_note(1, 1);
-    let mut note_block2 = create_consumed_external_input_note(2, 2);
+    let mut note_block3 = create_consumed_external_input_note(0, 3, None);
+    let mut note_block1 = create_consumed_external_input_note(1, 1, None);
+    let mut note_block2 = create_consumed_external_input_note(2, 2, None);
     note_block3.set_consumed_tx_order(Some(0));
     note_block1.set_consumed_tx_order(Some(1));
     note_block2.set_consumed_tx_order(Some(0));
@@ -322,9 +365,9 @@ async fn consumed_input_notes_same_block_ordered_by_tx_order() {
     let store = create_test_store().await;
 
     // All notes consumed at the same block height, different tx_order.
-    let mut note_tx2 = create_consumed_external_input_note(10, 5);
-    let mut note_tx0 = create_consumed_external_input_note(11, 5);
-    let mut note_tx1 = create_consumed_external_input_note(12, 5);
+    let mut note_tx2 = create_consumed_external_input_note(10, 5, None);
+    let mut note_tx0 = create_consumed_external_input_note(11, 5, None);
+    let mut note_tx1 = create_consumed_external_input_note(12, 5, None);
     note_tx2.set_consumed_tx_order(Some(2));
     note_tx0.set_consumed_tx_order(Some(0));
     note_tx1.set_consumed_tx_order(Some(1));
@@ -346,8 +389,8 @@ async fn consumed_input_notes_null_tx_order_sort_last_within_block() {
     let store = create_test_store().await;
 
     // Two notes at the same block: one with tx_order, one without (external consumption).
-    let mut note_with_order = create_consumed_external_input_note(20, 5);
-    let note_without_order = create_consumed_external_input_note(21, 5);
+    let mut note_with_order = create_consumed_external_input_note(20, 5, None);
+    let note_without_order = create_consumed_external_input_note(21, 5, None);
     note_with_order.set_consumed_tx_order(Some(0));
 
     store

--- a/crates/testing/miden-client-tests/src/tests.rs
+++ b/crates/testing/miden-client-tests/src/tests.rs
@@ -95,6 +95,7 @@ use miden_protocol::note::{
     NoteType,
 };
 use miden_protocol::testing::account_id::{
+    ACCOUNT_ID_PRIVATE_FUNGIBLE_FAUCET,
     ACCOUNT_ID_PRIVATE_SENDER,
     ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1,
     ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_2,
@@ -1181,6 +1182,106 @@ async fn p2id_transfer() {
         notes[0].clone().try_into().unwrap(),
     )
     .await;
+}
+
+#[tokio::test]
+async fn input_note_reader_finds_externally_consumed_notes() {
+    let sender_id: AccountId = ACCOUNT_ID_PRIVATE_SENDER.try_into().unwrap();
+    let faucet_id: AccountId = ACCOUNT_ID_PRIVATE_FUNGIBLE_FAUCET.try_into().unwrap();
+
+    // Build a MockChain with a sender, consumer, and a P2ID note from sender to consumer.
+    let mut builder = MockChainBuilder::new();
+    let consumer = builder.add_existing_mock_account(miden_testing::Auth::IncrNonce).unwrap();
+    let consumer_id = consumer.id();
+
+    let asset = Asset::Fungible(FungibleAsset::new(faucet_id, 100u64).unwrap());
+    let p2id_note = builder
+        .add_p2id_note(sender_id, consumer_id, &[asset], NoteType::Public)
+        .unwrap();
+    let p2id_note_id = p2id_note.id();
+
+    let mut chain = builder.build().unwrap();
+    // Block 1: makes the note consumable.
+    chain.prove_next_block().unwrap();
+
+    // Consumer consumes the note directly on the chain (bypassing any client).
+    let tx = Box::pin(
+        chain
+            .build_tx_context(
+                miden_testing::TxContextInput::Account(consumer.clone()),
+                &[],
+                core::slice::from_ref(&p2id_note),
+            )
+            .unwrap()
+            .build()
+            .unwrap()
+            .execute(),
+    )
+    .await
+    .unwrap();
+    chain.add_pending_executed_transaction(&tx).unwrap();
+    // Block 2: includes the consume transaction.
+    chain.prove_next_block().unwrap();
+
+    // Build a client backed by this chain.
+    let rng = RandomCoin::new(rand::random::<[u64; 4]>().map(Felt::new).into());
+    let keystore_path = std::env::temp_dir();
+    let keystore = FilesystemKeyStore::new(keystore_path).unwrap();
+    let mock_rpc = MockRpcApi::new(chain);
+
+    let mut client = ClientBuilder::new()
+        .rpc(Arc::new(mock_rpc))
+        .rng(Box::new(rng))
+        .sqlite_store(create_test_store_path())
+        .authenticator(Arc::new(keystore))
+        .in_debug_mode(DebugMode::Enabled)
+        .tx_discard_delta(None)
+        .build()
+        .await
+        .unwrap();
+    client.ensure_genesis_in_place().await.unwrap();
+
+    // Register the consumer account so sync_transactions returns its transactions.
+    client.add_account(&consumer, false).await.unwrap();
+
+    // Import the P2ID note as an input note so the client tracks it.
+    let note_file = NoteFile::NoteDetails {
+        details: p2id_note.into(),
+        after_block_num: BlockNumber::from(0u32),
+        tag: None,
+    };
+    client.import_notes(&[note_file]).await.unwrap();
+
+    // Sync: the client should discover the note was consumed externally by the tracked account.
+    client.sync_state().await.unwrap();
+
+    // The note should be in ConsumedExternal state with consumer_account set.
+    let input_note = client.get_input_note(p2id_note_id).await.unwrap().unwrap();
+    assert!(
+        matches!(input_note.state(), InputNoteState::ConsumedExternal(..)),
+        "Note should be in ConsumedExternal state, got: {}",
+        input_note.state(),
+    );
+    assert_eq!(
+        input_note.consumer_account(),
+        Some(consumer_id),
+        "consumer_account should be set to the tracked account that consumed the note",
+    );
+
+    // InputNoteReader should surface the externally-consumed note.
+    let mut reader = client.input_note_reader(consumer_id);
+    let mut collected = Vec::new();
+    while let Some(n) = reader.next().await.unwrap() {
+        collected.push(n);
+    }
+
+    assert_eq!(
+        collected.len(),
+        1,
+        "InputNoteReader should return the externally-consumed note for the tracked consumer",
+    );
+    assert_eq!(collected[0].id(), p2id_note_id);
+    assert_eq!(collected[0].consumer_account(), Some(consumer_id));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes https://github.com/0xMiden/miden-client/issues/1884

Track the consuming account on externally-consumed notes during sync, so `InputNoteReader` can find notes consumed by tracked accounts whose transactions were submitted by other client instances.

During sync, `TransactionUpdateTracker` now builds a `nullifier -> account_id` mapping from transaction inclusions that don't match any local transaction. Since each `TransactionInclusion` carries both the consuming account id and the nullifiers of its input notes, we can associate note consumption to tracked accounts even when the transaction was submitted by another client instance.