### PR TITLE
fix: flaky counter component web test

### DIFF
--- a/crates/web-client/test/new_transactions.test.ts
+++ b/crates/web-client/test/new_transactions.test.ts
@@ -1286,9 +1286,7 @@ export const counterAccountComponent = async (
     for (let attempt = 0; attempt < 10; attempt++) {
       await window.helpers.waitForBlocks(1);
 
-      account = await client.getAccount(
-        accountBuilderResult.account.id()
-      );
+      account = await client.getAccount(accountBuilderResult.account.id());
       let counter = account?.storage().getItem(COUNTER_SLOT_NAME)?.toHex();
       finalCounter = counter?.replace(/^0x/, "").replace(/^0+|0+$/g, "");
 

--- a/crates/web-client/test/new_transactions.test.ts
+++ b/crates/web-client/test/new_transactions.test.ts
@@ -1277,12 +1277,23 @@ export const counterAccountComponent = async (
       transactionUpdate.executedTransaction().id().toHex()
     );
 
-    // Wait for network account to update
-    await window.helpers.waitForBlocks(2);
+    // Wait for the node to consume the network note in subsequent blocks.
+    // Use a retry loop (up to 10 blocks) instead of a fixed wait, since the
+    // node may not have consumed the note within a fixed number of blocks
+    // (especially under CI load with multiple test shards).
+    let finalCounter: string | undefined;
+    let account;
+    for (let attempt = 0; attempt < 10; attempt++) {
+      await window.helpers.waitForBlocks(1);
 
-    let account = await client.getAccount(accountBuilderResult.account.id());
-    let counter = account?.storage().getItem(COUNTER_SLOT_NAME)?.toHex();
-    let finalCounter = counter?.replace(/^0x/, "").replace(/^0+|0+$/g, "");
+      account = await client.getAccount(
+        accountBuilderResult.account.id()
+      );
+      let counter = account?.storage().getItem(COUNTER_SLOT_NAME)?.toHex();
+      finalCounter = counter?.replace(/^0x/, "").replace(/^0+|0+$/g, "");
+
+      if (finalCounter === "2") break;
+    }
 
     let code = account?.code();
     let hasCounterComponent = code


### PR DESCRIPTION
Replace the fixed `waitForBlocks(2)` with a retry loop (up to 10 blocks) in the counter account component test, matching the pattern used by the equivalent Rust integration test (`test_counter_contract_ntx`). Under CI load the node may not consume the network note within 2 blocks.


Note: this is a dirty solution just to see if the error seen in [this workflow](https://github.com/0xMiden/miden-client/actions/runs/24105145924/job/70327340743) happens again.