### PR TITLE
chore: move to next

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2954,7 +2954,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-bench"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2971,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-cli"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-integration-tests"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3017,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-sqlite-store"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-unit-tests"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "miden-client",
  "miden-client-sqlite-store",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-web"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "console_error_panic_hook",
@@ -3209,7 +3209,7 @@ dependencies = [
 
 [[package]]
 name = "miden-idxdb-store"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -3933,7 +3933,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "node-builder"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "miden-node-block-producer",
@@ -6001,7 +6001,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "testing-remote-prover"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3225,9 +3225,8 @@ dependencies = [
 
 [[package]]
 name = "miden-large-smt-backend-rocksdb"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458b491aa032924cddd1a7e7e31f85b31546223c14dd513fe4e208d0be617342"
+version = "0.15.0"
+source = "git+https://github.com/0xMiden/node.git?branch=next#32f76e50a9aa5da2a4d3c02d141bdaa2f88d7414"
 dependencies = [
  "miden-crypto",
  "miden-node-rocksdb-cxx-linkage-fix",
@@ -3288,9 +3287,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-block-producer"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8b4118289a83e8591f035542e7334b0528259aa510c19ba17417f72600db86"
+version = "0.15.0"
+source = "git+https://github.com/0xMiden/node.git?branch=next#32f76e50a9aa5da2a4d3c02d141bdaa2f88d7414"
 dependencies = [
  "anyhow",
  "futures",
@@ -3315,9 +3313,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-db"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d64e879dfe91043a0b6bb494e3307f0d1008b312c4c4543c311b11ff0d46621"
+version = "0.15.0"
+source = "git+https://github.com/0xMiden/node.git?branch=next#32f76e50a9aa5da2a4d3c02d141bdaa2f88d7414"
 dependencies = [
  "deadpool",
  "deadpool-diesel",
@@ -3330,9 +3327,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-grpc-error-macro"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dbaff4590be922da19e030a9f09c6726b249e848feff9de39437d478093ce8c"
+version = "0.15.0"
+source = "git+https://github.com/0xMiden/node.git?branch=next#32f76e50a9aa5da2a4d3c02d141bdaa2f88d7414"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -3340,9 +3336,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-ntx-builder"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3aaab1ecb7c215c822394d2258bdeb190380d2e3480463c4fe9adafd849be0"
+version = "0.15.0"
+source = "git+https://github.com/0xMiden/node.git?branch=next#32f76e50a9aa5da2a4d3c02d141bdaa2f88d7414"
 dependencies = [
  "anyhow",
  "build-rs",
@@ -3371,9 +3366,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3816bbed7336cb6a6163f84dad338bc90c8b6837fe1fe8cf24a852507c15fc7"
+version = "0.15.0"
+source = "git+https://github.com/0xMiden/node.git?branch=next#32f76e50a9aa5da2a4d3c02d141bdaa2f88d7414"
 dependencies = [
  "anyhow",
  "build-rs",
@@ -3396,9 +3390,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c78309c58cbffd5fd92c944d6f7f3ed6d59340587c74d4eab4e6edf9e31e8d3"
+version = "0.15.0"
+source = "git+https://github.com/0xMiden/node.git?branch=next#32f76e50a9aa5da2a4d3c02d141bdaa2f88d7414"
 dependencies = [
  "build-rs",
  "fs-err",
@@ -3409,15 +3402,13 @@ dependencies = [
 
 [[package]]
 name = "miden-node-rocksdb-cxx-linkage-fix"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2945a5d1e6439296df7b5bfd4aac2467bf76db5c97ebccb34f4e92e75bed75da"
+version = "0.15.0"
+source = "git+https://github.com/0xMiden/node.git?branch=next#32f76e50a9aa5da2a4d3c02d141bdaa2f88d7414"
 
 [[package]]
 name = "miden-node-rpc"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a3efb5e23190b2afe8d04132587f5a7fe4669ab0c798c4d3754f94f726c836"
+version = "0.15.0"
+source = "git+https://github.com/0xMiden/node.git?branch=next#32f76e50a9aa5da2a4d3c02d141bdaa2f88d7414"
 dependencies = [
  "anyhow",
  "futures",
@@ -3444,9 +3435,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-store"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f157e2a0d2426771f625197108051ad6c0edc269332a9a4f6d799057b554d0b"
+version = "0.15.0"
+source = "git+https://github.com/0xMiden/node.git?branch=next#32f76e50a9aa5da2a4d3c02d141bdaa2f88d7414"
 dependencies = [
  "anyhow",
  "build-rs",
@@ -3486,9 +3476,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-utils"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09c2eb76afb33e3448095b293ecbac1528934f6cc5d28e1551ed0a34fa1d28c"
+version = "0.15.0"
+source = "git+https://github.com/0xMiden/node.git?branch=next#32f76e50a9aa5da2a4d3c02d141bdaa2f88d7414"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3521,9 +3510,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-validator"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c8975bbe5f559e6dc9e2a8f9c5fcaac301288df4d1ba69c1cedf7fcbb37402"
+version = "0.15.0"
+source = "git+https://github.com/0xMiden/node.git?branch=next#32f76e50a9aa5da2a4d3c02d141bdaa2f88d7414"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -3669,9 +3657,8 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover-client"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46b16f3b59286f3cecb473e3715501f64ad98f71327be82b6b990bfea5708722"
+version = "0.15.0"
+source = "git+https://github.com/0xMiden/node.git?branch=next#32f76e50a9aa5da2a4d3c02d141bdaa2f88d7414"
 dependencies = [
  "build-rs",
  "fs-err",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,16 +44,18 @@ miden-testing   = { default-features = false, version = "0.14" }
 miden-tx        = { default-features = false, version = "0.14" }
 
 # Miden node dependencies
-miden-node-block-producer        = { version = "0.14" }
-miden-node-ntx-builder           = { version = "0.14" }
-miden-node-proto                 = { version = "0.14" }
-miden-node-proto-build           = { default-features = false, version = "0.14" }
-miden-node-rpc                   = { version = "0.14" }
-miden-node-store                 = { version = "0.14" }
-miden-node-utils                 = { version = "0.14" }
-miden-node-validator             = { version = "0.14" }
+miden-node-block-producer = { branch = "next", git = "https://github.com/0xMiden/node.git" }
+miden-node-ntx-builder = { branch = "next", git = "https://github.com/0xMiden/node.git" }
+miden-node-proto = { branch = "next", git = "https://github.com/0xMiden/node.git" }
+miden-node-proto-build = { branch = "next", default-features = false, git = "https://github.com/0xMiden/node.git" }
+miden-node-rpc = { branch = "next", git = "https://github.com/0xMiden/node.git" }
+miden-node-store = { branch = "next", git = "https://github.com/0xMiden/node.git" }
+miden-node-utils = { branch = "next", git = "https://github.com/0xMiden/node.git" }
+miden-node-validator = { branch = "next", git = "https://github.com/0xMiden/node.git" }
 miden-note-transport-proto-build = { default-features = false, version = "0.2" }
-miden-remote-prover-client       = { default-features = false, features = ["tx-prover"], version = "0.14" }
+miden-remote-prover-client = { branch = "next", default-features = false, features = [
+  "tx-prover",
+], git = "https://github.com/0xMiden/node.git" }
 
 # External dependencies
 anyhow      = { default-features = false, version = "1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ edition      = "2024"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/miden-client"
 rust-version = "1.93"
-version      = "0.14.0"
+version      = "0.15.0"
 
 [profile.dev]
 codegen-units = 16
@@ -33,9 +33,9 @@ opt-level = 1
 
 [workspace.dependencies]
 # Workspace crates
-idxdb-store               = { default-features = false, package = "miden-idxdb-store", path = "crates/idxdb-store", version = "0.14.0" }
-miden-client              = { default-features = false, path = "crates/rust-client", version = "0.14.0" }
-miden-client-sqlite-store = { default-features = false, path = "crates/sqlite-store", version = "0.14.0" }
+idxdb-store               = { default-features = false, package = "miden-idxdb-store", path = "crates/idxdb-store", version = "0.15.0" }
+miden-client              = { default-features = false, path = "crates/rust-client", version = "0.15.0" }
+miden-client-sqlite-store = { default-features = false, path = "crates/sqlite-store", version = "0.15.0" }
 
 # Miden protocol dependencies
 miden-protocol  = { default-features = false, version = "0.14" }

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -588,15 +588,18 @@ impl NodeRpcClient for GrpcClient {
         block_from: BlockNumber,
         block_to: Option<BlockNumber>,
     ) -> Result<ChainMmrInfo, RpcError> {
-        let block_range = Some(BlockRange {
-            block_from: block_from.as_u32(),
-            block_to: block_to.map(|b| b.as_u32()),
-        });
+        let block_from = block_from.as_u32();
 
-        let request = proto::rpc::SyncChainMmrRequest {
-            block_range,
-            finality: proto::rpc::Finality::Committed as i32,
+        let upper_bound = match block_to {
+            Some(block_to) => {
+                Some(proto::rpc::sync_chain_mmr_request::UpperBound::BlockNum(block_to.as_u32()))
+            },
+            None => Some(proto::rpc::sync_chain_mmr_request::UpperBound::ChainTip(
+                proto::rpc::ChainTip::Committed.into(),
+            )),
         };
+
+        let request = proto::rpc::SyncChainMmrRequest { block_from, upper_bound };
 
         let response = self
             .call_with_retry(RpcEndpoint::SyncChainMmr, |mut rpc_api| {
@@ -883,7 +886,10 @@ impl NodeRpcClient for GrpcClient {
     }
 
     async fn get_block_by_number(&self, block_num: BlockNumber) -> Result<ProvenBlock, RpcError> {
-        let request = proto::blockchain::BlockNumber { block_num: block_num.as_u32() };
+        let request = proto::blockchain::BlockRequest {
+            block_num: block_num.as_u32(),
+            include_proof: Some(false),
+        };
 
         let response = self
             .call_with_retry(RpcEndpoint::GetBlockByNumber, |mut rpc_api| {


### PR DESCRIPTION
Bumps the node version from 0.14 to the next branch of the repository.