### PR TITLE
refactor: address add command takes AccountId and Address bech32

### DIFF
--- a/bin/miden-cli/src/commands/address.rs
+++ b/bin/miden-cli/src/commands/address.rs
@@ -39,11 +39,9 @@ impl From<CliAddressInterface> for AddressInterface {
 pub enum AddressSubCommand {
     /// List all addresses an account can be referenced by
     List { account_id: Option<String> },
-    /// Add a new address (encoded as a bech32 string) for the given account
+    /// Add a new address (encoded as a bech32 string)
     Add {
-        /// Account to add the address to
-        account_id: String,
-        /// Address encoded as a bech32 string
+        /// Address encoded as a bech32 string (embeds the account_id)
         address: String,
     },
     /// Remove the given address
@@ -79,8 +77,8 @@ impl AddressCmd {
                 let network_id = cli_config.rpc.endpoint.0.to_network_id();
                 list_account_addresses(client, account_id, network_id).await?;
             },
-            Some(AddressSubCommand::Add { account_id, address }) => {
-                add_address(client, account_id.clone(), address.clone()).await?;
+            Some(AddressSubCommand::Add { address }) => {
+                add_address(client, address.clone()).await?;
             },
             Some(AddressSubCommand::Encode { account_id, interface, tag_len }) => {
                 let cli_config = CliConfig::load()?;
@@ -153,22 +151,20 @@ async fn list_account_addresses<AUTH>(
 
 async fn add_address<AUTH>(
     mut client: Client<AUTH>,
-    account_id: String,
     address_str: String,
 ) -> Result<(), CliError> {
-    let account_id = parse_account_id(&client, &account_id).await?;
     let (_, address) =
         Address::decode(&address_str).map_err(|e| CliError::Address(e, address_str.clone()))?;
 
-    // Validate that the address belongs to the provided account_id
-    match address.id() {
-        AddressId::AccountId(addr_account_id) if addr_account_id == account_id => {},
+    // Extract the account_id from the address
+    let account_id = match address.id() {
+        AddressId::AccountId(addr_account_id) => addr_account_id,
         _ => {
             return Err(CliError::Input(format!(
-                "Address {address_str} does not belong to account {account_id}"
+                "Address {address_str} is not an ID-based address"
             )));
         },
-    }
+    };
 
     let note_tag = NoteTag::with_account_target(account_id);
     client.add_address(address, account_id).await?;

--- a/bin/miden-cli/src/commands/address.rs
+++ b/bin/miden-cli/src/commands/address.rs
@@ -39,14 +39,12 @@ impl From<CliAddressInterface> for AddressInterface {
 pub enum AddressSubCommand {
     /// List all addresses an account can be referenced by
     List { account_id: Option<String> },
-    /// Add a new address
+    /// Add a new address (encoded as a bech32 string) for the given account
     Add {
-        /// Account to add
+        /// Account to add the address to
         account_id: String,
-        /// Interface number for add/remove operations
-        interface: CliAddressInterface,
-        /// Optional tag length
-        tag_len: Option<u8>,
+        /// Address encoded as a bech32 string
+        address: String,
     },
     /// Remove the given address
     Remove {
@@ -54,6 +52,15 @@ pub enum AddressSubCommand {
         account_id: String,
         /// Address to remove
         address: String,
+    },
+    /// Encode an address from its components and print the bech32 string
+    Encode {
+        /// Account ID to encode the address for
+        account_id: String,
+        /// Interface for the address
+        interface: CliAddressInterface,
+        /// Optional tag length
+        tag_len: Option<u8>,
     },
 }
 
@@ -72,8 +79,13 @@ impl AddressCmd {
                 let network_id = cli_config.rpc.endpoint.0.to_network_id();
                 list_account_addresses(client, account_id, network_id).await?;
             },
-            Some(AddressSubCommand::Add { interface, account_id, tag_len }) => {
-                add_address(client, account_id.clone(), interface.clone(), *tag_len).await?;
+            Some(AddressSubCommand::Add { account_id, address }) => {
+                add_address(client, account_id.clone(), address.clone()).await?;
+            },
+            Some(AddressSubCommand::Encode { account_id, interface, tag_len }) => {
+                let cli_config = CliConfig::load()?;
+                let network_id = cli_config.rpc.endpoint.0.to_network_id();
+                encode_address(account_id, interface.clone(), *tag_len, network_id)?;
             },
             Some(AddressSubCommand::Remove { account_id, address }) => {
                 remove_address(client, account_id.clone(), address.clone()).await?;
@@ -142,11 +154,28 @@ async fn list_account_addresses<AUTH>(
 async fn add_address<AUTH>(
     mut client: Client<AUTH>,
     account_id: String,
-    interface: CliAddressInterface,
-    tag_len: Option<u8>,
+    address_str: String,
 ) -> Result<(), CliError> {
     let account_id = parse_account_id(&client, &account_id).await?;
-    let interface = interface.into();
+    let (_, address) =
+        Address::decode(&address_str).map_err(|e| CliError::Address(e, address_str))?;
+
+    let note_tag = NoteTag::with_account_target(account_id);
+    client.add_address(address, account_id).await?;
+
+    println!("Address added: Account Id {account_id} - Note tag: {note_tag}");
+    Ok(())
+}
+
+fn encode_address(
+    account_id: &str,
+    interface: CliAddressInterface,
+    tag_len: Option<u8>,
+    network_id: NetworkId,
+) -> Result<(), CliError> {
+    let account_id = miden_client::account::AccountId::from_hex(account_id)
+        .map_err(|e| CliError::Input(format!("Invalid account ID: {e}")))?;
+    let interface: AddressInterface = interface.into();
     let routing_params = match tag_len {
         Some(tag_len) => RoutingParameters::new(interface)
             .with_note_tag_len(tag_len)
@@ -154,11 +183,9 @@ async fn add_address<AUTH>(
         None => RoutingParameters::new(interface),
     };
     let address = Address::new(account_id).with_routing_parameters(routing_params);
+    let bech32 = address.encode(network_id);
 
-    let note_tag = NoteTag::with_account_target(account_id);
-    client.add_address(address, account_id).await?;
-
-    println!("Address added: Account Id {account_id} - Note tag: {note_tag}");
+    println!("{bech32}");
     Ok(())
 }
 

--- a/bin/miden-cli/src/commands/address.rs
+++ b/bin/miden-cli/src/commands/address.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use miden_client::Client;
-use miden_client::address::{Address, AddressInterface, NetworkId, RoutingParameters};
+use miden_client::address::{Address, AddressId, AddressInterface, NetworkId, RoutingParameters};
 use miden_client::note::NoteTag;
 
 use crate::config::CliConfig;
@@ -158,7 +158,17 @@ async fn add_address<AUTH>(
 ) -> Result<(), CliError> {
     let account_id = parse_account_id(&client, &account_id).await?;
     let (_, address) =
-        Address::decode(&address_str).map_err(|e| CliError::Address(e, address_str))?;
+        Address::decode(&address_str).map_err(|e| CliError::Address(e, address_str.clone()))?;
+
+    // Validate that the address belongs to the provided account_id
+    match address.id() {
+        AddressId::AccountId(addr_account_id) if addr_account_id == account_id => {},
+        _ => {
+            return Err(CliError::Input(format!(
+                "Address {address_str} does not belong to account {account_id}"
+            )));
+        },
+    }
 
     let note_tag = NoteTag::with_account_target(account_id);
     client.add_address(address, account_id).await?;

--- a/docs/external/src/rust-client/cli/index.md
+++ b/docs/external/src/rust-client/cli/index.md
@@ -307,13 +307,10 @@ The `list` subcommand optionally takes an account ID to only show the addresses 
 miden-client address list 0x17f13f4f83a8e8100c19d2961dfda2
 ```
 
-`add` and `remove` take the account ID as a mandatory argument, and also the interface of the address, this values can be:
-- `BasicWallet`: The basic wallet interface.
-
-Note: the `Unspecified` denotes an address not bound to any interface, it's the default address for every account created.
+`add` takes a bech32-encoded address string (which embeds the account ID), and `remove` takes the account ID and address. For example:
 
 ```sh
-miden-client address add 0x17f13f4f83a8e8100c19d2961dfda2 BasicWallet 10
+miden-client address add mlcl1qple0ejnutx8zyp0cm0pme9wjfgqz0u9djq
 ```
 
 ```sh


### PR DESCRIPTION
## Description

Refactor the `address add` CLI subcommand to accept an `AccountId` and a bech32-encoded `Address` string instead of building the address from interface and tag_len parameters.

Add a new `address encode` utility subcommand that constructs an Address from its components (account_id, interface, optional tag_len) and prints the bech32 string, preserving the old construction workflow.

### Changes

- **`address add <account_id> <address>`**: Now takes a bech32-encoded address string directly instead of interface + tag_len
- **`address encode <account_id> <interface> [tag_len]`**: New utility subcommand that constructs an address from fields and prints the bech32 encoding

### Motivation

As discussed in [#1367 (comment)](https://github.com/0xMiden/miden-client/pull/1367#issuecomment-3444198601), this improves UX by separating address construction from address registration. Users can:
1. Use `address encode` to build addresses from components
2. Use `address add` to register pre-built bech32 addresses

Closes #1432