### PR TITLE
feat: address follow-up items from get_account_proof (#1960)

### DIFF
--- a/crates/rust-client/src/rpc/domain/account.rs
+++ b/crates/rust-client/src/rpc/domain/account.rs
@@ -578,6 +578,11 @@ impl AccountProof {
         self.state_headers.as_ref().map(|d| &d.storage_details)
     }
 
+    /// Returns the vault details, if available (public accounts only).
+    pub fn vault_details(&self) -> Option<&AccountVaultDetails> {
+        self.state_headers.as_ref().map(|d| &d.vault_details)
+    }
+
     /// Returns the storage map details for a specific slot, if available.
     pub fn find_map_details(
         &self,

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -440,10 +440,11 @@ impl GrpcClient {
     async fn fetch_full_vault(
         &self,
         account_id: AccountId,
-        block_to: Option<BlockNumber>,
+        block_to: BlockNumber,
     ) -> Result<Vec<Asset>, RpcError> {
-        let vault_info =
-            self.sync_account_vault(BlockNumber::from(0), block_to, account_id).await?;
+        let vault_info = self
+            .sync_account_vault(BlockNumber::from(0), Some(block_to), account_id)
+            .await?;
         let mut updates = vault_info.updates;
         updates.sort_by_key(|u| u.block_num);
         Ok(updates
@@ -638,7 +639,7 @@ impl NodeRpcClient for GrpcClient {
             let account_id = details.header.id();
             let nonce = details.header.nonce();
             let assets = if details.vault_details.too_many_assets {
-                self.fetch_full_vault(account_id, Some(block_number)).await?
+                self.fetch_full_vault(account_id, block_number).await?
             } else {
                 details.vault_details.assets
             };
@@ -742,8 +743,7 @@ impl NodeRpcClient for GrpcClient {
                 .into_domain(&known_codes_by_commitment, &storage_requirements)?;
 
             if details.vault_details.too_many_assets {
-                details.vault_details.assets =
-                    self.fetch_full_vault(account_id, Some(block_num)).await?;
+                details.vault_details.assets = self.fetch_full_vault(account_id, block_num).await?;
             }
 
             Some(details)

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -911,13 +911,19 @@ pub(crate) async fn fetch_public_account_inputs(
     let known_account_code: Option<AccountCode> =
         store.get_foreign_account_code(vec![account_id]).await?.into_values().next();
 
+    // Get vault assets only if known commitment doesn't match the current one.
+    let known_vault_commitment = store
+        .get_account_header(account_id)
+        .await?
+        .map_or(EMPTY_WORD, |(header, _)| header.vault_root());
+
     let (_, account_proof) = rpc_api
         .get_account_proof(
             account_id,
             storage_requirements.clone(),
             account_state_at,
             known_account_code,
-            Some(EMPTY_WORD),
+            Some(known_vault_commitment),
         )
         .await?;
 

--- a/crates/web-client/src/models/account_proof.rs
+++ b/crates/web-client/src/models/account_proof.rs
@@ -11,6 +11,7 @@ use wasm_bindgen::prelude::*;
 use super::account_code::AccountCode;
 use super::account_header::AccountHeader;
 use super::account_id::AccountId;
+use super::fungible_asset::FungibleAsset;
 use super::word::Word;
 use crate::js_error_with_context;
 
@@ -134,6 +135,28 @@ impl AccountProof {
             .map_err(|err| js_error_with_context(err, "invalid slot name"))?;
 
         Ok(self.inner.find_map_details(&slot_name).map(|d| d.too_many_entries))
+    }
+
+    /// Returns the fungible assets in the account's vault, if vault details were included
+    /// in the proof response.
+    ///
+    /// Returns `undefined` if the account is private or vault data was not requested.
+    #[wasm_bindgen(js_name = "vaultFungibleAssets")]
+    pub fn vault_fungible_assets(&self) -> Option<Vec<FungibleAsset>> {
+        let (_, details) = self.inner.clone().into_parts();
+        details.map(|d| {
+            d.vault_details
+                .assets
+                .into_iter()
+                .filter_map(|asset| {
+                    if asset.is_fungible() {
+                        Some(asset.unwrap_fungible().into())
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        })
     }
 
     /// Returns the names of all storage slots that have map details available.

--- a/crates/web-client/src/models/account_proof.rs
+++ b/crates/web-client/src/models/account_proof.rs
@@ -3,6 +3,7 @@ use alloc::vec::Vec;
 
 use miden_client::Word as NativeWord;
 use miden_client::account::StorageSlotName;
+use miden_client::asset::Asset as NativeAsset;
 use miden_client::block::BlockNumber;
 use miden_client::rpc::domain::account::{AccountProof as NativeAccountProof, StorageMapEntries};
 use miden_protocol::account::AccountStorageHeader;
@@ -143,17 +144,12 @@ impl AccountProof {
     /// Returns `undefined` if the account is private or vault data was not requested.
     #[wasm_bindgen(js_name = "vaultFungibleAssets")]
     pub fn vault_fungible_assets(&self) -> Option<Vec<FungibleAsset>> {
-        let (_, details) = self.inner.clone().into_parts();
-        details.map(|d| {
-            d.vault_details
-                .assets
-                .into_iter()
-                .filter_map(|asset| {
-                    if asset.is_fungible() {
-                        Some(asset.unwrap_fungible().into())
-                    } else {
-                        None
-                    }
+        self.inner.vault_details().map(|d| {
+            d.assets
+                .iter()
+                .filter_map(|asset| match asset {
+                    NativeAsset::Fungible(f) => Some((*f).into()),
+                    NativeAsset::NonFungible(_) => None,
                 })
                 .collect()
         })

--- a/crates/web-client/test/account.test.ts
+++ b/crates/web-client/test/account.test.ts
@@ -525,8 +525,10 @@ test.describe("getAccountProof vault commitment", () => {
           emptyWord
         );
         const vaultCommitment = proof1.accountHeader()!.vaultCommitment();
+        const vaultCommitmentHex = vaultCommitment.toHex();
 
         // Query 2: actual vault commitment — matches node state, should skip vault data
+        // Note: passing vaultCommitment consumes the Word (wasm ownership transfer)
         const proof2 = await rpcClient.getAccountProof(
           accountId,
           undefined,
@@ -541,7 +543,7 @@ test.describe("getAccountProof vault commitment", () => {
           query1: {
             blockNum: proof1.blockNum(),
             hasAccountHeader: !!proof1.accountHeader(),
-            vaultCommitment: vaultCommitment.toHex(),
+            vaultCommitment: vaultCommitmentHex,
             numVaultAssets: proof1.vaultFungibleAssets()?.length ?? null,
           },
           query2: {

--- a/crates/web-client/test/account.test.ts
+++ b/crates/web-client/test/account.test.ts
@@ -525,7 +525,6 @@ test.describe("getAccountProof vault commitment", () => {
           emptyWord
         );
         const vaultCommitment = proof1.accountHeader()!.vaultCommitment();
-        const vaultCommitmentHex = vaultCommitment.toHex();
 
         // Query 2: actual vault commitment — matches node state, should skip vault data
         // Note: passing vaultCommitment consumes the Word (wasm ownership transfer)

--- a/crates/web-client/test/account.test.ts
+++ b/crates/web-client/test/account.test.ts
@@ -543,7 +543,8 @@ test.describe("getAccountProof vault commitment", () => {
         return {
           numVaultAssetsQuery1: vaultAssets.length,
           vaultAssetFaucetId: vaultAssets[0]?.faucetId().toString() ?? null,
-          vaultAssetAmount: vaultAssets[0] != null ? Number(vaultAssets[0].amount()) : null,
+          vaultAssetAmount:
+            vaultAssets[0] != null ? Number(vaultAssets[0].amount()) : null,
           numVaultAssetsQuery2: proof2.vaultFungibleAssets()?.length ?? null,
           numVaultAssetsQuery3: proof3.vaultFungibleAssets()?.length ?? null,
         };

--- a/crates/web-client/test/account.test.ts
+++ b/crates/web-client/test/account.test.ts
@@ -540,41 +540,19 @@ test.describe("getAccountProof vault commitment", () => {
         const proof3 = await rpcClient.getAccountProof(accountId);
 
         return {
-          query1: {
-            blockNum: proof1.blockNum(),
-            hasAccountHeader: !!proof1.accountHeader(),
-            vaultCommitment: vaultCommitmentHex,
-            numVaultAssets: proof1.vaultFungibleAssets()?.length ?? null,
-          },
-          query2: {
-            blockNum: proof2.blockNum(),
-            hasAccountHeader: !!proof2.accountHeader(),
-            numVaultAssets: proof2.vaultFungibleAssets()?.length ?? null,
-          },
-          query3: {
-            blockNum: proof3.blockNum(),
-            hasAccountHeader: !!proof3.accountHeader(),
-            numVaultAssets: proof3.vaultFungibleAssets()?.length ?? null,
-          },
+          numVaultAssetsQuery1: proof1.vaultFungibleAssets()?.length ?? null,
+          numVaultAssetsQuery2: proof2.vaultFungibleAssets()?.length ?? null,
+          numVaultAssetsQuery3: proof3.vaultFungibleAssets()?.length ?? null,
         };
       },
       { walletId: walletResult.id }
     );
 
-    // Query 1: EMPTY_WORD — always fetches vault data
-    expect(proofResults.query1.blockNum).toBeGreaterThan(0);
-    expect(proofResults.query1.hasAccountHeader).toBe(true);
-    expect(proofResults.query1.vaultCommitment).toMatch(/^0x[0-9a-fA-F]+$/);
-    expect(proofResults.query1.numVaultAssets).toBe(1);
-
-    // Query 2: actual vault commitment — matches, node skips vault data
-    expect(proofResults.query2.blockNum).toBeGreaterThan(0);
-    expect(proofResults.query2.hasAccountHeader).toBe(true);
-    expect(proofResults.query2.numVaultAssets).toBe(0);
-
-    // Query 3: undefined — vault data not requested
-    expect(proofResults.query3.blockNum).toBeGreaterThan(0);
-    expect(proofResults.query3.hasAccountHeader).toBe(true);
-    expect(proofResults.query3.numVaultAssets).toBe(0);
+    // EMPTY_WORD — always fetches vault data
+    expect(proofResults.numVaultAssetsQuery1).toBe(1);
+    // Actual vault commitment — matches, node skips vault data
+    expect(proofResults.numVaultAssetsQuery2).toBe(0);
+    // undefined — vault data not requested
+    expect(proofResults.numVaultAssetsQuery3).toBe(0);
   });
 });

--- a/crates/web-client/test/account.test.ts
+++ b/crates/web-client/test/account.test.ts
@@ -1,5 +1,11 @@
 import { Page, expect } from "@playwright/test";
 import test, { isLocalhost } from "./playwright.global.setup";
+import {
+  StorageMode,
+  createNewWallet,
+  createNewFaucet,
+  fundAccountFromFaucet,
+} from "./webClientTestUtils";
 
 // GET_ACCOUNT TESTS
 // =======================================================================================================
@@ -484,5 +490,89 @@ test.describe("getAccountByKeyCommitment tests", () => {
 
     expect(result.foundAccountId).toEqual(result.faucetId);
     expect(result.foundIsFaucet).toBe(true);
+  });
+});
+
+// GET_ACCOUNT_PROOF VAULT COMMITMENT TESTS
+// =======================================================================================================
+
+test.describe("getAccountProof vault commitment", () => {
+  test("returns vault details based on known_vault_commitment parameter", async ({
+    page,
+  }) => {
+    // Create public wallet and faucet, then fund the wallet so it has assets on-chain
+    const walletResult = await createNewWallet(page, {
+      storageMode: StorageMode.PUBLIC,
+      mutable: false,
+      authSchemeId: 2,
+    });
+    const faucetResult = await createNewFaucet(page, StorageMode.PUBLIC);
+    await fundAccountFromFaucet(page, walletResult.id, faucetResult.id);
+
+    const proofResults = await page.evaluate(
+      async ({ walletId }) => {
+        const endpoint = new window.Endpoint(window.rpcUrl);
+        const rpcClient = new window.RpcClient(endpoint);
+        const accountId = window.AccountId.fromHex(walletId);
+
+        const emptyWord = new window.Word(new BigUint64Array([0n, 0n, 0n, 0n]));
+
+        // Query 1: EMPTY_WORD — always fetches vault data (commitment never matches)
+        const proof1 = await rpcClient.getAccountProof(
+          accountId,
+          undefined,
+          undefined,
+          emptyWord
+        );
+        const vaultCommitment = proof1.accountHeader()!.vaultCommitment();
+
+        // Query 2: actual vault commitment — matches node state, should skip vault data
+        const proof2 = await rpcClient.getAccountProof(
+          accountId,
+          undefined,
+          undefined,
+          vaultCommitment
+        );
+
+        // Query 3: undefined — vault data not requested
+        const proof3 = await rpcClient.getAccountProof(accountId);
+
+        return {
+          query1: {
+            blockNum: proof1.blockNum(),
+            hasAccountHeader: !!proof1.accountHeader(),
+            vaultCommitment: vaultCommitment.toHex(),
+            numVaultAssets: proof1.vaultFungibleAssets()?.length ?? null,
+          },
+          query2: {
+            blockNum: proof2.blockNum(),
+            hasAccountHeader: !!proof2.accountHeader(),
+            numVaultAssets: proof2.vaultFungibleAssets()?.length ?? null,
+          },
+          query3: {
+            blockNum: proof3.blockNum(),
+            hasAccountHeader: !!proof3.accountHeader(),
+            numVaultAssets: proof3.vaultFungibleAssets()?.length ?? null,
+          },
+        };
+      },
+      { walletId: walletResult.id }
+    );
+
+    // Query 1: EMPTY_WORD — always fetches vault data
+    expect(proofResults.query1.blockNum).toBeGreaterThan(0);
+    expect(proofResults.query1.hasAccountHeader).toBe(true);
+    expect(proofResults.query1.vaultCommitment).toMatch(/^0x[0-9a-fA-F]+$/);
+    expect(proofResults.query1.numVaultAssets).toBe(1);
+
+    // Query 2: actual vault commitment — matches, node skips vault data
+    expect(proofResults.query2.blockNum).toBeGreaterThan(0);
+    expect(proofResults.query2.hasAccountHeader).toBe(true);
+    expect(proofResults.query2.numVaultAssets).toBe(0);
+
+    // Query 3: undefined — vault data not requested
+    expect(proofResults.query3.blockNum).toBeGreaterThan(0);
+    expect(proofResults.query3.hasAccountHeader).toBe(true);
+    expect(proofResults.query3.numVaultAssets).toBe(0);
   });
 });

--- a/crates/web-client/test/account.test.ts
+++ b/crates/web-client/test/account.test.ts
@@ -510,7 +510,7 @@ test.describe("getAccountProof vault commitment", () => {
     await fundAccountFromFaucet(page, walletResult.id, faucetResult.id);
 
     const proofResults = await page.evaluate(
-      async ({ walletId }) => {
+      async ({ walletId, faucetId }) => {
         const endpoint = new window.Endpoint(window.rpcUrl);
         const rpcClient = new window.RpcClient(endpoint);
         const accountId = window.AccountId.fromHex(walletId);
@@ -526,6 +526,8 @@ test.describe("getAccountProof vault commitment", () => {
         );
         const vaultCommitment = proof1.accountHeader()!.vaultCommitment();
 
+        const vaultAssets = proof1.vaultFungibleAssets() ?? [];
+
         // Query 2: actual vault commitment — matches node state, should skip vault data
         // Note: passing vaultCommitment consumes the Word (wasm ownership transfer)
         const proof2 = await rpcClient.getAccountProof(
@@ -539,16 +541,20 @@ test.describe("getAccountProof vault commitment", () => {
         const proof3 = await rpcClient.getAccountProof(accountId);
 
         return {
-          numVaultAssetsQuery1: proof1.vaultFungibleAssets()?.length ?? null,
+          numVaultAssetsQuery1: vaultAssets.length,
+          vaultAssetFaucetId: vaultAssets[0]?.faucetId().toString() ?? null,
+          vaultAssetAmount: vaultAssets[0] != null ? Number(vaultAssets[0].amount()) : null,
           numVaultAssetsQuery2: proof2.vaultFungibleAssets()?.length ?? null,
           numVaultAssetsQuery3: proof3.vaultFungibleAssets()?.length ?? null,
         };
       },
-      { walletId: walletResult.id }
+      { walletId: walletResult.id, faucetId: faucetResult.id }
     );
 
-    // EMPTY_WORD — always fetches vault data
+    // EMPTY_WORD — always fetches vault data with correct content
     expect(proofResults.numVaultAssetsQuery1).toBe(1);
+    expect(proofResults.vaultAssetFaucetId).toBe(faucetResult.id);
+    expect(proofResults.vaultAssetAmount).toBe(1000);
     // Actual vault commitment — matches, node skips vault data
     expect(proofResults.numVaultAssetsQuery2).toBe(0);
     // undefined — vault data not requested


### PR DESCRIPTION
Follow-up improvements from #1960 review comments, tracked in #1974.

- Expose `vaultFungibleAssets()` on `AccountProof` wasm wrapper + Playwright test for the three `known_vault_commitment` scenarios.
- Reuse stored vault commitment for imported foreign accounts instead of always passing `EMPTY_WORD`.
- Enforce `BlockNumber` instead of `Option<BlockNumber>` in `fetch_full_vault`.


Closes #1974