### PR TITLE
feat: show tracked faucet symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.15.0 (TBD)
+
+### Enhancements
+
+* Fixed the faucet token symbol display when showing account details ([#1985](https://github.com/0xMiden/miden-client/pull/1985)).
+
 ## 0.14.0 (2026-04-07)
 
 ### Enhancements

--- a/bin/miden-cli/src/commands/account.rs
+++ b/bin/miden-cli/src/commands/account.rs
@@ -12,6 +12,7 @@ use miden_client::address::{Address, AddressInterface, RoutingParameters};
 use miden_client::asset::Asset;
 use miden_client::rpc::{GrpcClient, NodeRpcClient};
 use miden_client::transaction::{AccountComponentInterface, AccountInterface};
+use miden_client::utils::base_units_to_tokens;
 use miden_client::{Client, PrettyPrint, ZERO};
 
 use crate::config::CliConfig;
@@ -166,8 +167,11 @@ pub async fn show_account<AUTH>(
         for asset in assets {
             let (asset_type, faucet, amount) = match asset {
                 Asset::Fungible(fungible_asset) => {
-                    let faucet = get_token_symbol(&client, fungible_asset.faucet_id()).await?;
-                    let amount = fungible_asset.amount().to_string();
+                    let metadata =
+                        get_token_metadata(&client, fungible_asset.faucet_id()).await?;
+                    let faucet = metadata.symbol().to_string();
+                    let amount =
+                        base_units_to_tokens(fungible_asset.amount(), metadata.decimals());
                     ("Fungible Asset", faucet, amount)
                 },
                 Asset::NonFungible(non_fungible_asset) => {
@@ -275,11 +279,11 @@ async fn print_summary_table<AUTH>(
     Ok(())
 }
 
-/// Reads the token symbol from a fungible faucet account's storage metadata slot.
-async fn get_token_symbol<AUTH>(
+/// Reads the token metadata from a fungible faucet account's storage metadata slot.
+async fn get_token_metadata<AUTH>(
     client: &Client<AUTH>,
     account_id: AccountId,
-) -> Result<String, CliError> {
+) -> Result<TokenMetadata, CliError> {
     let word = client
         .account_reader(account_id)
         .get_storage_item(TokenMetadata::metadata_slot().clone())
@@ -290,13 +294,12 @@ async fn get_token_symbol<AUTH>(
                 format!("Failed to read token metadata for faucet {account_id}"),
             )
         })?;
-    let metadata = TokenMetadata::try_from(word).map_err(|err| {
+    TokenMetadata::try_from(word).map_err(|err| {
         CliError::Faucet(
             err.into(),
             format!("Failed to parse token metadata for faucet {account_id}"),
         )
-    })?;
-    Ok(metadata.symbol().to_string())
+    })
 }
 
 /// Returns a display name for the account type.
@@ -306,7 +309,8 @@ async fn account_type_display_name<AUTH>(
 ) -> Result<String, CliError> {
     Ok(match account_id.account_type() {
         AccountType::FungibleFaucet => {
-            let token_symbol = get_token_symbol(client, account_id).await?;
+            let token_symbol =
+                get_token_metadata(client, account_id).await?.symbol().to_string();
             format!("Fungible faucet (token symbol: {token_symbol})")
         },
         AccountType::NonFungibleFaucet => "Non-fungible faucet".to_string(),

--- a/bin/miden-cli/src/commands/account.rs
+++ b/bin/miden-cli/src/commands/account.rs
@@ -114,7 +114,7 @@ async fn list_accounts<AUTH>(client: Client<AUTH>) -> Result<(), CliError> {
 
         table.add_row(vec![
             acc.id().to_hex(),
-            account_type_display_name(&client, acc.id()).await,
+            account_type_display_name(&client, acc.id()).await?,
             acc.id().storage_mode().to_string(),
             acc.nonce().as_canonical_u64().to_string(),
             status,
@@ -166,9 +166,7 @@ pub async fn show_account<AUTH>(
         for asset in assets {
             let (asset_type, faucet, amount) = match asset {
                 Asset::Fungible(fungible_asset) => {
-                    let faucet = get_token_symbol(&client, fungible_asset.faucet_id())
-                        .await
-                        .expect("Fungible faucet should have a token symbol");
+                    let faucet = get_token_symbol(&client, fungible_asset.faucet_id()).await?;
                     let amount = fungible_asset.amount().to_string();
                     ("Fungible Asset", faucet, amount)
                 },
@@ -253,7 +251,7 @@ async fn print_summary_table<AUTH>(
     ]);
     table.add_row(vec![
         Cell::new("Type"),
-        Cell::new(account_type_display_name(client, account.id()).await),
+        Cell::new(account_type_display_name(client, account.id()).await?),
     ]);
     table.add_row(vec![
         Cell::new("Storage mode"),
@@ -277,38 +275,44 @@ async fn print_summary_table<AUTH>(
     Ok(())
 }
 
-/// Reads the token symbol from a faucet account's storage metadata slot.
-///
-/// Returns `None` if the account is not a fungible faucet or the metadata can't be read.
-async fn get_token_symbol<AUTH>(client: &Client<AUTH>, account_id: AccountId) -> Option<String> {
-    if account_id.account_type() != AccountType::FungibleFaucet {
-        return None;
-    }
-
-    client
+/// Reads the token symbol from a fungible faucet account's storage metadata slot.
+async fn get_token_symbol<AUTH>(
+    client: &Client<AUTH>,
+    account_id: AccountId,
+) -> Result<String, CliError> {
+    let word = client
         .account_reader(account_id)
         .get_storage_item(TokenMetadata::metadata_slot().clone())
         .await
-        .ok()
-        .and_then(|word| TokenMetadata::try_from(word).ok())
-        .map(|m| m.symbol().to_string())
+        .map_err(|err| {
+            CliError::Faucet(
+                err.into(),
+                format!("Failed to read token metadata for faucet {account_id}"),
+            )
+        })?;
+    let metadata = TokenMetadata::try_from(word).map_err(|err| {
+        CliError::Faucet(
+            err.into(),
+            format!("Failed to parse token metadata for faucet {account_id}"),
+        )
+    })?;
+    Ok(metadata.symbol().to_string())
 }
 
 /// Returns a display name for the account type.
-///
-/// For fungible faucets, `token_symbol` is used if provided.
-async fn account_type_display_name<AUTH>(client: &Client<AUTH>, account_id: AccountId) -> String {
-    match account_id.account_type() {
+async fn account_type_display_name<AUTH>(
+    client: &Client<AUTH>,
+    account_id: AccountId,
+) -> Result<String, CliError> {
+    Ok(match account_id.account_type() {
         AccountType::FungibleFaucet => {
-            let token_symbol = get_token_symbol(client, account_id)
-                .await
-                .expect("Fungible faucet should have a token symbol");
+            let token_symbol = get_token_symbol(client, account_id).await?;
             format!("Fungible faucet (token symbol: {token_symbol})")
         },
         AccountType::NonFungibleFaucet => "Non-fungible faucet".to_string(),
         AccountType::RegularAccountImmutableCode => "Regular".to_string(),
         AccountType::RegularAccountUpdatableCode => "Regular (updatable)".to_string(),
-    }
+    })
 }
 
 /// Sets the provided account ID as the default account in the client's store, if not set already.

--- a/bin/miden-cli/src/commands/account.rs
+++ b/bin/miden-cli/src/commands/account.rs
@@ -167,11 +167,9 @@ pub async fn show_account<AUTH>(
         for asset in assets {
             let (asset_type, faucet, amount) = match asset {
                 Asset::Fungible(fungible_asset) => {
-                    let metadata =
-                        get_token_metadata(&client, fungible_asset.faucet_id()).await?;
+                    let metadata = get_token_metadata(&client, fungible_asset.faucet_id()).await?;
                     let faucet = metadata.symbol().to_string();
-                    let amount =
-                        base_units_to_tokens(fungible_asset.amount(), metadata.decimals());
+                    let amount = base_units_to_tokens(fungible_asset.amount(), metadata.decimals());
                     ("Fungible Asset", faucet, amount)
                 },
                 Asset::NonFungible(non_fungible_asset) => {
@@ -309,8 +307,7 @@ async fn account_type_display_name<AUTH>(
 ) -> Result<String, CliError> {
     Ok(match account_id.account_type() {
         AccountType::FungibleFaucet => {
-            let token_symbol =
-                get_token_metadata(client, account_id).await?.symbol().to_string();
+            let token_symbol = get_token_metadata(client, account_id).await?.symbol().to_string();
             format!("Fungible faucet (token symbol: {token_symbol})")
         },
         AccountType::NonFungibleFaucet => "Non-fungible faucet".to_string(),

--- a/bin/miden-cli/src/commands/account.rs
+++ b/bin/miden-cli/src/commands/account.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use comfy_table::{Cell, ContentArrangement, presets};
+use miden_client::account::component::TokenMetadata;
 use miden_client::account::{
     Account,
     AccountId,
@@ -15,7 +16,7 @@ use miden_client::{Client, PrettyPrint, ZERO};
 
 use crate::config::CliConfig;
 use crate::errors::CliError;
-use crate::utils::{load_faucet_details_map, parse_account_id};
+use crate::utils::parse_account_id;
 use crate::{client_binary_name, create_dynamic_table};
 
 pub const DEFAULT_ACCOUNT_ID_KEY: &str = "default_account_id";
@@ -113,7 +114,7 @@ async fn list_accounts<AUTH>(client: Client<AUTH>) -> Result<(), CliError> {
 
         table.add_row(vec![
             acc.id().to_hex(),
-            account_type_display_name(&acc.id())?,
+            account_type_display_name(&client, acc.id()).await,
             acc.id().storage_mode().to_string(),
             acc.nonce().as_canonical_u64().to_string(),
             status,
@@ -159,15 +160,16 @@ pub async fn show_account<AUTH>(
     // Vault Table
     {
         let assets = account.vault().assets();
-        let faucet_details_map = load_faucet_details_map()?;
         println!("Assets: ");
 
         let mut table = create_dynamic_table(&["Asset Type", "Faucet", "Amount"]);
         for asset in assets {
             let (asset_type, faucet, amount) = match asset {
                 Asset::Fungible(fungible_asset) => {
-                    let (faucet, amount) =
-                        faucet_details_map.format_fungible_asset(&fungible_asset)?;
+                    let faucet = get_token_symbol(&client, fungible_asset.faucet_id())
+                        .await
+                        .expect("Fungible faucet should have a token symbol");
+                    let amount = fungible_asset.amount().to_string();
                     ("Fungible Asset", faucet, amount)
                 },
                 Asset::NonFungible(non_fungible_asset) => {
@@ -249,7 +251,10 @@ async fn print_summary_table<AUTH>(
         Cell::new("Account Commitment"),
         Cell::new(account.to_commitment().to_string()),
     ]);
-    table.add_row(vec![Cell::new("Type"), Cell::new(account_type_display_name(&account.id())?)]);
+    table.add_row(vec![
+        Cell::new("Type"),
+        Cell::new(account_type_display_name(client, account.id()).await),
+    ]);
     table.add_row(vec![
         Cell::new("Storage mode"),
         Cell::new(account.id().storage_mode().to_string()),
@@ -272,19 +277,38 @@ async fn print_summary_table<AUTH>(
     Ok(())
 }
 
-/// Returns a display name for the account type.
-fn account_type_display_name(account_id: &AccountId) -> Result<String, CliError> {
-    Ok(match account_id.account_type() {
-        AccountType::FungibleFaucet => {
-            let faucet_details_map = load_faucet_details_map()?;
-            let token_symbol = faucet_details_map.get_token_symbol_or_default(account_id);
+/// Reads the token symbol from a faucet account's storage metadata slot.
+///
+/// Returns `None` if the account is not a fungible faucet or the metadata can't be read.
+async fn get_token_symbol<AUTH>(client: &Client<AUTH>, account_id: AccountId) -> Option<String> {
+    if account_id.account_type() != AccountType::FungibleFaucet {
+        return None;
+    }
 
+    client
+        .account_reader(account_id)
+        .get_storage_item(TokenMetadata::metadata_slot().clone())
+        .await
+        .ok()
+        .and_then(|word| TokenMetadata::try_from(word).ok())
+        .map(|m| m.symbol().to_string())
+}
+
+/// Returns a display name for the account type.
+///
+/// For fungible faucets, `token_symbol` is used if provided.
+async fn account_type_display_name<AUTH>(client: &Client<AUTH>, account_id: AccountId) -> String {
+    match account_id.account_type() {
+        AccountType::FungibleFaucet => {
+            let token_symbol = get_token_symbol(client, account_id)
+                .await
+                .expect("Fungible faucet should have a token symbol");
             format!("Fungible faucet (token symbol: {token_symbol})")
         },
         AccountType::NonFungibleFaucet => "Non-fungible faucet".to_string(),
         AccountType::RegularAccountImmutableCode => "Regular".to_string(),
         AccountType::RegularAccountUpdatableCode => "Regular (updatable)".to_string(),
-    })
+    }
 }
 
 /// Sets the provided account ID as the default account in the client's store, if not set already.

--- a/bin/miden-cli/src/errors.rs
+++ b/bin/miden-cli/src/errors.rs
@@ -70,9 +70,9 @@ pub enum CliError {
     #[error("export error: {0}")]
     #[diagnostic(code(cli::export_error), help("Check the ID."))]
     Export(String),
-    #[error("faucet error: {0}")]
+    #[error("faucet error: {1}")]
     #[diagnostic(code(cli::faucet_error))]
-    Faucet(String),
+    Faucet(#[source] SourceError, String),
     #[error("import error: {0}")]
     #[diagnostic(code(cli::import_error), help("Check the file name."))]
     Import(String),

--- a/bin/miden-cli/src/faucet_details_map.rs
+++ b/bin/miden-cli/src/faucet_details_map.rs
@@ -69,10 +69,6 @@ impl FaucetDetailsMap {
             .map(|(symbol, _)| symbol.clone())
     }
 
-    pub fn get_token_symbol_or_default(&self, faucet_id: &AccountId) -> String {
-        self.get_token_symbol(faucet_id).unwrap_or("Unknown".to_string())
-    }
-
     /// Parses a string representing a [`FungibleAsset`]. There are two accepted formats for the
     /// string:
     /// - `<AMOUNT>::<FAUCET_ID>` where `<AMOUNT>` is in the faucet base units and `<FAUCET_ID>` is

--- a/crates/rust-client/src/account/mod.rs
+++ b/crates/rust-client/src/account/mod.rs
@@ -107,7 +107,11 @@ pub mod component {
         singlesig_acl_library,
         singlesig_library,
     };
-    pub use miden_standards::account::faucets::{BasicFungibleFaucet, NetworkFungibleFaucet};
+    pub use miden_standards::account::faucets::{
+        BasicFungibleFaucet,
+        NetworkFungibleFaucet,
+        TokenMetadata,
+    };
     pub use miden_standards::account::mint_policies::{
         AuthControlled,
         AuthControlledInitConfig,


### PR DESCRIPTION
Small change to correctly show the token symbol on tracked faucet accounts. Currently the token symbol shows "Unknown" unless it's tracked on the `FaucetDetailsMap` - this is the default case unless the user manually creates the mapping file. This PR changes the display to fetch the asset symbol from the store, since it's a given that the account is tracked by the client when showing the account details.