### PR TITLE
feat: replace consume-notes error with message

### DIFF
--- a/bin/miden-cli/src/commands/new_transactions.rs
+++ b/bin/miden-cli/src/commands/new_transactions.rs
@@ -340,10 +340,8 @@ impl ConsumeNotesCmd {
         }
 
         if input_notes.is_empty() {
-            return Err(CliError::Transaction(
-                "No input notes were provided and the store does not contain any notes consumable by {account_id}".into(),
-                "Input notes check failed".to_string(),
-            ));
+            println!("Did not find any consumable notes for {account_id}.");
+            return Ok(());
         }
 
         let transaction_request = TransactionRequestBuilder::new()


### PR DESCRIPTION
Running the `miden-client consume-notes` command returns this error if there are no available notes for consuming:
```
Error: cli::transaction_error

  × transaction error: Input notes check failed
  ╰─▶ No input notes were provided and the store does not contain any
      notes consumable by {account_id}
```

This PR replaces the error with a friendlier message:
```
Did not find any consumable notes for 0x0afe5166423c2d802f2165a449843a
```