### PR TITLE
fix: make source manager handling more consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 * [FIX][web] Fixed `syncState` failure ("inconsistent partial mmr: tracked leaf at position N has no value in nodes") caused by skipping authentication node collection for blocks already tracked from the MMR delta during large catch-up syncs. Authentication nodes are now always collected for note-relevant blocks regardless of prior tracking state. ([#1997](https://github.com/0xMiden/miden-client/pull/1997)).
+* [FIX][rust] Made source manager handling consistent when building transaction scripts. The empty fallback script is now compiled against the client's source manager instead of a fresh one, so any source information on the produced `TransactionScript` is registered with the same source manager used by the executor ([#2006](https://github.com/0xMiden/miden-client/pull/2006)).
 
 ## 0.14.0 (2026-04-07)
 

--- a/bin/integration-tests/src/tests/client.rs
+++ b/bin/integration-tests/src/tests/client.rs
@@ -14,7 +14,7 @@ use miden_client::account::{
     StorageSlot,
     StorageSlotName,
 };
-use miden_client::assembly::{CodeBuilder, DefaultSourceManager, Module, ModuleKind, Path};
+use miden_client::assembly::CodeBuilder;
 use miden_client::asset::{Asset, FungibleAsset};
 use miden_client::auth::{AuthSchemeId, AuthSecretKey, AuthSingleSig, RPO_FALCON_SCHEME_ID};
 use miden_client::builder::ClientBuilder;
@@ -39,7 +39,6 @@ use miden_client::transaction::{
     PaymentNoteDescription,
     ProvenTransaction,
     TransactionInputs,
-    TransactionKernel,
     TransactionProver,
     TransactionProverError,
     TransactionRequestBuilder,
@@ -1368,15 +1367,8 @@ pub async fn test_unused_rpc_api(client_config: ClientConfig) -> Result<()> {
 
     client.sync_state().await.unwrap();
 
-    let assembler = TransactionKernel::assembler();
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let module = Module::parser(ModuleKind::Library)
-        .parse_str(Path::new("custom_library::set_map_item_library"), custom_code, source_manager)
-        .unwrap();
-    let custom_lib = assembler.assemble_library([module]).unwrap();
-
     let tx_script = CodeBuilder::new()
-        .with_statically_linked_library(&custom_lib)?
+        .with_linked_module("custom_library::set_map_item_library", custom_code)?
         .compile_tx_script(
             "
         use custom_library::set_map_item_library

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -295,8 +295,10 @@ where
         let future_notes: Vec<(NoteDetails, NoteTag)> =
             transaction_request.expected_future_notes().cloned().collect();
 
-        let tx_script = transaction_request
-            .build_transaction_script(&self.get_account_interface(account_id).await?)?;
+        let tx_script = transaction_request.build_transaction_script(
+            &self.get_account_interface(account_id).await?,
+            self.source_manager.clone(),
+        )?;
 
         let foreign_accounts = transaction_request.foreign_accounts().clone();
 

--- a/crates/rust-client/src/transaction/request/mod.rs
+++ b/crates/rust-client/src/transaction/request/mod.rs
@@ -3,11 +3,14 @@
 use alloc::boxed::Box;
 use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::string::{String, ToString};
+use alloc::sync::Arc;
 use alloc::vec::Vec;
 
 use miden_protocol::Word;
 use miden_protocol::account::AccountId;
+use miden_protocol::assembly::SourceManagerSync;
 use miden_protocol::asset::{Asset, NonFungibleAsset};
+use miden_protocol::assembly::SourceManagerSync;
 use miden_protocol::crypto::merkle::MerkleError;
 use miden_protocol::crypto::merkle::store::MerkleStore;
 use miden_protocol::errors::{
@@ -314,9 +317,17 @@ impl TransactionRequest {
 
     /// Builds the transaction script based on the account capabilities and the transaction request.
     /// The debug mode enables the script debug logs.
+    ///
+    /// The provided `source_manager` is used when compiling scripts owned by the request (currently
+    /// the empty fallback script) so that any source information attached to the produced
+    /// [`TransactionScript`] is registered in the same source manager used by the executor. Scripts
+    /// supplied by the caller via [`TransactionScriptTemplate::CustomScript`] are expected to have
+    /// already been compiled against the client's source manager (e.g. via
+    /// [`Client::code_builder`](crate::Client::code_builder)).
     pub(crate) fn build_transaction_script(
         &self,
         account_interface: &AccountInterface,
+        source_manager: Arc<dyn SourceManagerSync>,
     ) -> Result<TransactionScript, TransactionRequestError> {
         match &self.script_template {
             Some(TransactionScriptTemplate::CustomScript(script)) => Ok(script.clone()),
@@ -324,7 +335,8 @@ impl TransactionRequest {
                 Ok(account_interface.build_send_notes_script(notes, self.expiration_delta)?)
             },
             None => {
-                let empty_script = CodeBuilder::new().compile_tx_script("begin nop end")?;
+                let empty_script = CodeBuilder::with_source_manager(source_manager)
+                    .compile_tx_script("begin nop end")?;
 
                 Ok(empty_script)
             },

--- a/crates/rust-client/src/transaction/request/mod.rs
+++ b/crates/rust-client/src/transaction/request/mod.rs
@@ -331,6 +331,8 @@ impl TransactionRequest {
         match &self.script_template {
             Some(TransactionScriptTemplate::CustomScript(script)) => Ok(script.clone()),
             Some(TransactionScriptTemplate::SendNotes(notes)) => {
+                // TODO: We could pass `SourceManager` to this call, but it needs to be supported
+                // in the protocol struct (however, this should also not fail to build often)
                 Ok(account_interface.build_send_notes_script(notes, self.expiration_delta)?)
             },
             None => {

--- a/crates/rust-client/src/transaction/request/mod.rs
+++ b/crates/rust-client/src/transaction/request/mod.rs
@@ -10,7 +10,6 @@ use miden_protocol::Word;
 use miden_protocol::account::AccountId;
 use miden_protocol::assembly::SourceManagerSync;
 use miden_protocol::asset::{Asset, NonFungibleAsset};
-use miden_protocol::assembly::SourceManagerSync;
 use miden_protocol::crypto::merkle::MerkleError;
 use miden_protocol::crypto::merkle::store::MerkleStore;
 use miden_protocol::errors::{

--- a/crates/testing/miden-client-tests/src/tests.rs
+++ b/crates/testing/miden-client-tests/src/tests.rs
@@ -8,14 +8,7 @@ use std::sync::Arc;
 
 use miden_client::account::{Address, AddressInterface};
 use miden_client::address::RoutingParameters;
-use miden_client::assembly::{
-    Assembler,
-    CodeBuilder,
-    DefaultSourceManager,
-    Module,
-    ModuleKind,
-    Path,
-};
+use miden_client::assembly::CodeBuilder;
 use miden_client::auth::{
     AuthSchemeId,
     AuthSecretKey,
@@ -104,7 +97,7 @@ use miden_protocol::testing::account_id::{
     ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE,
     ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE,
 };
-use miden_protocol::transaction::{RawOutputNote, TransactionKernel};
+use miden_protocol::transaction::RawOutputNote;
 use miden_protocol::vm::AdviceInputs;
 use miden_protocol::{EMPTY_WORD, Felt, ONE, Word};
 use miden_standards::account::faucets::BasicFungibleFaucet;
@@ -2559,18 +2552,11 @@ async fn storage_and_vault_proofs() {
     .unwrap();
 
     // Build script that bumps the storage map item and adds a new one each time.
-    let assembler: Assembler = TransactionKernel::assembler();
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let module = Module::parser(ModuleKind::Library)
-        .parse_str(
-            Path::new("external_contract::bump_item_contract"),
-            BUMP_MAP_CODE.replace("{map_key}", &Word::from(MAP_KEY).to_hex()),
-            source_manager.clone(),
-        )
-        .unwrap();
-    let library = assembler.assemble_library([module]).unwrap();
     let tx_script = CodeBuilder::new()
-        .with_dynamically_linked_library(library)
+        .with_linked_module(
+            "external_contract::bump_item_contract",
+            BUMP_MAP_CODE.replace("{map_key}", &Word::from(MAP_KEY).to_hex()),
+        )
         .unwrap()
         .compile_tx_script(
             "use external_contract::bump_item_contract
@@ -3285,18 +3271,11 @@ async fn storage_and_vault_proofs_ecdsa() {
     .unwrap();
 
     // Build script that bumps the storage map item and adds a new one each time.
-    let assembler: Assembler = TransactionKernel::assembler();
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let module = Module::parser(ModuleKind::Library)
-        .parse_str(
-            Path::new("external_contract::bump_item_contract"),
-            BUMP_MAP_CODE.replace("{map_key}", &Word::from(MAP_KEY).to_hex()),
-            source_manager.clone(),
-        )
-        .unwrap();
-    let library = assembler.clone().assemble_library([module]).unwrap();
     let tx_script = CodeBuilder::new()
-        .with_dynamically_linked_library(&library)
+        .with_linked_module(
+            "external_contract::bump_item_contract",
+            BUMP_MAP_CODE.replace("{map_key}", &Word::from(MAP_KEY).to_hex()),
+        )
         .unwrap()
         .compile_tx_script(
             "use external_contract::bump_item_contract


### PR DESCRIPTION
Makes `SourceManager` handling a bit more consistent in light of the error handling panics from `miden-vm` (https://github.com/0xMiden/miden-vm/issues/2986). The main change is building internal transaction scripts with the client-held `SourceManager`.