### PR TITLE
chore(ci): replace deprecated actions-rs/toolchain with rustup update

### DIFF
--- a/.github/workflows/publish-web-client-next.yml
+++ b/.github/workflows/publish-web-client-next.yml
@@ -33,14 +33,8 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org/'
 
-      - name: Set up Rust and wasm target
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          target: wasm32-unknown-unknown
-          components: rust-src
+      - name: Install Rust toolchain
+        run: rustup update --no-self-update
 
       - name: Verify web-client version bump against next
         id: check_web_version

--- a/.github/workflows/publish-web-client-release.yml
+++ b/.github/workflows/publish-web-client-release.yml
@@ -23,14 +23,8 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org/'
 
-      - name: Set up Rust and wasm target
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          target: wasm32-unknown-unknown
-          components: rust-src
+      - name: Install Rust toolchain
+        run: rustup update --no-self-update
 
       - name: Ensure release tag has version bump
         id: check_version


### PR DESCRIPTION
## Description

Replace the deprecated and unmaintained `actions-rs/toolchain@v1` action with a simple `rustup update --no-self-update` call in the two web-client publish workflows:

- `publish-web-client-next.yml`
- `publish-web-client-release.yml`

This aligns these workflows with the pattern already used across all other CI workflows in this repo (`build.yml`, `web-docs-check.yml`, `publish-crates-dry-run.yml`, etc.). The `rust-toolchain.toml` already specifies the toolchain channel (`1.93`), profile, targets (`wasm32-unknown-unknown`), and components (`rust-src`, etc.), so the explicit `actions-rs/toolchain` configuration was redundant.

Closes 0xMiden/web-sdk#132