### PR TITLE
feat(rpc): block finality and `include_proof`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.15.0 (TBD)
 
+### Changes
+
+* [BREAKING][param][rust] `NodeRpcClient::get_block_by_number()` now takes an `include_proof: bool` parameter to control whether the block proof is included in the response. ([#TBD](https://github.com/0xMiden/miden-client/pull/TBD))
+* [BREAKING][param][rust] `NodeRpcClient::sync_chain_mmr()` replaced `block_to: Option<BlockNumber>` with `chain_tip: ChainTip` to match the RPC definition. Use `ChainTip::Committed` for previous default behavior (`None`). ([#TBD](https://github.com/0xMiden/miden-client/pull/TBD))
+
 ### Enhancements
 
 * Fixed the faucet token symbol display when showing account details ([#1985](https://github.com/0xMiden/miden-client/pull/1985)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Changes
 
-* [BREAKING][param][rust] `NodeRpcClient::get_block_by_number()` now takes an `include_proof: bool` parameter to control whether the block proof is included in the response. ([#TBD](https://github.com/0xMiden/miden-client/pull/TBD))
-* [BREAKING][param][rust] `NodeRpcClient::sync_chain_mmr()` replaced `block_to: Option<BlockNumber>` with `upper_bound: SyncTarget` to match the RPC definition. Use `SyncTarget::CommittedChainTip` for previous default behavior (`None`), or `SyncTarget::BlockNumber(num)` for a specific block number. ([#TBD](https://github.com/0xMiden/miden-client/pull/TBD))
+* [BREAKING][param][rust] `NodeRpcClient::get_block_by_number()` now takes an `include_proof: bool` parameter to control whether the block proof is included in the response. ([#1991](https://github.com/0xMiden/miden-client/pull/1991))
+* [BREAKING][param][rust] `NodeRpcClient::sync_chain_mmr()` replaced `block_to: Option<BlockNumber>` with `upper_bound: SyncTarget` to match the RPC definition. Use `SyncTarget::CommittedChainTip` for previous default behavior (`None`), or `SyncTarget::BlockNumber(num)` for a specific block number. ([#1991](https://github.com/0xMiden/miden-client/pull/1991))
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changes
 
 * [BREAKING][param][rust] `NodeRpcClient::get_block_by_number()` now takes an `include_proof: bool` parameter to control whether the block proof is included in the response. ([#TBD](https://github.com/0xMiden/miden-client/pull/TBD))
-* [BREAKING][param][rust] `NodeRpcClient::sync_chain_mmr()` replaced `block_to: Option<BlockNumber>` with `chain_tip: ChainTip` to match the RPC definition. Use `ChainTip::Committed` for previous default behavior (`None`). ([#TBD](https://github.com/0xMiden/miden-client/pull/TBD))
+* [BREAKING][param][rust] `NodeRpcClient::sync_chain_mmr()` replaced `block_to: Option<BlockNumber>` with `upper_bound: SyncTarget` to match the RPC definition. Use `SyncTarget::CommittedChainTip` for previous default behavior (`None`), or `SyncTarget::BlockNumber(num)` for a specific block number. ([#TBD](https://github.com/0xMiden/miden-client/pull/TBD))
 
 ### Enhancements
 

--- a/bin/integration-tests/src/tests/client.rs
+++ b/bin/integration-tests/src/tests/client.rs
@@ -1321,6 +1321,21 @@ pub async fn test_unused_rpc_api(client_config: ClientConfig) -> Result<()> {
 
     assert_eq!(&block_header, block.header());
 
+    // Test get_account_proof retrieval
+    let (proof_block_num, account_proof) = client
+        .test_rpc_api()
+        .get_account_proof(
+            first_basic_account.id(),
+            AccountStorageRequirements::default(),
+            AccountStateAt::ChainTip,
+            None,
+            None,
+        )
+        .await?;
+    assert!(proof_block_num >= first_block_num);
+    assert_eq!(account_proof.account_id(), first_basic_account.id());
+    assert!(account_proof.account_header().is_some());
+
     let (tx_id, note) =
         mint_note(&mut client, first_basic_account.id(), faucet_account.id(), NoteType::Public)
             .await;

--- a/bin/integration-tests/src/tests/client.rs
+++ b/bin/integration-tests/src/tests/client.rs
@@ -1317,7 +1317,7 @@ pub async fn test_unused_rpc_api(client_config: ClientConfig) -> Result<()> {
         .test_rpc_api()
         .get_block_header_by_number(Some(first_block_num), false)
         .await?;
-    let block = client.test_rpc_api().get_block_by_number(first_block_num).await.unwrap();
+    let block = client.test_rpc_api().get_block_by_number(first_block_num, false).await.unwrap();
 
     assert_eq!(&block_header, block.header());
 

--- a/bin/integration-tests/src/tests/client.rs
+++ b/bin/integration-tests/src/tests/client.rs
@@ -1345,6 +1345,15 @@ pub async fn test_unused_rpc_api(client_config: ClientConfig) -> Result<()> {
     assert_eq!(account_proof.account_id(), first_basic_account.id());
     assert!(account_proof.account_header().is_some());
 
+    // The witness's merkle path should resolve to the account root committed
+    // in the block header for `proof_block_num`.
+    let (proof_block_header, _) = client
+        .test_rpc_api()
+        .get_block_header_by_number(Some(proof_block_num), false)
+        .await?;
+    let computed_account_root = account_proof.account_witness().clone().into_proof().compute_root();
+    assert_eq!(computed_account_root, proof_block_header.account_root());
+
     // Define the account code for the custom library
     let custom_code = r#"
         use miden::protocol::native_account

--- a/bin/integration-tests/src/tests/client.rs
+++ b/bin/integration-tests/src/tests/client.rs
@@ -1330,6 +1330,20 @@ pub async fn test_unused_rpc_api(client_config: ClientConfig) -> Result<()> {
         consume_notes(&mut client, first_basic_account.id(), std::slice::from_ref(&note)).await;
     wait_for_tx(&mut client, tx_id).await?;
 
+    let (proof_block_num, account_proof) = client
+        .test_rpc_api()
+        .get_account_proof(
+            first_basic_account.id(),
+            AccountStorageRequirements::default(),
+            AccountStateAt::ChainTip,
+            None,
+            None,
+        )
+        .await?;
+    assert!(proof_block_num >= first_block_num);
+    assert_eq!(account_proof.account_id(), first_basic_account.id());
+    assert!(account_proof.account_header().is_some());
+
     // Define the account code for the custom library
     let custom_code = r#"
         use miden::protocol::native_account

--- a/bin/integration-tests/src/tests/client.rs
+++ b/bin/integration-tests/src/tests/client.rs
@@ -1321,21 +1321,6 @@ pub async fn test_unused_rpc_api(client_config: ClientConfig) -> Result<()> {
 
     assert_eq!(&block_header, block.header());
 
-    // Test get_account_proof retrieval
-    let (proof_block_num, account_proof) = client
-        .test_rpc_api()
-        .get_account_proof(
-            first_basic_account.id(),
-            AccountStorageRequirements::default(),
-            AccountStateAt::ChainTip,
-            None,
-            None,
-        )
-        .await?;
-    assert!(proof_block_num >= first_block_num);
-    assert_eq!(account_proof.account_id(), first_basic_account.id());
-    assert!(account_proof.account_header().is_some());
-
     let (tx_id, note) =
         mint_note(&mut client, first_basic_account.id(), faucet_account.id(), NoteType::Public)
             .await;
@@ -1345,6 +1330,7 @@ pub async fn test_unused_rpc_api(client_config: ClientConfig) -> Result<()> {
         consume_notes(&mut client, first_basic_account.id(), std::slice::from_ref(&note)).await;
     wait_for_tx(&mut client, tx_id).await?;
 
+    // Test get_account_proof retrieval (account must be deployed on-chain first)
     let (proof_block_num, account_proof) = client
         .test_rpc_api()
         .get_account_proof(

--- a/crates/rust-client/src/rpc/domain/sync.rs
+++ b/crates/rust-client/src/rpc/domain/sync.rs
@@ -21,6 +21,16 @@ pub enum SyncTarget {
     ProvenChainTip,
 }
 
+impl From<SyncTarget> for proto::rpc::sync_chain_mmr_request::UpperBound {
+    fn from(target: SyncTarget) -> Self {
+        match target {
+            SyncTarget::BlockNumber(block_num) => Self::BlockNum(block_num.as_u32()),
+            SyncTarget::CommittedChainTip => Self::ChainTip(proto::rpc::ChainTip::Committed.into()),
+            SyncTarget::ProvenChainTip => Self::ChainTip(proto::rpc::ChainTip::Proven.into()),
+        }
+    }
+}
+
 // CHAIN MMR INFO
 // ================================================================================================
 

--- a/crates/rust-client/src/rpc/domain/sync.rs
+++ b/crates/rust-client/src/rpc/domain/sync.rs
@@ -4,6 +4,23 @@ use miden_protocol::crypto::merkle::mmr::MmrDelta;
 use crate::rpc::domain::MissingFieldHelper;
 use crate::rpc::{RpcError, generated as proto};
 
+// SYNC UPPER BOUND
+// ================================================================================================
+
+/// Upper bound for chain MMR synchronization.
+///
+/// Determines how far ahead to sync: either to a specific block number or to a chain tip
+/// finality level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncTarget {
+    /// Sync up to a specific block number (inclusive).
+    BlockNumber(BlockNumber),
+    /// Sync up to the latest committed block (the chain tip).
+    CommittedChainTip,
+    /// Sync up to the latest proven block, which may be behind the committed tip.
+    ProvenChainTip,
+}
+
 // CHAIN MMR INFO
 // ================================================================================================
 

--- a/crates/rust-client/src/rpc/mod.rs
+++ b/crates/rust-client/src/rpc/mod.rs
@@ -97,6 +97,15 @@ pub enum AccountStateAt {
     Block(BlockNumber),
 }
 
+/// The chain tip finality variant to sync up to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChainTip {
+    /// Sync up to the latest committed block.
+    Committed,
+    /// Sync up to the latest proven block.
+    Proven,
+}
+
 // NODE RPC CLIENT TRAIT
 // ================================================================================================
 
@@ -138,7 +147,13 @@ pub trait NodeRpcClient: Send + Sync {
 
     /// Given a block number, fetches the block corresponding to that height from the node using
     /// the `/GetBlockByNumber` RPC endpoint.
-    async fn get_block_by_number(&self, block_num: BlockNumber) -> Result<ProvenBlock, RpcError>;
+    ///
+    /// If `include_proof` is set to true, the block proof will be included in the response.
+    async fn get_block_by_number(
+        &self,
+        block_num: BlockNumber,
+        include_proof: bool,
+    ) -> Result<ProvenBlock, RpcError>;
 
     /// Fetches note-related data for a list of [`NoteId`] using the `/GetNotesById`
     /// RPC endpoint.
@@ -156,11 +171,11 @@ pub trait NodeRpcClient: Send + Sync {
     /// Fetches the MMR delta for a given block range using the `/SyncChainMmr` RPC endpoint.
     ///
     /// - `block_from` is the last block number already present in the caller's MMR.
-    /// - `block_to` is the optional upper bound of the range. If `None`, syncs up to the chain tip.
+    /// - `chain_tip` determines the finality of the chain tip to sync up to.
     async fn sync_chain_mmr(
         &self,
         block_from: BlockNumber,
-        block_to: Option<BlockNumber>,
+        chain_tip: ChainTip,
     ) -> Result<ChainMmrInfo, RpcError>;
 
     /// Fetches the current state of an account from the node using the `/GetAccountDetails` RPC

--- a/crates/rust-client/src/rpc/mod.rs
+++ b/crates/rust-client/src/rpc/mod.rs
@@ -49,7 +49,7 @@ use core::fmt;
 use domain::account::{AccountProof, FetchedAccount};
 use domain::note::{FetchedNote, NoteSyncInfo, SyncNotesResult};
 use domain::nullifier::NullifierUpdate;
-use domain::sync::ChainMmrInfo;
+use domain::sync::{ChainMmrInfo, SyncTarget};
 use miden_protocol::Word;
 use miden_protocol::account::{Account, AccountCode, AccountHeader, AccountId};
 use miden_protocol::address::NetworkId;
@@ -95,15 +95,6 @@ pub enum AccountStateAt {
     ChainTip,
     /// Gets the state at a specific block number
     Block(BlockNumber),
-}
-
-/// The chain tip finality variant to sync up to.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ChainTip {
-    /// Sync up to the latest committed block.
-    Committed,
-    /// Sync up to the latest proven block.
-    Proven,
 }
 
 // NODE RPC CLIENT TRAIT
@@ -171,11 +162,14 @@ pub trait NodeRpcClient: Send + Sync {
     /// Fetches the MMR delta for a given block range using the `/SyncChainMmr` RPC endpoint.
     ///
     /// - `block_from` is the last block number already present in the caller's MMR.
-    /// - `chain_tip` determines the finality of the chain tip to sync up to.
+    /// - `upper_bound` determines the upper bound of the sync range. Can be a specific block number
+    ///   (`BlockNumber`), or a chain tip finality level: `CommittedChainTip` syncs up to the latest
+    ///   committed block (the chain tip), while `ProvenChainTip` syncs up to the latest proven
+    ///   block which may be behind the committed tip.
     async fn sync_chain_mmr(
         &self,
         block_from: BlockNumber,
-        chain_tip: ChainTip,
+        upper_bound: SyncTarget,
     ) -> Result<ChainMmrInfo, RpcError>;
 
     /// Fetches the current state of an account from the node using the `/GetAccountDetails` RPC

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -39,7 +39,7 @@ use super::{
     Endpoint, FetchedAccount, NodeRpcClient, RpcEndpoint, NoteSyncInfo, RpcError,
     RpcStatusInfo,
 };
-use crate::rpc::domain::sync::ChainMmrInfo;
+use crate::rpc::domain::sync::{ChainMmrInfo, SyncTarget};
 use crate::rpc::domain::account_vault::{AccountVaultInfo, AccountVaultUpdate};
 use crate::rpc::domain::storage_map::{StorageMapInfo, StorageMapUpdate};
 use crate::rpc::domain::transaction::TransactionsInfo;
@@ -49,7 +49,7 @@ use crate::rpc::generated::rpc::account_request::account_detail_request::storage
 use crate::rpc::generated::rpc::account_request::account_detail_request::StorageMapDetailRequest;
 use crate::rpc::generated::rpc::BlockRange;
 use crate::rpc::domain::limits::RpcLimits;
-use crate::rpc::{AccountStateAt, ChainTip, generated as proto};
+use crate::rpc::{AccountStateAt, generated as proto};
 
 mod api_client;
 mod retry;
@@ -586,16 +586,23 @@ impl NodeRpcClient for GrpcClient {
     async fn sync_chain_mmr(
         &self,
         block_from: BlockNumber,
-        chain_tip: ChainTip,
+        upper_bound: SyncTarget,
     ) -> Result<ChainMmrInfo, RpcError> {
         let block_from = block_from.as_u32();
 
-        let proto_chain_tip = match chain_tip {
-            ChainTip::Committed => proto::rpc::ChainTip::Committed,
-            ChainTip::Proven => proto::rpc::ChainTip::Proven,
-        };
-        let upper_bound =
-            Some(proto::rpc::sync_chain_mmr_request::UpperBound::ChainTip(proto_chain_tip.into()));
+        let upper_bound = Some(match upper_bound {
+            SyncTarget::BlockNumber(block_num) => {
+                proto::rpc::sync_chain_mmr_request::UpperBound::BlockNum(block_num.as_u32())
+            },
+            SyncTarget::CommittedChainTip => {
+                proto::rpc::sync_chain_mmr_request::UpperBound::ChainTip(
+                    proto::rpc::ChainTip::Committed.into(),
+                )
+            },
+            SyncTarget::ProvenChainTip => proto::rpc::sync_chain_mmr_request::UpperBound::ChainTip(
+                proto::rpc::ChainTip::Proven.into(),
+            ),
+        });
 
         let request = proto::rpc::SyncChainMmrRequest { block_from, upper_bound };
 

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -590,19 +590,7 @@ impl NodeRpcClient for GrpcClient {
     ) -> Result<ChainMmrInfo, RpcError> {
         let block_from = block_from.as_u32();
 
-        let upper_bound = Some(match upper_bound {
-            SyncTarget::BlockNumber(block_num) => {
-                proto::rpc::sync_chain_mmr_request::UpperBound::BlockNum(block_num.as_u32())
-            },
-            SyncTarget::CommittedChainTip => {
-                proto::rpc::sync_chain_mmr_request::UpperBound::ChainTip(
-                    proto::rpc::ChainTip::Committed.into(),
-                )
-            },
-            SyncTarget::ProvenChainTip => proto::rpc::sync_chain_mmr_request::UpperBound::ChainTip(
-                proto::rpc::ChainTip::Proven.into(),
-            ),
-        });
+        let upper_bound = Some(upper_bound.into());
 
         let request = proto::rpc::SyncChainMmrRequest { block_from, upper_bound };
 

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -49,7 +49,7 @@ use crate::rpc::generated::rpc::account_request::account_detail_request::storage
 use crate::rpc::generated::rpc::account_request::account_detail_request::StorageMapDetailRequest;
 use crate::rpc::generated::rpc::BlockRange;
 use crate::rpc::domain::limits::RpcLimits;
-use crate::rpc::{AccountStateAt, generated as proto};
+use crate::rpc::{AccountStateAt, ChainTip, generated as proto};
 
 mod api_client;
 mod retry;
@@ -586,18 +586,16 @@ impl NodeRpcClient for GrpcClient {
     async fn sync_chain_mmr(
         &self,
         block_from: BlockNumber,
-        block_to: Option<BlockNumber>,
+        chain_tip: ChainTip,
     ) -> Result<ChainMmrInfo, RpcError> {
         let block_from = block_from.as_u32();
 
-        let upper_bound = match block_to {
-            Some(block_to) => {
-                Some(proto::rpc::sync_chain_mmr_request::UpperBound::BlockNum(block_to.as_u32()))
-            },
-            None => Some(proto::rpc::sync_chain_mmr_request::UpperBound::ChainTip(
-                proto::rpc::ChainTip::Committed.into(),
-            )),
+        let proto_chain_tip = match chain_tip {
+            ChainTip::Committed => proto::rpc::ChainTip::Committed,
+            ChainTip::Proven => proto::rpc::ChainTip::Proven,
         };
+        let upper_bound =
+            Some(proto::rpc::sync_chain_mmr_request::UpperBound::ChainTip(proto_chain_tip.into()));
 
         let request = proto::rpc::SyncChainMmrRequest { block_from, upper_bound };
 
@@ -885,10 +883,14 @@ impl NodeRpcClient for GrpcClient {
         Ok(proofs)
     }
 
-    async fn get_block_by_number(&self, block_num: BlockNumber) -> Result<ProvenBlock, RpcError> {
+    async fn get_block_by_number(
+        &self,
+        block_num: BlockNumber,
+        include_proof: bool,
+    ) -> Result<ProvenBlock, RpcError> {
         let request = proto::blockchain::BlockRequest {
             block_num: block_num.as_u32(),
-            include_proof: Some(false),
+            include_proof: Some(include_proof),
         };
 
         let response = self

--- a/crates/rust-client/src/sync/state_sync.rs
+++ b/crates/rust-client/src/sync/state_sync.rs
@@ -16,12 +16,12 @@ use super::state_sync_update::TransactionUpdateTracker;
 use super::{AccountUpdates, StateSyncUpdate};
 use crate::ClientError;
 use crate::note::NoteUpdateTracker;
-use crate::rpc::NodeRpcClient;
 use crate::rpc::domain::note::{CommittedNote, NoteSyncBlock};
 use crate::rpc::domain::transaction::{
     TransactionInclusion,
     TransactionRecord as RpcTransactionRecord,
 };
+use crate::rpc::{ChainTip, NodeRpcClient};
 use crate::store::{InputNoteRecord, OutputNoteRecord, StoreError};
 use crate::transaction::TransactionRecord;
 
@@ -287,7 +287,8 @@ impl StateSync {
         note_tags: &Arc<BTreeSet<NoteTag>>,
     ) -> Result<Option<RawStateSyncData>, ClientError> {
         // Step 1: Fetch the MMR delta and chain tip header.
-        let chain_mmr_info = self.rpc_api.sync_chain_mmr(current_block_num, None).await?;
+        let chain_mmr_info =
+            self.rpc_api.sync_chain_mmr(current_block_num, ChainTip::Committed).await?;
         let chain_tip = chain_mmr_info.block_to;
 
         // No progress — already at the tip.

--- a/crates/rust-client/src/sync/state_sync.rs
+++ b/crates/rust-client/src/sync/state_sync.rs
@@ -16,12 +16,13 @@ use super::state_sync_update::TransactionUpdateTracker;
 use super::{AccountUpdates, StateSyncUpdate};
 use crate::ClientError;
 use crate::note::NoteUpdateTracker;
+use crate::rpc::NodeRpcClient;
 use crate::rpc::domain::note::{CommittedNote, NoteSyncBlock};
+use crate::rpc::domain::sync::SyncTarget;
 use crate::rpc::domain::transaction::{
     TransactionInclusion,
     TransactionRecord as RpcTransactionRecord,
 };
-use crate::rpc::{ChainTip, NodeRpcClient};
 use crate::store::{InputNoteRecord, OutputNoteRecord, StoreError};
 use crate::transaction::TransactionRecord;
 
@@ -287,8 +288,10 @@ impl StateSync {
         note_tags: &Arc<BTreeSet<NoteTag>>,
     ) -> Result<Option<RawStateSyncData>, ClientError> {
         // Step 1: Fetch the MMR delta and chain tip header.
-        let chain_mmr_info =
-            self.rpc_api.sync_chain_mmr(current_block_num, ChainTip::Committed).await?;
+        let chain_mmr_info = self
+            .rpc_api
+            .sync_chain_mmr(current_block_num, SyncTarget::CommittedChainTip)
+            .await?;
         let chain_tip = chain_mmr_info.block_to;
 
         // No progress — already at the tip.

--- a/crates/rust-client/src/test_utils/mock.rs
+++ b/crates/rust-client/src/test_utils/mock.rs
@@ -38,9 +38,9 @@ use crate::rpc::domain::note::{
 };
 use crate::rpc::domain::nullifier::NullifierUpdate;
 use crate::rpc::domain::storage_map::{StorageMapInfo, StorageMapUpdate};
-use crate::rpc::domain::sync::ChainMmrInfo;
+use crate::rpc::domain::sync::{ChainMmrInfo, SyncTarget};
 use crate::rpc::domain::transaction::{TransactionRecord, TransactionsInfo};
-use crate::rpc::{AccountStateAt, ChainTip, NodeRpcClient, RpcError, RpcStatusInfo};
+use crate::rpc::{AccountStateAt, NodeRpcClient, RpcError, RpcStatusInfo};
 
 pub type MockClient<AUTH> = Client<AUTH>;
 
@@ -351,12 +351,17 @@ impl NodeRpcClient for MockRpcApi {
     async fn sync_chain_mmr(
         &self,
         block_from: BlockNumber,
-        _chain_tip: ChainTip,
+        upper_bound: SyncTarget,
     ) -> Result<ChainMmrInfo, RpcError> {
         let chain_tip = self.get_chain_tip_block_num();
-        let target_block = chain_tip;
+        // The mock chain doesn't distinguish committed vs proven tips, but respects
+        // explicit block numbers.
+        let target_block = match upper_bound {
+            SyncTarget::BlockNumber(block_num) => block_num.min(chain_tip),
+            SyncTarget::CommittedChainTip | SyncTarget::ProvenChainTip => chain_tip,
+        };
 
-        let from_forest = if block_from == chain_tip {
+        let from_forest = if block_from == target_block {
             target_block.as_usize()
         } else {
             block_from.as_u32() as usize + 1

--- a/crates/rust-client/src/test_utils/mock.rs
+++ b/crates/rust-client/src/test_utils/mock.rs
@@ -40,7 +40,7 @@ use crate::rpc::domain::nullifier::NullifierUpdate;
 use crate::rpc::domain::storage_map::{StorageMapInfo, StorageMapUpdate};
 use crate::rpc::domain::sync::ChainMmrInfo;
 use crate::rpc::domain::transaction::{TransactionRecord, TransactionsInfo};
-use crate::rpc::{AccountStateAt, NodeRpcClient, RpcError, RpcStatusInfo};
+use crate::rpc::{AccountStateAt, ChainTip, NodeRpcClient, RpcError, RpcStatusInfo};
 
 pub type MockClient<AUTH> = Client<AUTH>;
 
@@ -351,10 +351,10 @@ impl NodeRpcClient for MockRpcApi {
     async fn sync_chain_mmr(
         &self,
         block_from: BlockNumber,
-        block_to: Option<BlockNumber>,
+        _chain_tip: ChainTip,
     ) -> Result<ChainMmrInfo, RpcError> {
         let chain_tip = self.get_chain_tip_block_num();
-        let target_block = block_to.unwrap_or(chain_tip).min(chain_tip);
+        let target_block = chain_tip;
 
         let from_forest = if block_from == chain_tip {
             target_block.as_usize()
@@ -582,7 +582,11 @@ impl NodeRpcClient for MockRpcApi {
             .collect())
     }
 
-    async fn get_block_by_number(&self, block_num: BlockNumber) -> Result<ProvenBlock, RpcError> {
+    async fn get_block_by_number(
+        &self,
+        block_num: BlockNumber,
+        _include_proof: bool,
+    ) -> Result<ProvenBlock, RpcError> {
         let block = self
             .mock_chain
             .read()

--- a/crates/web-client/src/rpc_client/mod.rs
+++ b/crates/web-client/src/rpc_client/mod.rs
@@ -107,16 +107,22 @@ impl RpcClient {
     }
 
     /// Fetches a block header by number. When `block_num` is undefined, returns the latest header.
+    ///
+    /// @param `block_num` - Optional block number. When `undefined`, returns the latest header.
+    /// @param `include_mmr_proof` - When `true`, includes the MMR proof in the response. Defaults
+    ///   to `false` when `undefined`.
     #[wasm_bindgen(js_name = "getBlockHeaderByNumber")]
     pub async fn get_block_header_by_number(
         &self,
         block_num: Option<u32>,
+        include_mmr_proof: Option<bool>,
     ) -> Result<BlockHeader, JsValue> {
         let native_block_num = block_num.map(BlockNumber::from);
-        let (header, _proof) =
-            self.inner.get_block_header_by_number(native_block_num, false).await.map_err(
-                |err| js_error_with_context(err, "failed to get block header by number"),
-            )?;
+        let (header, _proof) = self
+            .inner
+            .get_block_header_by_number(native_block_num, include_mmr_proof.unwrap_or(false))
+            .await
+            .map_err(|err| js_error_with_context(err, "failed to get block header by number"))?;
 
         Ok(header.into())
     }


### PR DESCRIPTION
- Exposes `include_proof` in `GetBlockHeaderByNumber`
- Exposes target setting for `SyncChainMmr`
- Minor refactors (moves an enum to a different module, etc.)

Closes #1989 
Closes #1988