### PR TITLE
fix(keystore): write index atomically via tempfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,7 @@
 ### Fixes
 
 * [FIX][web] Fixed `syncState` failure ("inconsistent partial mmr: tracked leaf at position N has no value in nodes") caused by skipping authentication node collection for blocks already tracked from the MMR delta during large catch-up syncs. Authentication nodes are now always collected for note-relevant blocks regardless of prior tracking state. ([#1997](https://github.com/0xMiden/miden-client/pull/1997)).
-
-### Fixes
-
-* [FIX][rust] Fixed `FilesystemKeyStore::add_key` failing on Linux when the system temp dir is on a different filesystem than the keys directory ([#2002](https://github.com/0xMiden/miden-client/issues/2002)).
+* [FIX][rust] Fixed `FilesystemKeyStore::add_key` failing on Linux when the system temp dir is on a different filesystem than the keys directory ([#2009](https://github.com/0xMiden/miden-client/pull/2009)).
 
 ## 0.14.0 (2026-04-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [FIX][web] Fixed `syncState` failure ("inconsistent partial mmr: tracked leaf at position N has no value in nodes") caused by skipping authentication node collection for blocks already tracked from the MMR delta during large catch-up syncs. Authentication nodes are now always collected for note-relevant blocks regardless of prior tracking state. ([#1997](https://github.com/0xMiden/miden-client/pull/1997)).
 
+### Fixes
+
+* [FIX][rust] Fixed `FilesystemKeyStore::add_key` failing on Linux when the system temp dir is on a different filesystem than the keys directory ([#2002](https://github.com/0xMiden/miden-client/issues/2002)).
+
 ## 0.14.0 (2026-04-07)
 
 ### Enhancements

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2940,6 +2940,7 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,6 @@ hex         = { version = "0.4" }
 miette      = { features = ["fancy"], version = "7.6" }
 rand        = { version = "0.9" }
 serde       = { features = ["derive"], version = "1.0" }
-tempfile    = { version = "3.0" }
 thiserror   = { default-features = false, version = "2.0" }
 tokio       = { features = ["macros", "rt-multi-thread"], version = "1.48" }
 tracing     = { version = "0.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ hex         = { version = "0.4" }
 miette      = { features = ["fancy"], version = "7.6" }
 rand        = { version = "0.9" }
 serde       = { features = ["derive"], version = "1.0" }
+tempfile    = { version = "3.0" }
 thiserror   = { default-features = false, version = "2.0" }
 tokio       = { features = ["macros", "rt-multi-thread"], version = "1.48" }
 tracing     = { version = "0.1" }

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -58,7 +58,7 @@ prost-types  = { version = "0.14" }
 rand         = { workspace = true }
 serde        = { workspace = true }
 serde_json   = { version = "1.0" }
-tempfile     = { optional = true, workspace = true }
+tempfile     = { optional = true, version = "3.0" }
 thiserror    = { workspace = true }
 tokio        = { features = ["time"], optional = true, workspace = true }
 tonic        = { default-features = false, features = ["codegen"], version = "0.14" }

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -26,6 +26,7 @@ crate-type = ["lib"]
 [features]
 default = ["std"]
 std = [
+  "dep:tempfile",
   "dep:tokio",
   "miden-protocol/std",
   "miden-remote-prover-client/std",
@@ -57,6 +58,7 @@ prost-types  = { version = "0.14" }
 rand         = { workspace = true }
 serde        = { workspace = true }
 serde_json   = { version = "1.0" }
+tempfile     = { optional = true, workspace = true }
 thiserror    = { workspace = true }
 tokio        = { features = ["time"], optional = true, workspace = true }
 tonic        = { default-features = false, features = ["codegen"], version = "0.14" }

--- a/crates/rust-client/src/keystore/fs_keystore.rs
+++ b/crates/rust-client/src/keystore/fs_keystore.rs
@@ -85,8 +85,7 @@ impl KeyIndex {
         })?;
 
         // Create the temp file in the same directory as the index so the subsequent atomic
-        // rename stays on the same filesystem (e.g. on Linux, `std::env::temp_dir()` is often
-        // a tmpfs mount, which would make a cross-device rename fail).
+        // rename stays on the same filesystem.
         let mut temp_file = tempfile::NamedTempFile::new_in(keys_directory)
             .map_err(keystore_error("error creating temp index file"))?;
         temp_file

--- a/crates/rust-client/src/keystore/fs_keystore.rs
+++ b/crates/rust-client/src/keystore/fs_keystore.rs
@@ -79,21 +79,30 @@ impl KeyIndex {
     /// Saves the index to disk atomically (write to temp file, then rename).
     fn write_to_file(&self, keys_directory: &Path) -> Result<(), KeyStoreError> {
         let index_path = keys_directory.join(INDEX_FILE_NAME);
-        let temp_path = std::env::temp_dir().join(INDEX_FILE_NAME);
 
         let contents = serde_json::to_string_pretty(self).map_err(|err| {
             KeyStoreError::StorageError(format!("error serializing index: {err:?}"))
         })?;
 
-        // Write to temp file
-        let mut file = fs::File::create(&temp_path)
+        // Create the temp file in the same directory as the index so the subsequent atomic
+        // rename stays on the same filesystem (e.g. on Linux, `std::env::temp_dir()` is often
+        // a tmpfs mount, which would make a cross-device rename fail).
+        let mut temp_file = tempfile::NamedTempFile::new_in(keys_directory)
             .map_err(keystore_error("error creating temp index file"))?;
-        file.write_all(contents.as_bytes())
+        temp_file
+            .write_all(contents.as_bytes())
             .map_err(keystore_error("error writing temp index file"))?;
-        file.sync_all().map_err(keystore_error("error syncing temp index file"))?;
+        temp_file
+            .as_file()
+            .sync_all()
+            .map_err(keystore_error("error syncing temp index file"))?;
 
-        // Atomically rename
-        fs::rename(&temp_path, &index_path).map_err(keystore_error("error renaming index file"))
+        // Atomically replace the index file.
+        temp_file
+            .persist(&index_path)
+            .map_err(|err| keystore_error("error renaming index file")(err.error))?;
+
+        Ok(())
     }
 
     /// Returns the account ID associated with a given public key commitment hex.

--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -429,6 +429,12 @@ where
     pub fn authenticator(&self) -> Option<&Arc<AUTH>> {
         self.authenticator.as_ref()
     }
+
+    /// Returns the shared source manager used to retain MASM source information for assembled
+    /// programs.
+    pub fn source_manager(&self) -> Arc<dyn SourceManagerSync> {
+        self.source_manager.clone()
+    }
 }
 
 impl<AUTH> Client<AUTH> {


### PR DESCRIPTION
- Fixes `add_key` failing on Linux when the system temp dir and keys directory are on different filesystems
- Removes a race where concurrent `add_key` calls could clobber each other's temp file
- Avoids leaving orphan temp files behind when a write fails partway through

Ended up using `tempfile` to simplify some things (makes it crash-safe, avoid unique naming, etc.) as opposed to using the approach in #2002.

Closes #2002