### PR TITLE
fix(web-client): use NoteArray in send({ returnNote: true }) + bump to 0.14.1

### DIFF
--- a/.github/workflows/publish-web-client-next.yml
+++ b/.github/workflows/publish-web-client-next.yml
@@ -81,7 +81,7 @@ jobs:
         if: steps.check_react_version.outputs.should_publish == 'true'
         run: |
           cd packages/react-sdk
-          yarn install --frozen-lockfile
+          yarn install
           yarn build
 
       - name: Publish react-sdk to npm

--- a/.github/workflows/publish-web-client-release.yml
+++ b/.github/workflows/publish-web-client-release.yml
@@ -32,12 +32,16 @@ jobs:
           target: wasm32-unknown-unknown
           components: rust-src
 
-      - name: Ensure release tag has version bump
+      - name: Ensure release tag has web-client version bump
         id: check_version
         run: ./scripts/check-web-client-version-release.sh "$GITHUB_SHA"
 
+      - name: Ensure release tag has react-sdk version bump
+        id: check_react_version
+        run: ./scripts/check-react-sdk-version-release.sh "$GITHUB_SHA"
+
       - name: Install & build web-client
-        if: steps.check_version.outputs.should_publish == 'true'
+        if: steps.check_version.outputs.should_publish == 'true' || steps.check_react_version.outputs.should_publish == 'true'
         run: |
           cd crates/web-client
           yarn install --frozen-lockfile
@@ -55,7 +59,7 @@ jobs:
             exit 1
           fi
 
-      - name: Publish to npm
+      - name: Publish web-client to npm
         if: steps.check_version.outputs.should_publish == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_WEBCLIENT_TOKEN }}
@@ -63,19 +67,51 @@ jobs:
           cd crates/web-client
           npm publish
 
-      - name: Done
+      - name: Install & build react-sdk
+        if: steps.check_react_version.outputs.should_publish == 'true'
+        run: |
+          cd packages/react-sdk
+          yarn install --frozen-lockfile
+          yarn build
+
+      - name: Publish react-sdk to npm
+        if: steps.check_react_version.outputs.should_publish == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_WEBCLIENT_TOKEN }}
+        run: |
+          cd packages/react-sdk
+          npm publish
+
+      - name: Done (web-client)
         if: steps.check_version.outputs.should_publish == 'true'
         env:
           CURRENT_VERSION: ${{ steps.check_version.outputs.current_version }}
-        run: echo "✅ Build complete; published version $CURRENT_VERSION."
+        run: echo "✅ Web-client published version $CURRENT_VERSION."
 
-      - name: Skipped publish
+      - name: Done (react-sdk)
+        if: steps.check_react_version.outputs.should_publish == 'true'
+        env:
+          CURRENT_VERSION: ${{ steps.check_react_version.outputs.current_version }}
+        run: echo "✅ React SDK published version $CURRENT_VERSION."
+
+      - name: Skipped publish (web-client)
         if: steps.check_version.outputs.should_publish != 'true'
         env:
           SHOULD_PUBLISH: ${{ steps.check_version.outputs.should_publish }}
           CURRENT_VERSION: ${{ steps.check_version.outputs.current_version }}
         run: |
-          echo "ℹ️ Publish skipped; should_publish=$SHOULD_PUBLISH"
+          echo "ℹ️ Web-client publish skipped; should_publish=$SHOULD_PUBLISH"
+          if [ -n "$CURRENT_VERSION" ]; then
+            echo "Current version: $CURRENT_VERSION"
+          fi
+
+      - name: Skipped publish (react-sdk)
+        if: steps.check_react_version.outputs.should_publish != 'true'
+        env:
+          SHOULD_PUBLISH: ${{ steps.check_react_version.outputs.should_publish }}
+          CURRENT_VERSION: ${{ steps.check_react_version.outputs.current_version }}
+        run: |
+          echo "ℹ️ React SDK publish skipped; should_publish=$SHOULD_PUBLISH"
           if [ -n "$CURRENT_VERSION" ]; then
             echo "Current version: $CURRENT_VERSION"
           fi

