### PR TITLE
docs: add NoteScreener documentation

### DIFF
--- a/bin/miden-cli/src/commands/address.rs
+++ b/bin/miden-cli/src/commands/address.rs
@@ -39,14 +39,12 @@ impl From<CliAddressInterface> for AddressInterface {
 pub enum AddressSubCommand {
     /// List all addresses an account can be referenced by
     List { account_id: Option<String> },
-    /// Add a new address
+    /// Add a new address (encoded as a bech32 string) for the given account
     Add {
-        /// Account to add
+        /// Account to add the address to
         account_id: String,
-        /// Interface number for add/remove operations
-        interface: CliAddressInterface,
-        /// Optional tag length
-        tag_len: Option<u8>,
+        /// Address encoded as a bech32 string
+        address: String,
     },
     /// Remove the given address
     Remove {
@@ -54,6 +52,15 @@ pub enum AddressSubCommand {
         account_id: String,
         /// Address to remove
         address: String,
+    },
+    /// Encode an address from its components and print the bech32 string
+    Encode {
+        /// Account ID to encode the address for
+        account_id: String,
+        /// Interface for the address
+        interface: CliAddressInterface,
+        /// Optional tag length
+        tag_len: Option<u8>,
     },
 }
 
@@ -72,8 +79,13 @@ impl AddressCmd {
                 let network_id = cli_config.rpc.endpoint.0.to_network_id();
                 list_account_addresses(client, account_id, network_id).await?;
             },
-            Some(AddressSubCommand::Add { interface, account_id, tag_len }) => {
-                add_address(client, account_id.clone(), interface.clone(), *tag_len).await?;
+            Some(AddressSubCommand::Add { account_id, address }) => {
+                add_address(client, account_id.clone(), address.clone()).await?;
+            },
+            Some(AddressSubCommand::Encode { account_id, interface, tag_len }) => {
+                let cli_config = CliConfig::load()?;
+                let network_id = cli_config.rpc.endpoint.0.to_network_id();
+                encode_address(account_id, interface.clone(), *tag_len, network_id)?;
             },
             Some(AddressSubCommand::Remove { account_id, address }) => {
                 remove_address(client, account_id.clone(), address.clone()).await?;
@@ -142,11 +154,28 @@ async fn list_account_addresses<AUTH>(
 async fn add_address<AUTH>(
     mut client: Client<AUTH>,
     account_id: String,
-    interface: CliAddressInterface,
-    tag_len: Option<u8>,
+    address_str: String,
 ) -> Result<(), CliError> {
     let account_id = parse_account_id(&client, &account_id).await?;
-    let interface = interface.into();
+    let (_, address) =
+        Address::decode(&address_str).map_err(|e| CliError::Address(e, address_str))?;
+
+    let note_tag = NoteTag::with_account_target(account_id);
+    client.add_address(address, account_id).await?;
+
+    println!("Address added: Account Id {account_id} - Note tag: {note_tag}");
+    Ok(())
+}
+
+fn encode_address(
+    account_id: &str,
+    interface: CliAddressInterface,
+    tag_len: Option<u8>,
+    network_id: NetworkId,
+) -> Result<(), CliError> {
+    let account_id = miden_client::account::AccountId::from_hex(account_id)
+        .map_err(|e| CliError::Input(format!("Invalid account ID: {e}")))?;
+    let interface: AddressInterface = interface.into();
     let routing_params = match tag_len {
         Some(tag_len) => RoutingParameters::new(interface)
             .with_note_tag_len(tag_len)
@@ -154,11 +183,9 @@ async fn add_address<AUTH>(
         None => RoutingParameters::new(interface),
     };
     let address = Address::new(account_id).with_routing_parameters(routing_params);
+    let bech32 = address.encode(network_id);
 
-    let note_tag = NoteTag::with_account_target(account_id);
-    client.add_address(address, account_id).await?;
-
-    println!("Address added: Account Id {account_id} - Note tag: {note_tag}");
+    println!("{bech32}");
     Ok(())
 }
 

--- a/bin/miden-cli/tests/cli.rs
+++ b/bin/miden-cli/tests/cli.rs
@@ -788,17 +788,18 @@ async fn list_addresses_add() -> Result<()> {
     assert!(!formatted_output.contains("BasicWallet"));
 
     // Add a basic wallet address to the account
-    let mut add_address_cmd = cargo_bin_cmd!("miden-client");
     let custom_note_tag_len = "10";
-    add_address_cmd.args([
-        "address",
-        "add",
-        &basic_account_id,
-        &AddressInterface::BasicWallet.to_string(),
-        custom_note_tag_len,
-    ]);
+    let basic_wallet_address =
+        encode_address_cli(&temp_dir, &basic_account_id, custom_note_tag_len);
+    let mut add_address_cmd = cargo_bin_cmd!("miden-client");
+    add_address_cmd.args(["address", "add", &basic_account_id, &basic_wallet_address]);
     let output = add_address_cmd.current_dir(temp_dir.clone()).output().unwrap();
-    assert!(output.status.success());
+    assert!(
+        output.status.success(),
+        "address add failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 
     // List of addresses for created account should now contain a BasicWallet address
     sync_cli(&temp_dir);
@@ -810,17 +811,18 @@ async fn list_addresses_add() -> Result<()> {
     assert_eq!(formatted_output.matches("BasicWallet").count(), 1);
 
     // Add another basic wallet address to the account
-    let mut add_address_cmd = cargo_bin_cmd!("miden-client");
     let custom_note_tag_len = "5";
-    add_address_cmd.args([
-        "address",
-        "add",
-        &basic_account_id,
-        &AddressInterface::BasicWallet.to_string(),
-        custom_note_tag_len,
-    ]);
+    let basic_wallet_address =
+        encode_address_cli(&temp_dir, &basic_account_id, custom_note_tag_len);
+    let mut add_address_cmd = cargo_bin_cmd!("miden-client");
+    add_address_cmd.args(["address", "add", &basic_account_id, &basic_wallet_address]);
     let output = add_address_cmd.current_dir(temp_dir.clone()).output().unwrap();
-    assert!(output.status.success());
+    assert!(
+        output.status.success(),
+        "address add failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 
     // List of addresses for created account should now contain two BasicWallet addresses
     sync_cli(&temp_dir);
@@ -1009,6 +1011,27 @@ fn sync_cli(cli_path: &Path) -> SyncResult {
         }
         std::thread::sleep(std::time::Duration::from_secs(3));
     }
+}
+
+fn encode_address_cli(cli_path: &Path, account_id: &str, tag_len: &str) -> String {
+    let mut encode_address_cmd = cargo_bin_cmd!("miden-client");
+    encode_address_cmd.args([
+        "address",
+        "encode",
+        account_id,
+        &AddressInterface::BasicWallet.to_string(),
+        tag_len,
+    ]);
+
+    let output = encode_address_cmd.current_dir(cli_path).output().unwrap();
+    assert!(
+        output.status.success(),
+        "address encode failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    String::from_utf8(output.stdout).unwrap().trim().to_string()
 }
 
 /// Mints 100 units of the corresponding faucet using the cli and checks that the command runs

--- a/docs/external/src/rust-client/cli/index.md
+++ b/docs/external/src/rust-client/cli/index.md
@@ -298,7 +298,8 @@ View and manage addresses.
 | Subcommand                       | Description                                                                            |
 | -------------------------------- | ---------------------------------------------------------------------------------------|
 | `list <ID>`                      | List all addresses or only for the specified account ID (default command)              |
-| `add <ID> <INTERFACE> <TAG_LEN>` | Bind an address for an interface for the specified account ID with optional tag length |
+| `add <ID> <ADDRESS>`             | Bind an encoded address to the specified account ID                                    |
+| `encode <ID> <INTERFACE> [TAG_LEN]` | Encode an address for the specified account ID                                      |
 | `remove <ID> <ADDRESS>`          | Remove an address for the specified account ID                                         |
 
 The `list` subcommand optionally takes an account ID to only show the addresses of that account, if it is not provided, it will show all addresses of all accounts.
@@ -307,13 +308,16 @@ The `list` subcommand optionally takes an account ID to only show the addresses 
 miden-client address list 0x17f13f4f83a8e8100c19d2961dfda2
 ```
 
-`add` and `remove` take the account ID as a mandatory argument, and also the interface of the address, this values can be:
+`encode` takes the account ID and address interface as mandatory arguments, with an optional tag length. The supported interfaces are:
 - `BasicWallet`: The basic wallet interface.
+
+`add` and `remove` take the account ID and encoded address as mandatory arguments.
 
 Note: the `Unspecified` denotes an address not bound to any interface, it's the default address for every account created.
 
 ```sh
-miden-client address add 0x17f13f4f83a8e8100c19d2961dfda2 BasicWallet 10
+miden-client address encode 0x17f13f4f83a8e8100c19d2961dfda2 BasicWallet 10
+miden-client address add 0x17f13f4f83a8e8100c19d2961dfda2 mlcl1qple0ejnutx8zyp0cm0pme9wjfgqz0u9djq
 ```
 
 ```sh

--- a/docs/external/src/rust-client/design.md
+++ b/docs/external/src/rust-client/design.md
@@ -55,9 +55,49 @@ These private keys are used by the executor to sign and authenticate transaction
 
 ## Note Screener
 
-The note screener is used to check the consumability of notes by tracked accounts. It performs fast static checks (e.g. checking the inputs for well known notes) and also dry runs of consumption transactions.
+The note screener determines which notes are relevant to the client by checking whether any tracked account can consume them. It does this by performing dry runs of consumption transactions using the `NoteConsumptionChecker` from the `miden-tx` crate internally.
 
-It can find the tracked accounts that can consume a note, and whether the note can be consumed at the moment or in the future.
+### Core functionality
+
+The `NoteScreener` is constructed with a reference to the client's store and RPC client:
+
+```rust
+let screener = NoteScreener::new(store, rpc_api);
+```
+
+It provides three main methods:
+
+- **`can_consume(note)`**: Checks whether any tracked account can consume a single note. Returns a list of `(AccountId, NoteConsumptionStatus)` pairs for each account that could consume it.
+- **`can_consume_batch(notes)`**: Checks a batch of notes against all tracked accounts. Returns a map from `NoteId` to the list of accounts that can consume each note.
+- **`check_notes_consumability(account_id, notes)`**: Checks a set of notes against a specific account by attempting to execute them together. Returns a `NoteConsumptionInfo` that splits notes into those that succeeded and those that failed.
+
+### Transaction arguments
+
+The screener supports an optional builder method for providing custom transaction arguments:
+
+```rust
+let screener = NoteScreener::new(store, rpc_api)
+    .with_transaction_args(tx_args);
+```
+
+If not set, the screener uses default `TransactionArgs` with an empty advice map.
+
+### Sync integration
+
+The `NoteScreener` implements the `OnNoteReceived` trait, which serves as a callback during state sync. When the client syncs with the network and receives note commitment updates, this callback determines what to do with each note:
+
+- If the note is already tracked (as an input or output note), it is committed.
+- If the note is public and matches a tracked note tag, it is inserted.
+- If the note is public and untracked, the screener checks its consumability — if any tracked account can consume it, the note is inserted; otherwise it is discarded.
+- If the note is private and untracked, it is discarded since its contents cannot be inspected.
+
+The callback returns a `NoteUpdateAction` enum (`Commit`, `Insert`, or `Discard`) that instructs the sync component on how to handle the note.
+
+Custom implementations of `OnNoteReceived` can be provided to the `StateSync` component to override this default behavior.
+
+### Security note
+
+During consumability checks, the screener deliberately does **not** attach a real authenticator to the transaction executor. This prevents external signers (e.g. wallet extensions) from being invoked during sync, which would produce unwanted confirmation popups. The `NoteConsumptionChecker` handles the missing authenticator gracefully by returning `ConsumableWithAuthorization` instead of calling `get_signature()`.
 
 ## State Sync component
 

--- a/docs/external/src/rust-client/library.md
+++ b/docs/external/src/rust-client/library.md
@@ -137,3 +137,57 @@ client.submit_transaction(transaction_execution_result).await?
 
 You can decide whether you want the note details to be public or private through the `note_type` parameter.
 You may also customize the transaction request with the other `TransactionRequestBuilder` methods. This allows you to run custom code, with custom note arguments and additional output/input notes as well.
+
+## Note screening
+
+The `NoteScreener` lets you check whether notes can be consumed by the accounts tracked in the client's store.
+
+### Checking a single note
+
+```rust
+use miden_client::note::NoteScreener;
+
+let screener = NoteScreener::new(store.clone(), rpc_api.clone());
+let consumability = screener.can_consume(&note).await?;
+
+for (account_id, status) in &consumability {
+    println!("Account {} can consume note: {:?}", account_id, status);
+}
+```
+
+### Batch checking
+
+For multiple notes, use `can_consume_batch` to check all notes against all tracked accounts at once:
+
+```rust
+let screener = NoteScreener::new(store.clone(), rpc_api.clone());
+let results = screener.can_consume_batch(&notes).await?;
+
+for (note_id, consumabilities) in &results {
+    for (account_id, status) in consumabilities {
+        println!("Note {} consumable by {}: {:?}", note_id, account_id, status);
+    }
+}
+```
+
+### Checking against a specific account
+
+To check which notes a specific account can consume together:
+
+```rust
+let screener = NoteScreener::new(store.clone(), rpc_api.clone());
+let info = screener.check_notes_consumability(account_id, notes).await?;
+
+// `info` contains which notes succeeded and which failed
+```
+
+### Providing custom transaction arguments
+
+If your notes require specific advice inputs for consumption, provide custom `TransactionArgs`:
+
+```rust
+let screener = NoteScreener::new(store.clone(), rpc_api.clone())
+    .with_transaction_args(tx_args);
+
+let consumability = screener.can_consume(&note).await?;
+```


### PR DESCRIPTION
## Summary

Adds comprehensive documentation for the \NoteScreener\ component.

### Changes

**design.md** — Expanded the Note Screener section with:
- Core methods (\can_consume\, \can_consume_batch\, \check_notes_consumability\)
- Transaction arguments builder pattern (\with_transaction_args\)
- \OnNoteReceived\ trait integration with the sync component
- Security note about authenticator handling during screening

**library.md** — Added a new 'Note screening' section with usage examples for:
- Single note consumability checking
- Batch checking across all tracked accounts
- Per-account consumability checks
- Providing custom transaction arguments

Closes #2000