### PR TITLE
fix(sync): keep block MMR forest implicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Fixes
 
-* [FIX][web] Fixed `syncState` failure ("mmr peaks are invalid: number of one bits in leaves does not equal peak length") caused by reconstructing `MmrPeaks` with `block_num` instead of the actual forest size at peak-capture time. The IndexedDB store now persists the forest value alongside peaks in both the `insert_block_header` and `apply_state_sync` code paths. ([#1997](https://github.com/0xMiden/miden-client/pull/1997)).
 * [FIX][web] Fixed `syncState` failure ("inconsistent partial mmr: tracked leaf at position N has no value in nodes") caused by skipping authentication node collection for blocks already tracked from the MMR delta during large catch-up syncs. Authentication nodes are now always collected for note-relevant blocks regardless of prior tracking state. ([#1997](https://github.com/0xMiden/miden-client/pull/1997)).
 
 ## 0.14.0 (2026-04-07)

--- a/crates/idxdb-store/src/chain_data/js_bindings.rs
+++ b/crates/idxdb-store/src/chain_data/js_bindings.rs
@@ -46,7 +46,6 @@ extern "C" {
         block_num: u32,
         header: Vec<u8>,
         partial_blockchain_peaks: Vec<u8>,
-        forest: u32,
         has_client_notes: bool,
     ) -> js_sys::Promise;
 

--- a/crates/idxdb-store/src/chain_data/mod.rs
+++ b/crates/idxdb-store/src/chain_data/mod.rs
@@ -49,28 +49,19 @@ impl IdxdbStore {
         partial_blockchain_peaks: MmrPeaks,
         has_client_notes: bool,
     ) -> Result<(), StoreError> {
-        let forest = u32::try_from(partial_blockchain_peaks.forest().num_leaves())
-            .expect("forest num_leaves should fit in u32");
         let partial_blockchain_peaks = partial_blockchain_peaks.peaks().to_vec();
         let SerializedBlockHeaderData {
             block_num,
             header,
             partial_blockchain_peaks,
-            forest,
             has_client_notes,
-        } = serialize_block_header(
-            block_header,
-            &partial_blockchain_peaks,
-            forest,
-            has_client_notes,
-        );
+        } = serialize_block_header(block_header, &partial_blockchain_peaks, has_client_notes);
 
         let promise = idxdb_insert_block_header(
             self.db_id(),
             block_num,
             header,
             partial_blockchain_peaks,
-            forest,
             has_client_notes,
         );
         await_ok(promise, "failed to insert block header").await?;
@@ -195,11 +186,7 @@ impl IdxdbStore {
         if let Some(peaks) = mmr_peaks_idxdb.peaks {
             let mmr_peaks_nodes: Vec<Word> = Vec::<Word>::read_from_bytes(&peaks)?;
 
-            // Use the stored forest value if available; fall back to block_num for
-            // records written before the forest field was added.
-            let forest_size = mmr_peaks_idxdb.forest.map_or(block_num.as_usize(), |f| f as usize);
-
-            return MmrPeaks::new(Forest::new(forest_size), mmr_peaks_nodes)
+            return MmrPeaks::new(Forest::new(block_num.as_usize()), mmr_peaks_nodes)
                 .map_err(StoreError::MmrError);
         }
 

--- a/crates/idxdb-store/src/chain_data/models.rs
+++ b/crates/idxdb-store/src/chain_data/models.rs
@@ -32,7 +32,4 @@ pub struct PartialBlockchainNodeIdxdbObject {
 pub struct PartialBlockchainPeaksIdxdbObject {
     #[serde(deserialize_with = "base64_to_vec_u8_optional", default)]
     pub peaks: Option<Vec<u8>>,
-    /// The forest (number of leaves) at the time the peaks were captured.
-    /// Older records may not have this field, in which case `block_num` is used as fallback.
-    pub forest: Option<u32>,
 }

--- a/crates/idxdb-store/src/chain_data/utils.rs
+++ b/crates/idxdb-store/src/chain_data/utils.rs
@@ -17,7 +17,6 @@ pub struct SerializedBlockHeaderData {
     pub block_num: u32,
     pub header: Vec<u8>,
     pub partial_blockchain_peaks: Vec<u8>,
-    pub forest: u32,
     pub has_client_notes: bool,
 }
 
@@ -29,7 +28,6 @@ pub struct SerializedPartialBlockchainNodeData {
 pub fn serialize_block_header(
     block_header: &BlockHeader,
     partial_blockchain_peaks: &[Word],
-    forest: u32,
     has_client_notes: bool,
 ) -> SerializedBlockHeaderData {
     let block_num = block_header.block_num().as_u32();
@@ -40,7 +38,6 @@ pub fn serialize_block_header(
         block_num,
         header,
         partial_blockchain_peaks,
-        forest,
         has_client_notes,
     }
 }

--- a/crates/idxdb-store/src/js/chainData.js
+++ b/crates/idxdb-store/src/js/chainData.js
@@ -1,13 +1,12 @@
 import { getDatabase } from "./schema.js";
 import { logWebStoreError, uint8ArrayToBase64 } from "./utils.js";
-export async function insertBlockHeader(dbId, blockNum, header, partialBlockchainPeaks, forest, hasClientNotes) {
+export async function insertBlockHeader(dbId, blockNum, header, partialBlockchainPeaks, hasClientNotes) {
     try {
         const db = getDatabase(dbId);
         const data = {
             blockNum: blockNum,
             header,
             partialBlockchainPeaks,
-            forest,
             hasClientNotes: hasClientNotes.toString(),
         };
         await db.blockHeaders.put(data);
@@ -108,7 +107,6 @@ export async function getPartialBlockchainPeaksByBlockNum(dbId, blockNum) {
         const partialBlockchainPeaksBase64 = uint8ArrayToBase64(blockHeader.partialBlockchainPeaks);
         return {
             peaks: partialBlockchainPeaksBase64,
-            forest: blockHeader.forest !== undefined ? blockHeader.forest : null,
         };
     }
     catch (err) {

--- a/crates/idxdb-store/src/js/sync.js
+++ b/crates/idxdb-store/src/js/sync.js
@@ -72,7 +72,7 @@ export async function removeNoteTag(dbId, tag, sourceNoteId, sourceAccountId) {
 }
 export async function applyStateSync(dbId, stateUpdate) {
     const db = getDatabase(dbId);
-    const { blockNum, flattenedNewBlockHeaders, flattenedPartialBlockChainPeaks, newBlockNums, newBlockForests, blockHasRelevantNotes, serializedNodeIds, serializedNodes, committedNoteIds, serializedInputNotes, serializedOutputNotes, accountUpdates, transactionUpdates, } = stateUpdate;
+    const { blockNum, flattenedNewBlockHeaders, flattenedPartialBlockChainPeaks, newBlockNums, blockHasRelevantNotes, serializedNodeIds, serializedNodes, committedNoteIds, serializedInputNotes, serializedOutputNotes, accountUpdates, transactionUpdates, } = stateUpdate;
     const newBlockHeaders = reconstructFlattenedVec(flattenedNewBlockHeaders);
     const partialBlockchainPeaks = reconstructFlattenedVec(flattenedPartialBlockChainPeaks);
     const tablesToAccess = [
@@ -128,7 +128,7 @@ export async function applyStateSync(dbId, stateUpdate) {
             updatePartialBlockchainNodes(tx, serializedNodeIds, serializedNodes),
             updateCommittedNoteTags(tx, committedNoteIds),
             Promise.all(newBlockHeaders.map((newBlockHeader, i) => {
-                return updateBlockHeader(tx, newBlockNums[i], newBlockHeader, partialBlockchainPeaks[i], newBlockForests[i], blockHasRelevantNotes[i] == 1);
+                return updateBlockHeader(tx, newBlockNums[i], newBlockHeader, partialBlockchainPeaks[i], blockHasRelevantNotes[i] == 1);
             })),
         ]);
     });
@@ -147,13 +147,12 @@ async function updateSyncHeight(tx, blockNum) {
         logWebStoreError(error, "Failed to update sync height");
     }
 }
-async function updateBlockHeader(tx, blockNum, blockHeader, partialBlockchainPeaks, forest, hasClientNotes) {
+async function updateBlockHeader(tx, blockNum, blockHeader, partialBlockchainPeaks, hasClientNotes) {
     try {
         const data = {
             blockNum: blockNum,
             header: blockHeader,
             partialBlockchainPeaks,
-            forest,
             hasClientNotes: hasClientNotes.toString(),
         };
         const existingBlockHeader = await tx.blockHeaders.get(blockNum);

--- a/crates/idxdb-store/src/sync/js_bindings.rs
+++ b/crates/idxdb-store/src/sync/js_bindings.rs
@@ -77,11 +77,6 @@ pub struct JsStateSyncUpdate {
     #[wasm_bindgen(js_name = "flattenedPartialBlockChainPeaks")]
     pub flattened_partial_blockchain_peaks: FlattenedU8Vec,
 
-    /// The forest (number of MMR leaves) at peak-capture time for each block.
-    /// Same length as `new_block_nums`.
-    #[wasm_bindgen(js_name = "newBlockForests")]
-    pub new_block_forests: Vec<u32>,
-
     /// For each block in this update, stores a boolean (as u8) indicating whether
     /// that block contains notes relevant to this client. Index i corresponds to
     /// the ith block, with 1 meaning relevant and 0 meaning not relevant.

--- a/crates/idxdb-store/src/sync/mod.rs
+++ b/crates/idxdb-store/src/sync/mod.rs
@@ -124,7 +124,6 @@ impl IdxdbStore {
             block_headers_as_bytes,
             new_mmr_peaks_as_bytes,
             block_nums,
-            block_forests,
             block_has_relevant_notes,
             serialized_node_ids,
             serialized_nodes,
@@ -199,7 +198,6 @@ impl IdxdbStore {
             flattened_new_block_headers: flatten_nested_u8_vec(block_headers_as_bytes),
             new_block_nums: block_nums,
             flattened_partial_blockchain_peaks: flatten_nested_u8_vec(new_mmr_peaks_as_bytes),
-            new_block_forests: block_forests,
             block_has_relevant_notes,
             serialized_node_ids,
             serialized_nodes,
@@ -230,15 +228,8 @@ impl IdxdbStore {
     }
 }
 
-type SerializedBlockData = (
-    Vec<Vec<u8>>,
-    Vec<Vec<u8>>,
-    Vec<u32>,
-    Vec<u32>,
-    Vec<u8>,
-    Vec<String>,
-    Vec<String>,
-);
+type SerializedBlockData =
+    (Vec<Vec<u8>>, Vec<Vec<u8>>, Vec<u32>, Vec<u8>, Vec<String>, Vec<String>);
 
 fn serialize_block_updates(
     block_updates: &BlockUpdates,
@@ -246,17 +237,12 @@ fn serialize_block_updates(
     let mut block_headers_as_bytes = Vec::new();
     let mut new_mmr_peaks_as_bytes = Vec::new();
     let mut block_nums = Vec::new();
-    let mut block_forests = Vec::new();
     let mut block_has_relevant_notes = Vec::new();
 
     for (block_header, has_client_notes, mmr_peaks) in block_updates.block_headers() {
         block_headers_as_bytes.push(block_header.to_bytes());
         new_mmr_peaks_as_bytes.push(mmr_peaks.peaks().to_vec().to_bytes());
         block_nums.push(block_header.block_num().as_u32());
-        block_forests.push(
-            u32::try_from(mmr_peaks.forest().num_leaves())
-                .expect("forest num_leaves should fit in u32"),
-        );
         block_has_relevant_notes.push(u8::from(*has_client_notes));
     }
 
@@ -274,7 +260,6 @@ fn serialize_block_updates(
         block_headers_as_bytes,
         new_mmr_peaks_as_bytes,
         block_nums,
-        block_forests,
         block_has_relevant_notes,
         serialized_node_ids,
         serialized_nodes,

--- a/crates/idxdb-store/src/ts/chainData.ts
+++ b/crates/idxdb-store/src/ts/chainData.ts
@@ -6,7 +6,6 @@ export async function insertBlockHeader(
   blockNum: number,
   header: Uint8Array,
   partialBlockchainPeaks: Uint8Array,
-  forest: number,
   hasClientNotes: boolean
 ) {
   try {
@@ -15,7 +14,6 @@ export async function insertBlockHeader(
       blockNum: blockNum,
       header,
       partialBlockchainPeaks,
-      forest,
       hasClientNotes: hasClientNotes.toString(),
     };
 
@@ -144,7 +142,6 @@ export async function getPartialBlockchainPeaksByBlockNum(
 
     return {
       peaks: partialBlockchainPeaksBase64,
-      forest: blockHeader.forest !== undefined ? blockHeader.forest : null,
     };
   } catch (err) {
     logWebStoreError(err, "Failed to get partial blockchain peaks");

--- a/crates/idxdb-store/src/ts/schema.ts
+++ b/crates/idxdb-store/src/ts/schema.ts
@@ -214,7 +214,6 @@ export interface IBlockHeader {
   blockNum: number;
   header: Uint8Array;
   partialBlockchainPeaks: Uint8Array;
-  forest?: number;
   hasClientNotes: string;
 }
 

--- a/crates/idxdb-store/src/ts/sync.ts
+++ b/crates/idxdb-store/src/ts/sync.ts
@@ -159,7 +159,6 @@ interface JsStateSyncUpdate {
   flattenedNewBlockHeaders: FlattenedU8Vec;
   flattenedPartialBlockChainPeaks: FlattenedU8Vec;
   newBlockNums: number[];
-  newBlockForests: number[];
   blockHasRelevantNotes: Uint8Array;
   serializedNodeIds: string[];
   serializedNodes: string[];
@@ -180,7 +179,6 @@ export async function applyStateSync(
     flattenedNewBlockHeaders,
     flattenedPartialBlockChainPeaks,
     newBlockNums,
-    newBlockForests,
     blockHasRelevantNotes,
     serializedNodeIds,
     serializedNodes,
@@ -307,7 +305,6 @@ export async function applyStateSync(
             newBlockNums[i],
             newBlockHeader,
             partialBlockchainPeaks[i],
-            newBlockForests[i],
             blockHasRelevantNotes[i] == 1
           );
         })
@@ -339,7 +336,6 @@ async function updateBlockHeader(
   blockNum: number,
   blockHeader: Uint8Array,
   partialBlockchainPeaks: Uint8Array,
-  forest: number,
   hasClientNotes: boolean
 ) {
   try {
@@ -347,7 +343,6 @@ async function updateBlockHeader(
       blockNum: blockNum,
       header: blockHeader,
       partialBlockchainPeaks,
-      forest,
       hasClientNotes: hasClientNotes.toString(),
     };
 

--- a/crates/rust-client/src/sync/state_sync_update.rs
+++ b/crates/rust-client/src/sync/state_sync_update.rs
@@ -120,6 +120,12 @@ impl BlockUpdates {
         peaks: MmrPeaks,
         new_authentication_nodes: Vec<(InOrderIndex, Word)>,
     ) {
+        debug_assert_eq!(
+            peaks.forest().num_leaves(),
+            block_header.block_num().as_usize(),
+            "MMR peaks stored for a block header must use that block number as the forest",
+        );
+
         self.block_headers
             .entry(block_header.block_num())
             .and_modify(|(_, existing_has_notes, _)| {


### PR DESCRIPTION
Simplifies #1997 by keeping MMR forest implicit which would be a bit less error prone (because we avoid separately handling it) and still is correct. 