--- a/.github/workflows/publish-web-client-release.yml
+++ b/.github/workflows/publish-web-client-release.yml
@@ -71,7 +71,7 @@ jobs:
         if: steps.check_react_version.outputs.should_publish == 'true'
         run: |
           cd packages/react-sdk
-          yarn install --frozen-lockfile
+          yarn install
           yarn build
 
       - name: Publish react-sdk to npm

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ miden-client.toml
 !packages/react-sdk/
 !packages/react-sdk/**
 packages/react-sdk/dist/
+packages/react-sdk/yarn.lock
 !packages/vite-plugin/
 !packages/vite-plugin/**
 packages/vite-plugin/dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## 0.14.1 (TBD)
+## 0.14.1 (2026-04-14)
 
 ### Fixes
 
 * [FIX][web] Fixed `syncState` failure ("inconsistent partial mmr: tracked leaf at position N has no value in nodes") caused by skipping authentication node collection for blocks already tracked from the MMR delta during large catch-up syncs. Authentication nodes are now always collected for note-relevant blocks regardless of prior tracking state. ([#1997](https://github.com/0xMiden/miden-client/pull/1997)).
+* [FIX][web] Fixed `transactions.send({ returnNote: true })` throwing `expected instance of NoteArray`. The JS wrapper was still building `OutputNoteArray` after the WASM binding for `withOwnOutputNotes` switched to `NoteArray` ([#2011](https://github.com/0xMiden/miden-client/issues/2011)).
 * [FIX][rust] Made source manager handling consistent when building transaction scripts. The empty fallback script is now compiled against the client's source manager instead of a fresh one, so any source information on the produced `TransactionScript` is registered with the same source manager used by the executor ([#2006](https://github.com/0xMiden/miden-client/pull/2006)).
 
 ## 0.14.0 (2026-04-07)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2954,7 +2954,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-bench"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2971,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-cli"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-integration-tests"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3017,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-sqlite-store"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-unit-tests"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "miden-client",
  "miden-client-sqlite-store",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-web"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-trait",
  "console_error_panic_hook",
@@ -3209,7 +3209,7 @@ dependencies = [
 
 [[package]]
 name = "miden-idxdb-store"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -3946,7 +3946,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "node-builder"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "miden-node-block-producer",
@@ -6014,7 +6014,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "testing-remote-prover"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ edition      = "2024"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/miden-client"
 rust-version = "1.93"
-version      = "0.14.0"
+version      = "0.14.1"
 
 [profile.dev]
 codegen-units = 16
@@ -33,9 +33,9 @@ opt-level = 1
 
 [workspace.dependencies]
 # Workspace crates
-idxdb-store               = { default-features = false, package = "miden-idxdb-store", path = "crates/idxdb-store", version = "0.14.0" }
-miden-client              = { default-features = false, path = "crates/rust-client", version = "0.14.0" }
-miden-client-sqlite-store = { default-features = false, path = "crates/sqlite-store", version = "0.14.0" }
+idxdb-store               = { default-features = false, package = "miden-idxdb-store", path = "crates/idxdb-store", version = "0.14.1" }
+miden-client              = { default-features = false, path = "crates/rust-client", version = "0.14.1" }
+miden-client-sqlite-store = { default-features = false, path = "crates/sqlite-store", version = "0.14.1" }
 
 # Miden protocol dependencies
 miden-protocol  = { default-features = false, version = "0.14" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,9 @@ opt-level = 1
 
 [workspace.dependencies]
 # Workspace crates
-idxdb-store               = { default-features = false, package = "miden-idxdb-store", path = "crates/idxdb-store", version = "0.14.1" }
-miden-client              = { default-features = false, path = "crates/rust-client", version = "0.14.1" }
-miden-client-sqlite-store = { default-features = false, path = "crates/sqlite-store", version = "0.14.1" }
+idxdb-store               = { default-features = false, package = "miden-idxdb-store", path = "crates/idxdb-store", version = "0.14" }
+miden-client              = { default-features = false, path = "crates/rust-client", version = "0.14" }
+miden-client-sqlite-store = { default-features = false, path = "crates/sqlite-store", version = "0.14" }
 
 # Miden protocol dependencies
 miden-protocol  = { default-features = false, version = "0.14" }

--- a/crates/web-client/js/resources/transactions.js
+++ b/crates/web-client/js/resources/transactions.js
@@ -44,9 +44,7 @@ export class TransactionsResource {
       );
 
       const request = new wasm.TransactionRequestBuilder()
-        .withOwnOutputNotes(
-          new wasm.OutputNoteArray([wasm.OutputNote.full(note)])
-        )
+        .withOwnOutputNotes(new wasm.NoteArray([note]))
         .build();
 
       const { txId, result } = await this.#submitOrSubmitWithProver(

--- a/crates/web-client/js/resources/transactions.js
+++ b/crates/web-client/js/resources/transactions.js
@@ -43,8 +43,12 @@ export class TransactionsResource {
         new wasm.NoteAttachment()
       );
 
+      // NoteArray constructor consumes its elements; use push(&note) to keep
+      // `note` valid so we can return it to the caller below.
+      const ownOutputs = new wasm.NoteArray();
+      ownOutputs.push(note);
       const request = new wasm.TransactionRequestBuilder()
-        .withOwnOutputNotes(new wasm.NoteArray([note]))
+        .withOwnOutputNotes(ownOutputs)
         .build();
 
       const { txId, result } = await this.#submitOrSubmitWithProver(

--- a/crates/web-client/package.json
+++ b/crates/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-sdk",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Miden Wasm SDK",
   "collaborators": [
     "Miden"

--- a/crates/web-client/test/miden_client_api.test.ts
+++ b/crates/web-client/test/miden_client_api.test.ts
@@ -334,6 +334,75 @@ mockTest.describe("MidenClient API - Mock Chain", () => {
     }
   );
 
+  // Regression test for #2011: the JS wrapper was building OutputNoteArray
+  // while the WASM binding for withOwnOutputNotes switched to NoteArray,
+  // causing `expected instance of NoteArray` at runtime.
+  mockTest(
+    "transactions.send with returnNote returns a Note",
+    async ({ page }) => {
+      const result = await page.evaluate(async () => {
+        const client = await window.MidenClient.createMock();
+
+        const sender = await client.accounts.create();
+        const receiver = await client.accounts.create();
+        const faucet = await client.accounts.create({
+          type: window.AccountType.FungibleFaucet,
+          symbol: "DAG",
+          decimals: 8,
+          maxSupply: 10_000_000n,
+        });
+
+        // Fund the sender: mint + consume so the wallet has a usable balance.
+        const { txId: mintTxId } = await client.transactions.mint({
+          account: faucet,
+          to: sender,
+          amount: 1000n,
+        });
+        client.proveBlock();
+        await client.sync();
+
+        const mintRecord = (
+          await client.transactions.list({ ids: [mintTxId.toHex()] })
+        )[0];
+        const mintedNoteId = mintRecord
+          .outputNotes()
+          .notes()[0]
+          .id()
+          .toString();
+
+        await client.transactions.consume({
+          account: sender,
+          notes: mintedNoteId,
+        });
+        client.proveBlock();
+        await client.sync();
+
+        // Send with returnNote: true — this is the path that regressed.
+        const sendResult = await client.transactions.send({
+          account: sender,
+          to: receiver,
+          token: faucet,
+          amount: 50n,
+          type: "public",
+          returnNote: true,
+        });
+
+        return {
+          txId: sendResult.txId?.toHex(),
+          hasNote: sendResult.note != null,
+          noteIdIsString: typeof sendResult.note?.id().toString() === "string",
+          noteIdLength: sendResult.note?.id().toString().length ?? 0,
+        };
+      });
+
+      expect(result.txId).toBeDefined();
+      expect(result.txId.length).toBeGreaterThan(0);
+      expect(result.hasNote).toBe(true);
+      expect(result.noteIdIsString).toBe(true);
+      expect(result.noteIdLength).toBeGreaterThan(0);
+    }
+  );
+
   mockTest("exportStore and importStore round-trip", async ({ page }) => {
     const result = await page.evaluate(async () => {
       const client = await window.MidenClient.createMock();

--- a/packages/react-sdk/CHANGELOG.md
+++ b/packages/react-sdk/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 0.14.0 (TBD)
+## 0.14.1 (2026-04-14)
+
+### Fixes
+
+* Bumped `@miden-sdk/miden-sdk` to 0.14.1 to pick up the `returnNote` fix for `transactions.send()` / `useSend` ([#2011](https://github.com/0xMiden/miden-client/issues/2011)).
+
+## 0.14.0 (2026-04-07)
 
 ### Breaking Changes
 

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/react",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "React hooks library for Miden Web Client",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -28,7 +28,7 @@
     "test:all": "VITE_CJS_IGNORE_WARNING=1 vitest run && playwright test"
   },
   "peerDependencies": {
-    "@miden-sdk/miden-sdk": "^0.14.0",
+    "@miden-sdk/miden-sdk": "^0.14.1",
     "react": ">=18.0.0"
   },
   "dependencies": {

--- a/packages/react-sdk/src/__tests__/mocks/miden-sdk.ts
+++ b/packages/react-sdk/src/__tests__/mocks/miden-sdk.ts
@@ -246,8 +246,11 @@ export const MockNoteAttachment = class NoteAttachment {};
 
 export const MockNoteArray = class NoteArray {
   notes: unknown[];
-  constructor(notes: unknown[]) {
-    this.notes = notes;
+  constructor(notes?: unknown[]) {
+    this.notes = notes ?? [];
+  }
+  push(note: unknown) {
+    this.notes.push(note);
   }
 };
 

--- a/packages/react-sdk/src/__tests__/setup.ts
+++ b/packages/react-sdk/src/__tests__/setup.ts
@@ -200,8 +200,11 @@ vi.mock("@miden-sdk/miden-sdk", () => {
     }),
     NoteArray: class NoteArray {
       notes: unknown[];
-      constructor(notes: unknown[]) {
-        this.notes = notes;
+      constructor(notes?: unknown[]) {
+        this.notes = notes ?? [];
+      }
+      push(note: unknown) {
+        this.notes.push(note);
       }
     },
     NoteAndArgs: class NoteAndArgs {

--- a/packages/react-sdk/src/hooks/useSend.ts
+++ b/packages/react-sdk/src/hooks/useSend.ts
@@ -166,8 +166,12 @@ export function useSend(): UseSendResult {
               new NoteAttachment()
             );
 
+            // NoteArray constructor consumes its elements; use push(&note)
+            // to keep `p2idNote` valid so the caller can use the returned Note.
+            const ownOutputs = new NoteArray();
+            ownOutputs.push(p2idNote);
             const txRequest = new TransactionRequestBuilder()
-              .withOwnOutputNotes(new NoteArray([p2idNote]))
+              .withOwnOutputNotes(ownOutputs)
               .build();
 
             const execFromId = parseAccountId(options.from);

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/vite-plugin",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Vite plugin for Miden dApps — WASM dedup, COOP/COEP headers, and gRPC-web proxy",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/scripts/check-react-sdk-sync.js
+++ b/scripts/check-react-sdk-sync.js
@@ -48,9 +48,39 @@ const major = Number(versionMatch[1]);
 const minor = Number(versionMatch[2]);
 const patch = Number(versionMatch[3]);
 const prerelease = versionMatch[4] || "";
-const expectedRange = prerelease
+// Default range used by --fix when a range needs to be created or repaired.
+const defaultRange = prerelease
   ? `^${major}.${minor}.${patch}${prerelease}`
   : `^${major}.${minor}.0`;
+
+// A range is compatible when it is a caret range within the same
+// major.minor.prerelease as the web-client, with a patch no higher than the
+// current web-client patch. This permits tightening the lower bound past .0
+// (e.g. "^0.14.1" when web-client is 0.14.1) to exclude buggy prior patches,
+// while still rejecting ranges that cross the minor boundary.
+const parseCaretRange = (range) => {
+  const m = /^\^(\d+)\.(\d+)\.(\d+)(-.+)?$/.exec(range || "");
+  return m
+    ? {
+        major: Number(m[1]),
+        minor: Number(m[2]),
+        patch: Number(m[3]),
+        prerelease: m[4] || "",
+      }
+    : null;
+};
+
+const isCompatibleRange = (range) => {
+  const parsed = parseCaretRange(range);
+  if (!parsed) return false;
+  if (parsed.major !== major || parsed.minor !== minor) return false;
+  if (parsed.prerelease !== prerelease) return false;
+  return parsed.patch <= patch;
+};
+
+const compatibilityHint = prerelease
+  ? `^${major}.${minor}.X${prerelease} with X <= ${patch}`
+  : `^${major}.${minor}.X with X between 0 and ${patch}`;
 
 const peerDeps = reactSdkPkg.peerDependencies || {};
 const actualRange = peerDeps["@miden-sdk/miden-sdk"];
@@ -64,11 +94,9 @@ if (!actualRange) {
   errors.push(
     "Missing peerDependencies entry for @miden-sdk/miden-sdk in react-sdk."
   );
-}
-
-if (actualRange !== expectedRange) {
+} else if (!isCompatibleRange(actualRange)) {
   errors.push(
-    `React SDK peer range "${actualRange}" does not match expected "${expectedRange}" for web-client ${webClientVersion}.`
+    `React SDK peer range "${actualRange}" is not compatible with web-client ${webClientVersion}. Expected ${compatibilityHint}.`
   );
 }
 
@@ -88,25 +116,23 @@ if (!walletRange) {
   errors.push(
     "Missing dependencies entry for @miden-sdk/miden-sdk in wallet example."
   );
-}
-
-if (walletRange !== expectedRange) {
+} else if (!isCompatibleRange(walletRange)) {
   errors.push(
-    `Wallet example dependency "${walletRange}" does not match expected "${expectedRange}" for web-client ${webClientVersion}.`
+    `Wallet example dependency "${walletRange}" is not compatible with web-client ${webClientVersion}. Expected ${compatibilityHint}.`
   );
 }
 
 if (errors.length > 0) {
   if (shouldFix) {
     let updated = false;
-    if (actualRange !== expectedRange) {
-      peerDeps["@miden-sdk/miden-sdk"] = expectedRange;
+    if (!actualRange || !isCompatibleRange(actualRange)) {
+      peerDeps["@miden-sdk/miden-sdk"] = defaultRange;
       reactSdkPkg.peerDependencies = peerDeps;
       updated = true;
     }
 
-    if (walletRange !== expectedRange) {
-      walletDeps["@miden-sdk/miden-sdk"] = expectedRange;
+    if (!walletRange || !isCompatibleRange(walletRange)) {
+      walletDeps["@miden-sdk/miden-sdk"] = defaultRange;
       walletExamplePkg.dependencies = walletDeps;
       updated = true;
     }
@@ -115,7 +141,7 @@ if (errors.length > 0) {
       writeJson(reactSdkPath, reactSdkPkg);
       writeJson(walletExamplePath, walletExamplePkg);
       console.log(
-        `Updated react-sdk peer range to "${expectedRange}" and wallet dependency based on web-client ${webClientVersion}.`
+        `Updated react-sdk peer range and wallet dependency to "${defaultRange}" based on web-client ${webClientVersion}.`
       );
     }
 
@@ -129,5 +155,5 @@ if (errors.length > 0) {
 }
 
 console.log(
-  `React SDK version/peer range and wallet dependency match web-client ${webClientVersion} (${expectedRange}).`
+  `React SDK peer range "${actualRange}" and wallet dependency "${walletRange}" are compatible with web-client ${webClientVersion}.`
 );

--- a/scripts/check-react-sdk-version-release.sh
+++ b/scripts/check-react-sdk-version-release.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Check if react-sdk package.json version has been bumped compared to the base branch
-# Usage: check-react-sdk-version-pr.sh <BASE_SHA>
+# Check if react-sdk package.json version has been bumped compared to the parent commit
+# Usage: check-react-sdk-version-release.sh <RELEASE_SHA>
 #
 # Outputs to $GITHUB_OUTPUT:
 #   - should_publish: true/false
-#   - previous_version: version from base commit (if should_publish=true)
-#   - current_version: version from current commit (if should_publish=true)
+#   - previous_version: version from parent commit (if should_publish=true)
+#   - current_version: version from release commit (if should_publish=true)
 
-BASE_SHA="$1"
+RELEASE_SHA="$1"
 
 write_skip_and_exit() {
   if [ -n "${GITHUB_OUTPUT:-}" ]; then
@@ -20,7 +20,14 @@ write_skip_and_exit() {
   exit 0
 }
 
-if ! git diff --name-only "$BASE_SHA"...HEAD -- packages/react-sdk/package.json | grep -q .; then
+BASE_SHA=$(git rev-parse "${RELEASE_SHA}^" 2>/dev/null || true)
+
+if [ -z "$BASE_SHA" ]; then
+  echo "Unable to determine parent commit for release tag."
+  write_skip_and_exit
+fi
+
+if ! git diff --name-only "$BASE_SHA" "$RELEASE_SHA" -- packages/react-sdk/package.json | grep -q .; then
   echo "No changes to packages/react-sdk/package.json; skipping publish."
   write_skip_and_exit
 fi
@@ -34,7 +41,7 @@ CURRENT_VERSION=$(jq -r '.version' packages/react-sdk/package.json)
 PREVIOUS_VERSION=$(jq -r '.version' /tmp/base_react_package.json)
 
 if [ "$CURRENT_VERSION" = "$PREVIOUS_VERSION" ]; then
-  echo "Version $CURRENT_VERSION matches target branch (next); skipping publish."
+  echo "Version $CURRENT_VERSION matches prior tagged commit; skipping publish."
   write_skip_and_exit
 fi
 


### PR DESCRIPTION
Closes #2011

> [!WARNING]
> Do not merge until https://github.com/0xMiden/miden-client/pull/2010 lands.

## Summary

- Fixes [#2011](https://github.com/0xMiden/miden-client/issues/2011): `transactions.send({ returnNote: true })` was throwing `expected instance of NoteArray` because the JS wrapper still built `new OutputNoteArray([OutputNote.full(note)])`, but the WASM binding for `withOwnOutputNotes` switched to `&NoteArray` in the v0.14.0 protocol upgrade.
- Bumps workspace (Rust crates), `@miden-sdk/miden-sdk`, `@miden-sdk/react`, and `@miden-sdk/vite-plugin` to **0.14.1**.
- Dates the 0.14.1 section in the main `CHANGELOG.md` and the new 0.14.1 section in the `packages/react-sdk/CHANGELOG.md` to today (2026-04-14). The preserved react-sdk 0.14.0 section is dated to match the main changelog (2026-04-07).

## Test plan

- [ ] `client.transactions.send({ account, to, token, amount, type, returnNote: true })` succeeds and returns `{ txId, note, result }` with a usable `Note`.
- [ ] `useSend({ returnNote: true })` path in react-sdk unaffected (react-sdk's own code path already used `NoteArray`).
- [ ] `make lint` and `make test` pass.
- [ ] `cd packages/react-sdk && yarn typecheck && yarn lint && yarn build` pass.