### PR TITLE
feat: prune MMR auth nodes for blocks which notes have all been consumed

### DIFF
--- a/crates/idxdb-store/src/chain_data/js_bindings.rs
+++ b/crates/idxdb-store/src/chain_data/js_bindings.rs
@@ -59,13 +59,10 @@ extern "C" {
     // DELETES
     // ================================================================================================
 
-    #[wasm_bindgen(js_name = untrackBlocks)]
-    pub fn idxdb_untrack_blocks(
-        db_id: &str,
-        block_nums: Vec<u32>,
-        node_ids: Vec<String>,
-    ) -> js_sys::Promise;
-
     #[wasm_bindgen(js_name = pruneIrrelevantBlocks)]
-    pub fn idxdb_prune_irrelevant_blocks(db_id: &str) -> js_sys::Promise;
+    pub fn idxdb_prune_irrelevant_blocks(
+        db_id: &str,
+        blocks_to_untrack: Vec<u32>,
+        node_ids_to_remove: Vec<String>,
+    ) -> js_sys::Promise;
 }

--- a/crates/idxdb-store/src/chain_data/js_bindings.rs
+++ b/crates/idxdb-store/src/chain_data/js_bindings.rs
@@ -59,6 +59,13 @@ extern "C" {
     // DELETES
     // ================================================================================================
 
+    #[wasm_bindgen(js_name = untrackBlocks)]
+    pub fn idxdb_untrack_blocks(
+        db_id: &str,
+        block_nums: Vec<u32>,
+        node_ids: Vec<String>,
+    ) -> js_sys::Promise;
+
     #[wasm_bindgen(js_name = pruneIrrelevantBlocks)]
     pub fn idxdb_prune_irrelevant_blocks(db_id: &str) -> js_sys::Promise;
 }

--- a/crates/idxdb-store/src/chain_data/mod.rs
+++ b/crates/idxdb-store/src/chain_data/mod.rs
@@ -24,6 +24,7 @@ use js_bindings::{
     idxdb_insert_block_header,
     idxdb_insert_partial_blockchain_nodes,
     idxdb_prune_irrelevant_blocks,
+    idxdb_untrack_blocks,
 };
 
 mod models;
@@ -212,6 +213,25 @@ impl IdxdbStore {
             serialized_nodes,
         );
         await_ok(promise, "failed to insert partial blockchain nodes").await?;
+
+        Ok(())
+    }
+
+    pub(crate) async fn untrack_blocks(
+        &self,
+        block_nums: &[BlockNumber],
+        node_indices: &[InOrderIndex],
+    ) -> Result<(), StoreError> {
+        if block_nums.is_empty() && node_indices.is_empty() {
+            return Ok(());
+        }
+
+        let block_nums_vec: Vec<u32> = block_nums.iter().map(BlockNumber::as_u32).collect();
+        let node_ids_vec: Vec<String> =
+            node_indices.iter().map(|id| (Into::<usize>::into(*id)).to_string()).collect();
+
+        let promise = idxdb_untrack_blocks(self.db_id(), block_nums_vec, node_ids_vec);
+        await_ok(promise, "failed to untrack blocks").await?;
 
         Ok(())
     }

--- a/crates/idxdb-store/src/chain_data/mod.rs
+++ b/crates/idxdb-store/src/chain_data/mod.rs
@@ -24,7 +24,6 @@ use js_bindings::{
     idxdb_insert_block_header,
     idxdb_insert_partial_blockchain_nodes,
     idxdb_prune_irrelevant_blocks,
-    idxdb_untrack_blocks,
 };
 
 mod models;
@@ -217,28 +216,19 @@ impl IdxdbStore {
         Ok(())
     }
 
-    pub(crate) async fn untrack_blocks(
+    pub(crate) async fn prune_irrelevant_blocks(
         &self,
-        block_nums: &[BlockNumber],
-        node_indices: &[InOrderIndex],
+        blocks_to_untrack: &[BlockNumber],
+        node_indices_to_remove: &[InOrderIndex],
     ) -> Result<(), StoreError> {
-        if block_nums.is_empty() && node_indices.is_empty() {
-            return Ok(());
-        }
+        let block_nums_vec: Vec<u32> = blocks_to_untrack.iter().map(BlockNumber::as_u32).collect();
+        let node_ids_vec: Vec<String> = node_indices_to_remove
+            .iter()
+            .map(|id| (Into::<usize>::into(*id)).to_string())
+            .collect();
 
-        let block_nums_vec: Vec<u32> = block_nums.iter().map(BlockNumber::as_u32).collect();
-        let node_ids_vec: Vec<String> =
-            node_indices.iter().map(|id| (Into::<usize>::into(*id)).to_string()).collect();
-
-        let promise = idxdb_untrack_blocks(self.db_id(), block_nums_vec, node_ids_vec);
-        await_ok(promise, "failed to untrack blocks").await?;
-
-        Ok(())
-    }
-
-    pub(crate) async fn prune_irrelevant_blocks(&self) -> Result<(), StoreError> {
-        let promise = idxdb_prune_irrelevant_blocks(self.db_id());
-        await_ok(promise, "failed to prune block header").await?;
+        let promise = idxdb_prune_irrelevant_blocks(self.db_id(), block_nums_vec, node_ids_vec);
+        await_ok(promise, "failed to prune irrelevant blocks").await?;
 
         Ok(())
     }

--- a/crates/idxdb-store/src/js/chainData.js
+++ b/crates/idxdb-store/src/js/chainData.js
@@ -150,39 +150,34 @@ export async function getPartialBlockchainNodesUpToInOrderIndex(dbId, maxInOrder
         logWebStoreError(err, "Failed to get partial blockchain nodes up to index");
     }
 }
-export async function untrackBlocks(dbId, blockNums, nodeIds) {
+export async function pruneIrrelevantBlocks(dbId, blocksToUntrack, nodeIdsToRemove) {
     try {
         const db = getDatabase(dbId);
-        const numericNodeIds = nodeIds.map(Number);
-        await db.dexie.transaction("rw", db.blockHeaders, db.partialBlockchainNodes, async () => {
-            if (numericNodeIds.length > 0) {
-                await db.partialBlockchainNodes.bulkDelete(numericNodeIds);
-            }
-            if (blockNums.length > 0) {
-                await db.blockHeaders
-                    .where("blockNum")
-                    .anyOf(blockNums)
-                    .modify({ hasClientNotes: "false" });
-            }
-        });
-    }
-    catch (err) {
-        logWebStoreError(err, "Failed to untrack blocks");
-    }
-}
-export async function pruneIrrelevantBlocks(dbId) {
-    try {
-        const db = getDatabase(dbId);
+        const numericNodeIds = nodeIdsToRemove.map(Number);
         const syncHeight = await db.stateSync.get(1);
         if (syncHeight == undefined) {
             throw Error("SyncHeight is undefined -- is the state sync table empty?");
         }
-        const allMatchingRecords = await db.blockHeaders
-            .where("hasClientNotes")
-            .equals("false")
-            .and((record) => record.blockNum !== 0 && record.blockNum !== syncHeight.blockNum)
-            .toArray();
-        await db.blockHeaders.bulkDelete(allMatchingRecords.map((r) => r.blockNum));
+        await db.dexie.transaction("rw", db.blockHeaders, db.partialBlockchainNodes, async () => {
+            // 1. Delete stale MMR authentication nodes.
+            if (numericNodeIds.length > 0) {
+                await db.partialBlockchainNodes.bulkDelete(numericNodeIds);
+            }
+            // 2. Mark untracked blocks as irrelevant.
+            if (blocksToUntrack.length > 0) {
+                await db.blockHeaders
+                    .where("blockNum")
+                    .anyOf(blocksToUntrack)
+                    .modify({ hasClientNotes: "false" });
+            }
+            // 3. Delete irrelevant block headers.
+            const allMatchingRecords = await db.blockHeaders
+                .where("hasClientNotes")
+                .equals("false")
+                .and((record) => record.blockNum !== 0 && record.blockNum !== syncHeight.blockNum)
+                .toArray();
+            await db.blockHeaders.bulkDelete(allMatchingRecords.map((r) => r.blockNum));
+        });
     }
     catch (err) {
         logWebStoreError(err, "Failed to prune irrelevant blocks");

--- a/crates/idxdb-store/src/js/chainData.js
+++ b/crates/idxdb-store/src/js/chainData.js
@@ -150,6 +150,26 @@ export async function getPartialBlockchainNodesUpToInOrderIndex(dbId, maxInOrder
         logWebStoreError(err, "Failed to get partial blockchain nodes up to index");
     }
 }
+export async function untrackBlocks(dbId, blockNums, nodeIds) {
+    try {
+        const db = getDatabase(dbId);
+        const numericNodeIds = nodeIds.map(Number);
+        await db.dexie.transaction("rw", db.blockHeaders, db.partialBlockchainNodes, async () => {
+            if (numericNodeIds.length > 0) {
+                await db.partialBlockchainNodes.bulkDelete(numericNodeIds);
+            }
+            if (blockNums.length > 0) {
+                await db.blockHeaders
+                    .where("blockNum")
+                    .anyOf(blockNums)
+                    .modify({ hasClientNotes: "false" });
+            }
+        });
+    }
+    catch (err) {
+        logWebStoreError(err, "Failed to untrack blocks");
+    }
+}
 export async function pruneIrrelevantBlocks(dbId) {
     try {
         const db = getDatabase(dbId);

--- a/crates/idxdb-store/src/lib.rs
+++ b/crates/idxdb-store/src/lib.rs
@@ -284,7 +284,7 @@ impl Store for IdxdbStore {
         self.get_partial_blockchain_peaks_by_block_num(block_num).await
     }
 
-    async fn prune_irrelevant_blocks(
+    async fn untrack_and_prune_irrelevant_blocks(
         &self,
         blocks_to_untrack: &[BlockNumber],
         node_indices_to_remove: &[InOrderIndex],

--- a/crates/idxdb-store/src/lib.rs
+++ b/crates/idxdb-store/src/lib.rs
@@ -284,16 +284,12 @@ impl Store for IdxdbStore {
         self.get_partial_blockchain_peaks_by_block_num(block_num).await
     }
 
-    async fn prune_irrelevant_blocks(&self) -> Result<(), StoreError> {
-        self.prune_irrelevant_blocks().await
-    }
-
-    async fn untrack_blocks(
+    async fn prune_irrelevant_blocks(
         &self,
-        block_nums: &[BlockNumber],
-        node_indices: &[InOrderIndex],
+        blocks_to_untrack: &[BlockNumber],
+        node_indices_to_remove: &[InOrderIndex],
     ) -> Result<(), StoreError> {
-        self.untrack_blocks(block_nums, node_indices).await
+        self.prune_irrelevant_blocks(blocks_to_untrack, node_indices_to_remove).await
     }
 
     async fn prune_account_history(

--- a/crates/idxdb-store/src/lib.rs
+++ b/crates/idxdb-store/src/lib.rs
@@ -288,6 +288,14 @@ impl Store for IdxdbStore {
         self.prune_irrelevant_blocks().await
     }
 
+    async fn untrack_blocks(
+        &self,
+        block_nums: &[BlockNumber],
+        node_indices: &[InOrderIndex],
+    ) -> Result<(), StoreError> {
+        self.untrack_blocks(block_nums, node_indices).await
+    }
+
     async fn prune_account_history(
         &self,
         account_id: AccountId,

--- a/crates/idxdb-store/src/ts/chainData.ts
+++ b/crates/idxdb-store/src/ts/chainData.ts
@@ -189,56 +189,53 @@ export async function getPartialBlockchainNodesUpToInOrderIndex(
   }
 }
 
-export async function untrackBlocks(
+export async function pruneIrrelevantBlocks(
   dbId: string,
-  blockNums: number[],
-  nodeIds: string[]
+  blocksToUntrack: number[],
+  nodeIdsToRemove: string[]
 ) {
   try {
     const db = getDatabase(dbId);
-    const numericNodeIds = nodeIds.map(Number);
+    const numericNodeIds = nodeIdsToRemove.map(Number);
+
+    const syncHeight = await db.stateSync.get(1);
+    if (syncHeight == undefined) {
+      throw Error("SyncHeight is undefined -- is the state sync table empty?");
+    }
 
     await db.dexie.transaction(
       "rw",
       db.blockHeaders,
       db.partialBlockchainNodes,
       async () => {
+        // 1. Delete stale MMR authentication nodes.
         if (numericNodeIds.length > 0) {
           await db.partialBlockchainNodes.bulkDelete(numericNodeIds);
         }
 
-        if (blockNums.length > 0) {
+        // 2. Mark untracked blocks as irrelevant.
+        if (blocksToUntrack.length > 0) {
           await db.blockHeaders
             .where("blockNum")
-            .anyOf(blockNums)
+            .anyOf(blocksToUntrack)
             .modify({ hasClientNotes: "false" });
         }
+
+        // 3. Delete irrelevant block headers.
+        const allMatchingRecords = await db.blockHeaders
+          .where("hasClientNotes")
+          .equals("false")
+          .and(
+            (record) =>
+              record.blockNum !== 0 && record.blockNum !== syncHeight.blockNum
+          )
+          .toArray();
+
+        await db.blockHeaders.bulkDelete(
+          allMatchingRecords.map((r) => r.blockNum)
+        );
       }
     );
-  } catch (err) {
-    logWebStoreError(err, "Failed to untrack blocks");
-  }
-}
-
-export async function pruneIrrelevantBlocks(dbId: string) {
-  try {
-    const db = getDatabase(dbId);
-    const syncHeight = await db.stateSync.get(1);
-
-    if (syncHeight == undefined) {
-      throw Error("SyncHeight is undefined -- is the state sync table empty?");
-    }
-
-    const allMatchingRecords = await db.blockHeaders
-      .where("hasClientNotes")
-      .equals("false")
-      .and(
-        (record) =>
-          record.blockNum !== 0 && record.blockNum !== syncHeight.blockNum
-      )
-      .toArray();
-
-    await db.blockHeaders.bulkDelete(allMatchingRecords.map((r) => r.blockNum));
   } catch (err) {
     logWebStoreError(err, "Failed to prune irrelevant blocks");
   }

--- a/crates/idxdb-store/src/ts/chainData.ts
+++ b/crates/idxdb-store/src/ts/chainData.ts
@@ -189,6 +189,37 @@ export async function getPartialBlockchainNodesUpToInOrderIndex(
   }
 }
 
+export async function untrackBlocks(
+  dbId: string,
+  blockNums: number[],
+  nodeIds: string[]
+) {
+  try {
+    const db = getDatabase(dbId);
+    const numericNodeIds = nodeIds.map(Number);
+
+    await db.dexie.transaction(
+      "rw",
+      db.blockHeaders,
+      db.partialBlockchainNodes,
+      async () => {
+        if (numericNodeIds.length > 0) {
+          await db.partialBlockchainNodes.bulkDelete(numericNodeIds);
+        }
+
+        if (blockNums.length > 0) {
+          await db.blockHeaders
+            .where("blockNum")
+            .anyOf(blockNums)
+            .modify({ hasClientNotes: "false" });
+        }
+      }
+    );
+  } catch (err) {
+    logWebStoreError(err, "Failed to untrack blocks");
+  }
+}
+
 export async function pruneIrrelevantBlocks(dbId: string) {
   try {
     const db = getDatabase(dbId);

--- a/crates/rust-client/src/builder.rs
+++ b/crates/rust-client/src/builder.rs
@@ -366,12 +366,11 @@ where
 
     /// Sets the number of synced blocks between automatic irrelevant-block pruning runs.
     ///
-    /// `Some(1)` preserves the current behavior and prunes after every sync. Larger values defer
-    /// pruning until the client has advanced by at least that many sync blocks since the last
-    /// prune. `None` disables automatic pruning entirely.
+    /// Values defer pruning until the client has advanced by at least that many sync blocks since
+    /// the last prune. `None` disables automatic pruning entirely.
     #[must_use]
     pub fn irrelevant_block_prune_interval(mut self, interval: Option<u32>) -> Self {
-        self.irrelevant_block_prune_interval = interval.map(|interval| interval.max(1));
+        self.irrelevant_block_prune_interval = interval;
         self
     }
 

--- a/crates/rust-client/src/builder.rs
+++ b/crates/rust-client/src/builder.rs
@@ -25,6 +25,8 @@ use crate::{Client, ClientError, ClientRng, ClientRngBox, DebugMode, grpc_suppor
 /// The default number of blocks after which pending transactions are considered stale and
 /// discarded.
 const TX_DISCARD_DELTA: u32 = 20;
+/// The default number of synced blocks between automatic irrelevant-block pruning runs.
+const IRRELEVANT_BLOCK_PRUNE_INTERVAL: u32 = 1;
 
 pub use grpc_support::*;
 
@@ -114,6 +116,9 @@ pub struct ClientBuilder<AUTH> {
     /// Number of blocks after which pending transactions are considered stale and discarded.
     /// If `None`, there is no limit and transactions will be kept indefinitely.
     tx_discard_delta: Option<u32>,
+    /// Number of synced blocks between automatic pruning runs for irrelevant block data.
+    /// If `None`, automatic irrelevant-block pruning is disabled.
+    irrelevant_block_prune_interval: Option<u32>,
     /// Maximum number of blocks the client can be behind the network for transactions and account
     /// proofs to be considered valid.
     max_block_number_delta: Option<u32>,
@@ -137,6 +142,7 @@ impl<AUTH> Default for ClientBuilder<AUTH> {
             authenticator: None,
             in_debug_mode: DebugMode::Disabled,
             tx_discard_delta: Some(TX_DISCARD_DELTA),
+            irrelevant_block_prune_interval: Some(IRRELEVANT_BLOCK_PRUNE_INTERVAL),
             max_block_number_delta: None,
             note_transport_api: None,
             note_transport_config: None,
@@ -358,6 +364,17 @@ where
         self
     }
 
+    /// Sets the number of synced blocks between automatic irrelevant-block pruning runs.
+    ///
+    /// `Some(1)` preserves the current behavior and prunes after every sync. Larger values defer
+    /// pruning until the client has advanced by at least that many sync blocks since the last
+    /// prune. `None` disables automatic pruning entirely.
+    #[must_use]
+    pub fn irrelevant_block_prune_interval(mut self, interval: Option<u32>) -> Self {
+        self.irrelevant_block_prune_interval = interval.map(|interval| interval.max(1));
+        self
+    }
+
     /// Sets the number of blocks after which pending transactions are considered stale and
     /// discarded.
     ///
@@ -479,6 +496,8 @@ where
             )
             .expect("Default executor's options should always be valid"),
             tx_discard_delta: self.tx_discard_delta,
+            irrelevant_block_prune_interval: self.irrelevant_block_prune_interval,
+            last_irrelevant_block_prune_sync_height: None,
             max_block_number_delta: self.max_block_number_delta,
             note_transport_api: self.note_transport_api.clone(),
         })

--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -324,6 +324,7 @@ pub mod testing {
 
 use alloc::sync::Arc;
 
+use miden_protocol::block::BlockNumber;
 use miden_protocol::crypto::rand::FeltRng;
 use miden_tx::auth::TransactionAuthenticator;
 use rand::RngCore;
@@ -364,6 +365,10 @@ pub struct Client<AUTH> {
     exec_options: ExecutionOptions,
     /// Number of blocks after which pending transactions are considered stale and discarded.
     tx_discard_delta: Option<u32>,
+    /// Number of synced blocks between automatic irrelevant-block pruning runs.
+    irrelevant_block_prune_interval: Option<u32>,
+    /// Sync height at which the last automatic irrelevant-block prune completed.
+    last_irrelevant_block_prune_sync_height: Option<BlockNumber>,
     /// Maximum number of blocks the client can be behind the network for transactions and account
     /// proofs to be considered valid.
     max_block_number_delta: Option<u32>,

--- a/crates/rust-client/src/store/mod.rs
+++ b/crates/rust-client/src/store/mod.rs
@@ -266,6 +266,20 @@ pub trait Store: Send + Sync {
     /// block.
     async fn prune_irrelevant_blocks(&self) -> Result<(), StoreError>;
 
+    /// Removes MMR authentication nodes and marks block headers as no longer having relevant
+    /// notes.
+    ///
+    /// `block_nums` are the blocks to untrack (their `has_client_notes` flag is set to `false`).
+    /// `node_indices` are the in-order indices of authentication nodes to delete from the
+    /// partial blockchain nodes table.
+    ///
+    /// Both operations must be performed atomically to keep the store consistent.
+    async fn untrack_blocks(
+        &self,
+        block_nums: &[BlockNumber],
+        node_indices: &[InOrderIndex],
+    ) -> Result<(), StoreError>;
+
     /// Prunes historical account states for the specified account up to the given nonce.
     ///
     /// Deletes all historical entries with `replaced_at_nonce <= up_to_nonce` from the

--- a/crates/rust-client/src/store/mod.rs
+++ b/crates/rust-client/src/store/mod.rs
@@ -270,7 +270,7 @@ pub trait Store: Send + Sync {
     ///    consumed).
     /// 3. Deletes block headers with `has_client_notes = false` that are not the genesis or
     ///    sync-height block.
-    async fn prune_irrelevant_blocks(
+    async fn untrack_and_prune_irrelevant_blocks(
         &self,
         blocks_to_untrack: &[BlockNumber],
         node_indices_to_remove: &[InOrderIndex],

--- a/crates/rust-client/src/store/mod.rs
+++ b/crates/rust-client/src/store/mod.rs
@@ -262,22 +262,18 @@ pub trait Store: Send + Sync {
         has_client_notes: bool,
     ) -> Result<(), StoreError>;
 
-    /// Removes block headers that do not contain any client notes and aren't the genesis or last
-    /// block.
-    async fn prune_irrelevant_blocks(&self) -> Result<(), StoreError>;
-
-    /// Removes MMR authentication nodes and marks block headers as no longer having relevant
-    /// notes.
+    /// Prunes irrelevant block data from the store.
     ///
-    /// `block_nums` are the blocks to untrack (their `has_client_notes` flag is set to `false`).
-    /// `node_indices` are the in-order indices of authentication nodes to delete from the
-    /// partial blockchain nodes table.
-    ///
-    /// Both operations must be performed atomically to keep the store consistent.
-    async fn untrack_blocks(
+    /// This performs three operations atomically:
+    /// 1. Deletes MMR authentication nodes at the given `node_indices`.
+    /// 2. Sets `has_client_notes = false` for `blocks_to_untrack` (blocks whose notes have all been
+    ///    consumed).
+    /// 3. Deletes block headers with `has_client_notes = false` that are not the genesis or
+    ///    sync-height block.
+    async fn prune_irrelevant_blocks(
         &self,
-        block_nums: &[BlockNumber],
-        node_indices: &[InOrderIndex],
+        blocks_to_untrack: &[BlockNumber],
+        node_indices_to_remove: &[InOrderIndex],
     ) -> Result<(), StoreError>;
 
     /// Prunes historical account states for the specified account up to the given nonce.

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -152,7 +152,7 @@ where
             .map_err(ClientError::StoreError)?;
 
         // Prune irrelevant blocks and their MMR authentication nodes.
-        self.prune_irrelevant_blocks().await?;
+        self.untrack_and_prune_irrelevant_blocks().await?;
 
         Ok(sync_summary)
     }
@@ -194,18 +194,18 @@ where
         self.store.apply_state_sync(update).await?;
 
         // Prune irrelevant blocks and their MMR authentication nodes.
-        self.prune_irrelevant_blocks().await?;
+        self.untrack_and_prune_irrelevant_blocks().await?;
 
         Ok(())
     }
 
     /// Prunes irrelevant block data from the store.
     ///
-    /// Identifies tracked blocks whose input notes have all been consumed, untracks them
-    /// from the `PartialMmr` to determine which authentication nodes are no longer needed,
-    /// then delegates to [`Store::prune_irrelevant_blocks`] to atomically remove the stale
-    /// nodes, mark the blocks as irrelevant, and delete irrelevant block headers.
-    async fn prune_irrelevant_blocks(&self) -> Result<(), ClientError> {
+    /// Identifies tracked blocks whose input notes have all been consumed, untracks them from the
+    /// `PartialMmr` to determine which authentication nodes are no longer needed, then delegates
+    /// to [`Store::untrack_and_prune_irrelevant_blocks`] to atomically remove the stale nodes,
+    /// mark the blocks as irrelevant, and delete irrelevant block headers.
+    async fn untrack_and_prune_irrelevant_blocks(&self) -> Result<(), ClientError> {
         let tracked_blocks = self.store.get_tracked_block_header_numbers().await?;
 
         // Determine which tracked blocks no longer have unspent input notes and can be
@@ -247,7 +247,9 @@ where
 
         // Store deletes stale auth nodes, marks blocks as irrelevant, and removes irrelevant block
         // headers.
-        self.store.prune_irrelevant_blocks(&blocks_to_untrack, &nodes_to_remove).await?;
+        self.store
+            .untrack_and_prune_irrelevant_blocks(&blocks_to_untrack, &nodes_to_remove)
+            .await?;
 
         Ok(())
     }

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -228,7 +228,8 @@ where
     async fn untrack_and_prune_irrelevant_blocks(&self) -> Result<(), ClientError> {
         let tracked_blocks = self.store.get_tracked_block_header_numbers().await?;
         let to_untrack: Vec<usize> = if tracked_blocks.is_empty() {
-            // Do not early-return: even without blocks to untrack, old irrelevant tip headers may need pruning.
+            // Do not early-return: even without blocks to untrack, old irrelevant tip headers may
+            // need pruning.
             Vec::new()
         } else {
             // Blocks that still have at least one unspent note need to stay tracked.

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -208,10 +208,13 @@ where
     async fn prune_irrelevant_blocks(&self) -> Result<(), ClientError> {
         let tracked_blocks = self.store.get_tracked_block_header_numbers().await?;
 
-        // Determine which blocks to untrack by finding tracked blocks with no live notes.
+        // Determine which tracked blocks no longer have unspent input notes and can be
+        // untracked from the MMR. For each block, PartialMmr::untrack() returns the
+        // authentication node indices that are no longer needed by any remaining tracked leaf.
         let (blocks_to_untrack, nodes_to_remove) = if tracked_blocks.is_empty() {
             (vec![], vec![])
         } else {
+            // Blocks that still have at least one unspent note need to stay tracked.
             let unspent_notes = self.store.get_input_notes(NoteFilter::Unspent).await?;
             let live_blocks: BTreeSet<usize> = unspent_notes
                 .iter()
@@ -223,11 +226,12 @@ where
             if to_untrack.is_empty() {
                 (vec![], vec![])
             } else {
+                // Rebuild the PartialMmr and untrack each block to collect stale node indices.
                 let mut partial_mmr = self.store.get_current_partial_mmr().await?;
                 let mut removed_nodes: Vec<InOrderIndex> = Vec::new();
                 for &block_pos in &to_untrack {
-                    let removed = partial_mmr.untrack(block_pos);
-                    removed_nodes.extend(removed.iter().map(|(idx, _)| *idx));
+                    removed_nodes
+                        .extend(partial_mmr.untrack(block_pos).into_iter().map(|(idx, _)| idx));
                 }
 
                 let block_nums: Vec<BlockNumber> = to_untrack
@@ -241,6 +245,8 @@ where
             }
         };
 
+        // Store deletes stale auth nodes, marks blocks as irrelevant, and removes irrelevant block
+        // headers.
         self.store.prune_irrelevant_blocks(&blocks_to_untrack, &nodes_to_remove).await?;
 
         Ok(())

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -151,8 +151,6 @@ where
             .await
             .map_err(ClientError::StoreError)?;
 
-        // Prune irrelevant blocks and their MMR authentication nodes according to the configured
-        // cadence.
         self.maybe_untrack_and_prune_irrelevant_blocks().await?;
 
         Ok(sync_summary)

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -151,8 +151,9 @@ where
             .await
             .map_err(ClientError::StoreError)?;
 
-        // Prune irrelevant blocks and their MMR authentication nodes.
-        self.untrack_and_prune_irrelevant_blocks().await?;
+        // Prune irrelevant blocks and their MMR authentication nodes according to the configured
+        // cadence.
+        self.maybe_untrack_and_prune_irrelevant_blocks().await?;
 
         Ok(sync_summary)
     }
@@ -187,14 +188,37 @@ where
         })
     }
 
-    /// Applies the state sync update to the store and prunes irrelevant blocks.
+    /// Applies the state sync update to the store and prunes irrelevant blocks according to the
+    /// configured cadence.
     ///
     /// See [`crate::Store::apply_state_sync()`] for what the update implies.
     pub async fn apply_state_sync(&mut self, update: StateSyncUpdate) -> Result<(), ClientError> {
         self.store.apply_state_sync(update).await?;
 
-        // Prune irrelevant blocks and their MMR authentication nodes.
+        
+        self.maybe_untrack_and_prune_irrelevant_blocks().await?;
+
+        Ok(())
+    }
+
+    /// Prunes irrelevant blocks and their MMR authentication nodes according to the configured
+    /// cadence.
+    async fn maybe_untrack_and_prune_irrelevant_blocks(&mut self) -> Result<(), ClientError> {
+        let Some(interval) = self.irrelevant_block_prune_interval else {
+            return Ok(());
+        };
+
+        let sync_height = self.store.get_sync_height().await?;
+
+        // Check if we've exceeded the prune interval, early return if we haven't.
+        if let Some(last_prune_height) = self.last_irrelevant_block_prune_sync_height
+            && sync_height < last_prune_height + interval
+        {
+            return Ok(());
+        }
+
         self.untrack_and_prune_irrelevant_blocks().await?;
+        self.last_irrelevant_block_prune_sync_height = Some(sync_height);
 
         Ok(())
     }

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -151,10 +151,8 @@ where
             .await
             .map_err(ClientError::StoreError)?;
 
-        // Prune MMR authentication nodes for blocks whose notes have all been consumed,
-        // then remove irrelevant block headers.
-        self.prune_mmr_authentication_nodes().await?;
-        self.store.prune_irrelevant_blocks().await?;
+        // Prune irrelevant blocks and their MMR authentication nodes.
+        self.prune_irrelevant_blocks().await?;
 
         Ok(sync_summary)
     }
@@ -189,63 +187,61 @@ where
         })
     }
 
-    /// Applies the state sync update to the store and prunes the irrelevant block headers.
+    /// Applies the state sync update to the store and prunes irrelevant blocks.
     ///
     /// See [`crate::Store::apply_state_sync()`] for what the update implies.
     pub async fn apply_state_sync(&mut self, update: StateSyncUpdate) -> Result<(), ClientError> {
         self.store.apply_state_sync(update).await?;
 
-        // Prune MMR authentication nodes for blocks whose notes have all been consumed,
-        // then remove irrelevant block headers.
-        self.prune_mmr_authentication_nodes().await?;
-        self.store.prune_irrelevant_blocks().await?;
+        // Prune irrelevant blocks and their MMR authentication nodes.
+        self.prune_irrelevant_blocks().await?;
 
         Ok(())
     }
 
-    /// Prunes MMR authentication nodes for blocks whose input notes have all been consumed.
+    /// Prunes irrelevant block data from the store.
     ///
-    /// This identifies tracked blocks (blocks with `has_client_notes = true`) that no longer
-    /// have any unspent input notes, untracks them from the `PartialMmr`, and atomically
-    /// removes the redundant authentication nodes from the store while marking those blocks
-    /// as irrelevant.
-    async fn prune_mmr_authentication_nodes(&self) -> Result<(), ClientError> {
-        // Get blocks currently tracked in the MMR.
+    /// Identifies tracked blocks whose input notes have all been consumed, untracks them
+    /// from the `PartialMmr` to determine which authentication nodes are no longer needed,
+    /// then delegates to [`Store::prune_irrelevant_blocks`] to atomically remove the stale
+    /// nodes, mark the blocks as irrelevant, and delete irrelevant block headers.
+    async fn prune_irrelevant_blocks(&self) -> Result<(), ClientError> {
         let tracked_blocks = self.store.get_tracked_block_header_numbers().await?;
-        if tracked_blocks.is_empty() {
-            return Ok(());
-        }
 
-        // Determine which blocks still have live (unspent) input notes.
-        let unspent_notes = self.store.get_input_notes(NoteFilter::Unspent).await?;
-        let live_blocks: BTreeSet<usize> = unspent_notes
-            .iter()
-            .filter_map(|n| n.inclusion_proof().map(|p| p.location().block_num().as_usize()))
-            .collect();
+        // Determine which blocks to untrack by finding tracked blocks with no live notes.
+        let (blocks_to_untrack, nodes_to_remove) = if tracked_blocks.is_empty() {
+            (vec![], vec![])
+        } else {
+            let unspent_notes = self.store.get_input_notes(NoteFilter::Unspent).await?;
+            let live_blocks: BTreeSet<usize> = unspent_notes
+                .iter()
+                .filter_map(|n| n.inclusion_proof().map(|p| p.location().block_num().as_usize()))
+                .collect();
 
-        // Blocks to untrack: tracked but no longer have live notes.
-        let blocks_to_untrack: Vec<usize> =
-            tracked_blocks.difference(&live_blocks).copied().collect();
+            let to_untrack: Vec<usize> = tracked_blocks.difference(&live_blocks).copied().collect();
 
-        if blocks_to_untrack.is_empty() {
-            return Ok(());
-        }
+            if to_untrack.is_empty() {
+                (vec![], vec![])
+            } else {
+                let mut partial_mmr = self.store.get_current_partial_mmr().await?;
+                let mut removed_nodes: Vec<InOrderIndex> = Vec::new();
+                for &block_pos in &to_untrack {
+                    let removed = partial_mmr.untrack(block_pos);
+                    removed_nodes.extend(removed.iter().map(|(idx, _)| *idx));
+                }
 
-        // Build the PartialMmr and untrack each block, collecting removed auth nodes.
-        let mut partial_mmr = self.store.get_current_partial_mmr().await?;
-        let mut nodes_to_remove: Vec<InOrderIndex> = Vec::new();
-        for &block_pos in &blocks_to_untrack {
-            let removed = partial_mmr.untrack(block_pos);
-            nodes_to_remove.extend(removed.iter().map(|(idx, _)| *idx));
-        }
+                let block_nums: Vec<BlockNumber> = to_untrack
+                    .iter()
+                    .map(|&b| {
+                        BlockNumber::from(u32::try_from(b).expect("block number fits in u32"))
+                    })
+                    .collect();
 
-        // Atomically remove auth nodes and mark blocks as irrelevant.
-        let block_nums: Vec<BlockNumber> = blocks_to_untrack
-            .iter()
-            .map(|&b| BlockNumber::from(u32::try_from(b).expect("block number fits in u32")))
-            .collect();
+                (block_nums, removed_nodes)
+            }
+        };
 
-        self.store.untrack_blocks(&block_nums, &nodes_to_remove).await?;
+        self.store.prune_irrelevant_blocks(&blocks_to_untrack, &nodes_to_remove).await?;
 
         Ok(())
     }

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -62,7 +62,6 @@ use core::cmp::max;
 
 use miden_protocol::account::AccountId;
 use miden_protocol::block::BlockNumber;
-use miden_protocol::crypto::merkle::mmr::InOrderIndex;
 use miden_protocol::note::NoteId;
 use miden_protocol::transaction::TransactionId;
 use miden_tx::auth::TransactionAuthenticator;
@@ -228,37 +227,40 @@ where
     /// mark the blocks as irrelevant, and delete irrelevant block headers.
     async fn untrack_and_prune_irrelevant_blocks(&self) -> Result<(), ClientError> {
         let tracked_blocks = self.store.get_tracked_block_header_numbers().await?;
-        if tracked_blocks.is_empty() {
-            return Ok(());
+        let to_untrack: Vec<usize> = if tracked_blocks.is_empty() {
+            // Do not early-return: even without blocks to untrack, old irrelevant tip headers may need pruning.
+            Vec::new()
+        } else {
+            // Blocks that still have at least one unspent note need to stay tracked.
+            let unspent_notes = self.store.get_input_notes(NoteFilter::Unspent).await?;
+            let live_blocks: BTreeSet<usize> = unspent_notes
+                .iter()
+                .filter_map(|n| n.inclusion_proof().map(|p| p.location().block_num().as_usize()))
+                .collect();
+
+            tracked_blocks.difference(&live_blocks).copied().collect()
+        };
+
+        let mut blocks_to_untrack = Vec::new();
+        let mut nodes_to_remove = Vec::new();
+
+        if !to_untrack.is_empty() {
+            // Rebuild the PartialMmr and untrack each block to collect the authentication node
+            // indices that are no longer needed by any remaining tracked leaf.
+            let mut partial_mmr = self.store.get_current_partial_mmr().await?;
+            for &block_pos in &to_untrack {
+                nodes_to_remove
+                    .extend(partial_mmr.untrack(block_pos).into_iter().map(|(idx, _)| idx));
+            }
+
+            blocks_to_untrack = to_untrack
+                .iter()
+                .map(|&b| BlockNumber::from(u32::try_from(b).expect("block number fits in u32")))
+                .collect();
         }
-
-        // Blocks that still have at least one unspent note need to stay tracked.
-        let unspent_notes = self.store.get_input_notes(NoteFilter::Unspent).await?;
-        let live_blocks: BTreeSet<usize> = unspent_notes
-            .iter()
-            .filter_map(|n| n.inclusion_proof().map(|p| p.location().block_num().as_usize()))
-            .collect();
-
-        let to_untrack: Vec<usize> = tracked_blocks.difference(&live_blocks).copied().collect();
-        if to_untrack.is_empty() {
-            return Ok(());
-        }
-
-        // Rebuild the PartialMmr and untrack each block to collect the authentication node
-        // indices that are no longer needed by any remaining tracked leaf.
-        let mut partial_mmr = self.store.get_current_partial_mmr().await?;
-        let mut nodes_to_remove: Vec<InOrderIndex> = Vec::new();
-        for &block_pos in &to_untrack {
-            nodes_to_remove.extend(partial_mmr.untrack(block_pos).into_iter().map(|(idx, _)| idx));
-        }
-
-        let blocks_to_untrack: Vec<BlockNumber> = to_untrack
-            .iter()
-            .map(|&b| BlockNumber::from(u32::try_from(b).expect("block number fits in u32")))
-            .collect();
 
         // Store deletes stale auth nodes, marks blocks as irrelevant, and removes irrelevant
-        // block headers.
+        // block headers. Old irrelevant tip headers may still need pruning.
         self.store
             .untrack_and_prune_irrelevant_blocks(&blocks_to_untrack, &nodes_to_remove)
             .await?;

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -195,7 +195,6 @@ where
     pub async fn apply_state_sync(&mut self, update: StateSyncUpdate) -> Result<(), ClientError> {
         self.store.apply_state_sync(update).await?;
 
-        
         self.maybe_untrack_and_prune_irrelevant_blocks().await?;
 
         Ok(())

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -223,12 +223,9 @@ where
             .filter_map(|n| n.inclusion_proof().map(|p| p.location().block_num().as_usize()))
             .collect();
 
-        // Blocks to untrack: tracked but no longer have live notes (excluding genesis).
-        let blocks_to_untrack: Vec<usize> = tracked_blocks
-            .iter()
-            .copied()
-            .filter(|&b| b != BlockNumber::GENESIS.as_usize() && !live_blocks.contains(&b))
-            .collect();
+        // Blocks to untrack: tracked but no longer have live notes.
+        let blocks_to_untrack: Vec<usize> =
+            tracked_blocks.difference(&live_blocks).copied().collect();
 
         if blocks_to_untrack.is_empty() {
             return Ok(());

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -55,12 +55,14 @@
 //! `committed_note_updates` and `consumed_note_updates`) to understand how the sync data is
 //! processed and applied to the local store.
 
+use alloc::collections::BTreeSet;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::cmp::max;
 
 use miden_protocol::account::AccountId;
 use miden_protocol::block::BlockNumber;
+use miden_protocol::crypto::merkle::mmr::InOrderIndex;
 use miden_protocol::note::NoteId;
 use miden_protocol::transaction::TransactionId;
 use miden_tx::auth::TransactionAuthenticator;
@@ -149,7 +151,9 @@ where
             .await
             .map_err(ClientError::StoreError)?;
 
-        // Remove irrelevant block headers
+        // Prune MMR authentication nodes for blocks whose notes have all been consumed,
+        // then remove irrelevant block headers.
+        self.prune_mmr_authentication_nodes().await?;
         self.store.prune_irrelevant_blocks().await?;
 
         Ok(sync_summary)
@@ -191,8 +195,60 @@ where
     pub async fn apply_state_sync(&mut self, update: StateSyncUpdate) -> Result<(), ClientError> {
         self.store.apply_state_sync(update).await?;
 
-        // Remove irrelevant block headers
+        // Prune MMR authentication nodes for blocks whose notes have all been consumed,
+        // then remove irrelevant block headers.
+        self.prune_mmr_authentication_nodes().await?;
         self.store.prune_irrelevant_blocks().await?;
+
+        Ok(())
+    }
+
+    /// Prunes MMR authentication nodes for blocks whose input notes have all been consumed.
+    ///
+    /// This identifies tracked blocks (blocks with `has_client_notes = true`) that no longer
+    /// have any unspent input notes, untracks them from the `PartialMmr`, and atomically
+    /// removes the redundant authentication nodes from the store while marking those blocks
+    /// as irrelevant.
+    async fn prune_mmr_authentication_nodes(&self) -> Result<(), ClientError> {
+        // Get blocks currently tracked in the MMR.
+        let tracked_blocks = self.store.get_tracked_block_header_numbers().await?;
+        if tracked_blocks.is_empty() {
+            return Ok(());
+        }
+
+        // Determine which blocks still have live (unspent) input notes.
+        let unspent_notes = self.store.get_input_notes(NoteFilter::Unspent).await?;
+        let live_blocks: BTreeSet<usize> = unspent_notes
+            .iter()
+            .filter_map(|n| n.inclusion_proof().map(|p| p.location().block_num().as_usize()))
+            .collect();
+
+        // Blocks to untrack: tracked but no longer have live notes (excluding genesis).
+        let blocks_to_untrack: Vec<usize> = tracked_blocks
+            .iter()
+            .copied()
+            .filter(|&b| b != BlockNumber::GENESIS.as_usize() && !live_blocks.contains(&b))
+            .collect();
+
+        if blocks_to_untrack.is_empty() {
+            return Ok(());
+        }
+
+        // Build the PartialMmr and untrack each block, collecting removed auth nodes.
+        let mut partial_mmr = self.store.get_current_partial_mmr().await?;
+        let mut nodes_to_remove: Vec<InOrderIndex> = Vec::new();
+        for &block_pos in &blocks_to_untrack {
+            let removed = partial_mmr.untrack(block_pos);
+            nodes_to_remove.extend(removed.iter().map(|(idx, _)| *idx));
+        }
+
+        // Atomically remove auth nodes and mark blocks as irrelevant.
+        let block_nums: Vec<BlockNumber> = blocks_to_untrack
+            .iter()
+            .map(|&b| BlockNumber::from(u32::try_from(b).expect("block number fits in u32")))
+            .collect();
+
+        self.store.untrack_blocks(&block_nums, &nodes_to_remove).await?;
 
         Ok(())
     }

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -207,46 +207,37 @@ where
     /// mark the blocks as irrelevant, and delete irrelevant block headers.
     async fn untrack_and_prune_irrelevant_blocks(&self) -> Result<(), ClientError> {
         let tracked_blocks = self.store.get_tracked_block_header_numbers().await?;
+        if tracked_blocks.is_empty() {
+            return Ok(());
+        }
 
-        // Determine which tracked blocks no longer have unspent input notes and can be
-        // untracked from the MMR. For each block, PartialMmr::untrack() returns the
-        // authentication node indices that are no longer needed by any remaining tracked leaf.
-        let (blocks_to_untrack, nodes_to_remove) = if tracked_blocks.is_empty() {
-            (vec![], vec![])
-        } else {
-            // Blocks that still have at least one unspent note need to stay tracked.
-            let unspent_notes = self.store.get_input_notes(NoteFilter::Unspent).await?;
-            let live_blocks: BTreeSet<usize> = unspent_notes
-                .iter()
-                .filter_map(|n| n.inclusion_proof().map(|p| p.location().block_num().as_usize()))
-                .collect();
+        // Blocks that still have at least one unspent note need to stay tracked.
+        let unspent_notes = self.store.get_input_notes(NoteFilter::Unspent).await?;
+        let live_blocks: BTreeSet<usize> = unspent_notes
+            .iter()
+            .filter_map(|n| n.inclusion_proof().map(|p| p.location().block_num().as_usize()))
+            .collect();
 
-            let to_untrack: Vec<usize> = tracked_blocks.difference(&live_blocks).copied().collect();
+        let to_untrack: Vec<usize> = tracked_blocks.difference(&live_blocks).copied().collect();
+        if to_untrack.is_empty() {
+            return Ok(());
+        }
 
-            if to_untrack.is_empty() {
-                (vec![], vec![])
-            } else {
-                // Rebuild the PartialMmr and untrack each block to collect stale node indices.
-                let mut partial_mmr = self.store.get_current_partial_mmr().await?;
-                let mut removed_nodes: Vec<InOrderIndex> = Vec::new();
-                for &block_pos in &to_untrack {
-                    removed_nodes
-                        .extend(partial_mmr.untrack(block_pos).into_iter().map(|(idx, _)| idx));
-                }
+        // Rebuild the PartialMmr and untrack each block to collect the authentication node
+        // indices that are no longer needed by any remaining tracked leaf.
+        let mut partial_mmr = self.store.get_current_partial_mmr().await?;
+        let mut nodes_to_remove: Vec<InOrderIndex> = Vec::new();
+        for &block_pos in &to_untrack {
+            nodes_to_remove.extend(partial_mmr.untrack(block_pos).into_iter().map(|(idx, _)| idx));
+        }
 
-                let block_nums: Vec<BlockNumber> = to_untrack
-                    .iter()
-                    .map(|&b| {
-                        BlockNumber::from(u32::try_from(b).expect("block number fits in u32"))
-                    })
-                    .collect();
+        let blocks_to_untrack: Vec<BlockNumber> = to_untrack
+            .iter()
+            .map(|&b| BlockNumber::from(u32::try_from(b).expect("block number fits in u32")))
+            .collect();
 
-                (block_nums, removed_nodes)
-            }
-        };
-
-        // Store deletes stale auth nodes, marks blocks as irrelevant, and removes irrelevant block
-        // headers.
+        // Store deletes stale auth nodes, marks blocks as irrelevant, and removes irrelevant
+        // block headers.
         self.store
             .untrack_and_prune_irrelevant_blocks(&blocks_to_untrack, &nodes_to_remove)
             .await?;

--- a/crates/sqlite-store/src/chain_data.rs
+++ b/crates/sqlite-store/src/chain_data.rs
@@ -228,22 +228,23 @@ impl SqliteStore {
         Ok(())
     }
 
-    /// Removes MMR authentication nodes and marks block headers as no longer having relevant
-    /// notes.
-    pub fn untrack_blocks(
+    /// Prunes irrelevant block data from the store.
+    ///
+    /// This performs three operations in a single transaction:
+    /// 1. Deletes MMR authentication nodes at the given `node_indices`.
+    /// 2. Sets `has_client_notes = false` for `blocks_to_untrack`.
+    /// 3. Deletes block headers with `has_client_notes = false` that are not the genesis or
+    ///    sync-height block.
+    pub fn prune_irrelevant_blocks(
         conn: &mut Connection,
-        block_nums: &[BlockNumber],
-        node_indices: &[InOrderIndex],
+        blocks_to_untrack: &[BlockNumber],
+        node_indices_to_remove: &[InOrderIndex],
     ) -> Result<(), StoreError> {
-        // Early return to avoid opening a transaction when there is nothing to do.
-        if block_nums.is_empty() && node_indices.is_empty() {
-            return Ok(());
-        }
-
         let tx = conn.transaction().into_store_error()?;
 
-        if !node_indices.is_empty() {
-            let id_values = node_indices
+        // 1. Delete stale MMR authentication nodes.
+        if !node_indices_to_remove.is_empty() {
+            let id_values = node_indices_to_remove
                 .iter()
                 .map(|id| Value::Integer(i64::try_from(id.inner()).expect("id is a valid i64")))
                 .collect::<Vec<_>>();
@@ -255,8 +256,9 @@ impl SqliteStore {
             .into_store_error()?;
         }
 
-        if !block_nums.is_empty() {
-            let block_values = block_nums
+        // 2. Mark untracked blocks as irrelevant.
+        if !blocks_to_untrack.is_empty() {
+            let block_values = blocks_to_untrack
                 .iter()
                 .map(|b| Value::Integer(i64::from(b.as_u32())))
                 .collect::<Vec<_>>();
@@ -268,13 +270,7 @@ impl SqliteStore {
             .into_store_error()?;
         }
 
-        tx.commit().into_store_error()
-    }
-
-    /// Removes block headers that do not contain any client notes and aren't the genesis or last
-    /// block.
-    pub fn prune_irrelevant_blocks(conn: &mut Connection) -> Result<(), StoreError> {
-        let tx = conn.transaction().into_store_error()?;
+        // 3. Delete irrelevant block headers.
         let genesis: u32 = BlockNumber::GENESIS.as_u32();
 
         let sync_block: Option<u32> = tx
@@ -284,12 +280,10 @@ impl SqliteStore {
 
         if let Some(sync_height) = sync_block {
             tx.execute(
-                r"
-            DELETE FROM block_headers
-            WHERE has_client_notes = 0
-              AND block_num > ?1
-              AND block_num < ?2
-            ",
+                "DELETE FROM block_headers \
+                 WHERE has_client_notes = 0 \
+                 AND block_num > ?1 \
+                 AND block_num < ?2",
                 rusqlite::params![genesis, sync_height],
             )
             .into_store_error()?;
@@ -598,7 +592,7 @@ mod test {
                 .unwrap();
 
             // Prune
-            store.prune_irrelevant_blocks().await.unwrap();
+            store.prune_irrelevant_blocks(&[], &[]).await.unwrap();
 
             // Assert blocks
             let remaining_headers: i64 = store
@@ -726,7 +720,10 @@ mod test {
 
         // Execute the store operation.
         let block_nums_to_untrack = vec![BlockNumber::from(30u32)];
-        store.untrack_blocks(&block_nums_to_untrack, &removed_indices).await.unwrap();
+        store
+            .prune_irrelevant_blocks(&block_nums_to_untrack, &removed_indices)
+            .await
+            .unwrap();
 
         // Verify: fewer nodes in the table.
         let final_node_count: i64 = store
@@ -742,20 +739,20 @@ mod test {
             "expected fewer nodes after untrack, got {final_node_count} vs {initial_node_count}"
         );
 
-        // Verify: block 30 is no longer tracked.
-        let block_30_has_notes: bool = store
+        // Verify: block 30 header was deleted (it had has_client_notes set to false and
+        // was below sync_height, so prune_irrelevant_blocks removed it).
+        let block_30_exists: bool = store
             .interact_with_connection(|conn| {
                 Ok(conn
-                    .query_row(
-                        "SELECT has_client_notes FROM block_headers WHERE block_num = 30",
-                        [],
-                        |r| r.get(0),
-                    )
-                    .unwrap())
+                    .query_row("SELECT COUNT(*) FROM block_headers WHERE block_num = 30", [], |r| {
+                        r.get::<_, i64>(0)
+                    })
+                    .unwrap()
+                    > 0)
             })
             .await
             .unwrap();
-        assert!(!block_30_has_notes, "block 30 should no longer be tracked");
+        assert!(!block_30_exists, "block 30 should have been pruned");
 
         // Verify: the PartialMmr can be rebuilt and remaining tracked blocks (10, 50)
         // still have valid authentication paths.

--- a/crates/sqlite-store/src/chain_data.rs
+++ b/crates/sqlite-store/src/chain_data.rs
@@ -228,6 +228,49 @@ impl SqliteStore {
         Ok(())
     }
 
+    /// Removes MMR authentication nodes and marks block headers as no longer having relevant
+    /// notes.
+    pub fn untrack_blocks(
+        conn: &mut Connection,
+        block_nums: &[BlockNumber],
+        node_indices: &[InOrderIndex],
+    ) -> Result<(), StoreError> {
+        // Early return to avoid opening a transaction when there is nothing to do.
+        if block_nums.is_empty() && node_indices.is_empty() {
+            return Ok(());
+        }
+
+        let tx = conn.transaction().into_store_error()?;
+
+        if !node_indices.is_empty() {
+            let id_values = node_indices
+                .iter()
+                .map(|id| Value::Integer(i64::try_from(id.inner()).expect("id is a valid i64")))
+                .collect::<Vec<_>>();
+
+            tx.execute(
+                "DELETE FROM partial_blockchain_nodes WHERE id IN rarray(?)",
+                params![Rc::new(id_values)],
+            )
+            .into_store_error()?;
+        }
+
+        if !block_nums.is_empty() {
+            let block_values = block_nums
+                .iter()
+                .map(|b| Value::Integer(i64::from(b.as_u32())))
+                .collect::<Vec<_>>();
+
+            tx.execute(
+                "UPDATE block_headers SET has_client_notes = 0 WHERE block_num IN rarray(?)",
+                params![Rc::new(block_values)],
+            )
+            .into_store_error()?;
+        }
+
+        tx.commit().into_store_error()
+    }
+
     /// Removes block headers that do not contain any client notes and aren't the genesis or last
     /// block.
     pub fn prune_irrelevant_blocks(conn: &mut Connection) -> Result<(), StoreError> {
@@ -393,6 +436,7 @@ mod test {
     use miden_client::Word;
     use miden_client::block::BlockHeader;
     use miden_client::crypto::{Forest, InOrderIndex, MmrPeaks};
+    use miden_client::note::BlockNumber;
     use miden_client::store::Store;
     use miden_protocol::crypto::merkle::mmr::Mmr;
     use miden_protocol::transaction::TransactionKernel;
@@ -586,5 +630,149 @@ mod test {
                 mmr.open(block_num).unwrap().merkle_path()
             );
         }
+    }
+
+    /// Tests that untracking blocks removes their redundant authentication nodes while
+    /// preserving nodes needed by blocks that remain tracked.
+    #[tokio::test]
+    async fn untrack_blocks_removes_redundant_auth_nodes() {
+        let store = create_test_store().await;
+        const TOTAL_BLOCKS: usize = 64;
+
+        let tx_kernel_commitment = TransactionKernel.to_commitment();
+        let block_headers: Vec<BlockHeader> = (0..TOTAL_BLOCKS)
+            .map(|block_num| {
+                BlockHeader::mock(
+                    u32::try_from(block_num).unwrap(),
+                    None,
+                    None,
+                    &[],
+                    tx_kernel_commitment,
+                )
+            })
+            .collect();
+
+        // Build a full MMR and track three specific blocks.
+        let mut mmr = Mmr::default();
+        for header in &block_headers {
+            mmr.add(header.commitment());
+        }
+
+        let tracked_set: BTreeSet<usize> = [10, 30, 50].iter().copied().collect();
+
+        // Collect all authentication nodes for the tracked blocks.
+        let mut tracked_nodes: BTreeMap<InOrderIndex, Word> = BTreeMap::new();
+        for &block_num in &tracked_set {
+            let header = &block_headers[block_num];
+            tracked_nodes.insert(InOrderIndex::from_leaf_pos(block_num), header.commitment());
+            let proof = mmr.open(block_num).expect("valid proof");
+            let mut idx = InOrderIndex::from_leaf_pos(block_num);
+            for node in proof.merkle_path().nodes() {
+                tracked_nodes.insert(idx.sibling(), *node);
+                idx = idx.parent();
+            }
+        }
+        let tracked_nodes_vec: Vec<(InOrderIndex, Word)> = tracked_nodes.into_iter().collect();
+
+        let peaks_by_block: Vec<MmrPeaks> = (0..TOTAL_BLOCKS)
+            .map(|block_num| mmr.peaks_at(Forest::new(block_num)).expect("valid peaks"))
+            .collect();
+
+        // Persist blocks and nodes.
+        let block_headers_clone = block_headers.clone();
+        store
+            .interact_with_connection(move |conn| {
+                let tx = conn.transaction().unwrap();
+                for block_num in 0..TOTAL_BLOCKS {
+                    let has_notes = tracked_set.contains(&block_num);
+                    SqliteStore::insert_block_header_tx(
+                        &tx,
+                        &block_headers_clone[block_num],
+                        &peaks_by_block[block_num],
+                        has_notes,
+                    )
+                    .unwrap();
+                }
+                SqliteStore::insert_partial_blockchain_nodes_tx(&tx, &tracked_nodes_vec).unwrap();
+
+                // Set sync height to last block.
+                tx.execute(
+                    "UPDATE state_sync SET block_num = ?",
+                    params![i64::try_from(TOTAL_BLOCKS - 1).unwrap()],
+                )
+                .unwrap();
+                tx.commit().unwrap();
+                Ok(())
+            })
+            .await
+            .unwrap();
+
+        // Count initial nodes.
+        let initial_node_count: i64 = store
+            .interact_with_connection(|conn| {
+                Ok(conn
+                    .query_row("SELECT COUNT(*) FROM partial_blockchain_nodes", [], |r| r.get(0))
+                    .unwrap())
+            })
+            .await
+            .unwrap();
+        assert!(initial_node_count > 0);
+
+        // Rebuild the PartialMmr and untrack block 30 (simulate: all notes consumed).
+        let mut partial_mmr = Store::get_current_partial_mmr(&store).await.unwrap();
+        let removed_nodes = partial_mmr.untrack(30);
+        let removed_indices: Vec<InOrderIndex> =
+            removed_nodes.iter().map(|(idx, _)| *idx).collect();
+
+        // Execute the store operation.
+        let block_nums_to_untrack = vec![BlockNumber::from(30u32)];
+        store.untrack_blocks(&block_nums_to_untrack, &removed_indices).await.unwrap();
+
+        // Verify: fewer nodes in the table.
+        let final_node_count: i64 = store
+            .interact_with_connection(|conn| {
+                Ok(conn
+                    .query_row("SELECT COUNT(*) FROM partial_blockchain_nodes", [], |r| r.get(0))
+                    .unwrap())
+            })
+            .await
+            .unwrap();
+        assert!(
+            final_node_count < initial_node_count,
+            "expected fewer nodes after untrack, got {final_node_count} vs {initial_node_count}"
+        );
+
+        // Verify: block 30 is no longer tracked.
+        let block_30_has_notes: bool = store
+            .interact_with_connection(|conn| {
+                Ok(conn
+                    .query_row(
+                        "SELECT has_client_notes FROM block_headers WHERE block_num = 30",
+                        [],
+                        |r| r.get(0),
+                    )
+                    .unwrap())
+            })
+            .await
+            .unwrap();
+        assert!(!block_30_has_notes, "block 30 should no longer be tracked");
+
+        // Verify: the PartialMmr can be rebuilt and remaining tracked blocks (10, 50)
+        // still have valid authentication paths.
+        let rebuilt_mmr = Store::get_current_partial_mmr(&store).await.unwrap();
+        assert_eq!(rebuilt_mmr.peaks().hash_peaks(), mmr.peaks().hash_peaks());
+
+        for &block_num in &[10, 50] {
+            let partial_proof = rebuilt_mmr.open(block_num).expect("partial mmr query succeeds");
+            assert!(partial_proof.is_some(), "block {block_num} should still be provable");
+            assert_eq!(
+                partial_proof.unwrap().merkle_path(),
+                mmr.open(block_num).unwrap().merkle_path()
+            );
+        }
+
+        // Verify: block 30 is no longer provable.
+        let block_30_proof = rebuilt_mmr.open(30).expect("open should not error");
+        assert!(block_30_proof.is_none(), "block 30 should no longer be provable");
     }
 }

--- a/crates/sqlite-store/src/chain_data.rs
+++ b/crates/sqlite-store/src/chain_data.rs
@@ -626,70 +626,65 @@ mod test {
         }
     }
 
-    /// Tests that untracking blocks removes their redundant authentication nodes while
-    /// preserving nodes needed by blocks that remain tracked.
-    #[tokio::test]
-    async fn untrack_blocks_removes_redundant_auth_nodes() {
-        let store = create_test_store().await;
-        const TOTAL_BLOCKS: usize = 64;
-
-        let tx_kernel_commitment = TransactionKernel.to_commitment();
-        let block_headers: Vec<BlockHeader> = (0..TOTAL_BLOCKS)
-            .map(|block_num| {
-                BlockHeader::mock(
-                    u32::try_from(block_num).unwrap(),
-                    None,
-                    None,
-                    &[],
-                    tx_kernel_commitment,
-                )
-            })
-            .collect();
-
-        // Build a full MMR and track three specific blocks.
-        let mut mmr = Mmr::default();
-        for header in &block_headers {
-            mmr.add(header.commitment());
-        }
-
-        let tracked_set: BTreeSet<usize> = [10, 30, 50].iter().copied().collect();
-
-        // Collect all authentication nodes for the tracked blocks.
-        let mut tracked_nodes: BTreeMap<InOrderIndex, Word> = BTreeMap::new();
-        for &block_num in &tracked_set {
-            let header = &block_headers[block_num];
-            tracked_nodes.insert(InOrderIndex::from_leaf_pos(block_num), header.commitment());
+    /// Collects authentication nodes for a set of tracked leaves in an MMR.
+    fn collect_auth_nodes(
+        mmr: &Mmr,
+        block_headers: &[BlockHeader],
+        tracked: &BTreeSet<usize>,
+    ) -> Vec<(InOrderIndex, Word)> {
+        let mut nodes: BTreeMap<InOrderIndex, Word> = BTreeMap::new();
+        for &block_num in tracked {
+            nodes.insert(
+                InOrderIndex::from_leaf_pos(block_num),
+                block_headers[block_num].commitment(),
+            );
             let proof = mmr.open(block_num).expect("valid proof");
             let mut idx = InOrderIndex::from_leaf_pos(block_num);
             for node in proof.merkle_path().nodes() {
-                tracked_nodes.insert(idx.sibling(), *node);
+                nodes.insert(idx.sibling(), *node);
                 idx = idx.parent();
             }
         }
-        let tracked_nodes_vec: Vec<(InOrderIndex, Word)> = tracked_nodes.into_iter().collect();
+        nodes.into_iter().collect()
+    }
 
-        let peaks_by_block: Vec<MmrPeaks> = (0..TOTAL_BLOCKS)
-            .map(|block_num| mmr.peaks_at(Forest::new(block_num)).expect("valid peaks"))
+    /// Tests that `prune_irrelevant_blocks` removes redundant authentication nodes for
+    /// untracked blocks while preserving nodes needed by blocks that remain tracked.
+    #[tokio::test]
+    async fn prune_irrelevant_blocks_removes_redundant_auth_nodes() {
+        let store = create_test_store().await;
+        const TOTAL_BLOCKS: usize = 16;
+        let tx_kernel = TransactionKernel.to_commitment();
+
+        let headers: Vec<BlockHeader> = (0..TOTAL_BLOCKS)
+            .map(|n| BlockHeader::mock(u32::try_from(n).unwrap(), None, None, &[], tx_kernel))
             .collect();
+        let mut mmr = Mmr::default();
+        for h in &headers {
+            mmr.add(h.commitment());
+        }
 
-        // Persist blocks and nodes.
-        let block_headers_clone = block_headers.clone();
+        // Track blocks 3 and 10; we will untrack 3 later.
+        let tracked: BTreeSet<usize> = [3, 10].into();
+        let auth_nodes = collect_auth_nodes(&mmr, &headers, &tracked);
+        let peaks_by_block: Vec<MmrPeaks> =
+            (0..TOTAL_BLOCKS).map(|n| mmr.peaks_at(Forest::new(n)).unwrap()).collect();
+
+        // Persist everything.
+        let headers_clone = headers.clone();
         store
             .interact_with_connection(move |conn| {
                 let tx = conn.transaction().unwrap();
-                for block_num in 0..TOTAL_BLOCKS {
-                    let has_notes = tracked_set.contains(&block_num);
+                for i in 0..TOTAL_BLOCKS {
                     SqliteStore::insert_block_header_tx(
                         &tx,
-                        &block_headers_clone[block_num],
-                        &peaks_by_block[block_num],
-                        has_notes,
+                        &headers_clone[i],
+                        &peaks_by_block[i],
+                        tracked.contains(&i),
                     )
                     .unwrap();
                 }
-                SqliteStore::insert_partial_blockchain_nodes_tx(&tx, &tracked_nodes_vec).unwrap();
-
-                // Set sync height to last block.
+                SqliteStore::insert_partial_blockchain_nodes_tx(&tx, &auth_nodes).unwrap();
                 tx.execute(
                     "UPDATE state_sync SET block_num = ?",
                     params![i64::try_from(TOTAL_BLOCKS - 1).unwrap()],
@@ -701,75 +696,25 @@ mod test {
             .await
             .unwrap();
 
-        // Count initial nodes.
-        let initial_node_count: i64 = store
-            .interact_with_connection(|conn| {
-                Ok(conn
-                    .query_row("SELECT COUNT(*) FROM partial_blockchain_nodes", [], |r| r.get(0))
-                    .unwrap())
-            })
-            .await
-            .unwrap();
-        assert!(initial_node_count > 0);
-
-        // Rebuild the PartialMmr and untrack block 30 (simulate: all notes consumed).
+        // Untrack block 3 via the PartialMmr, then prune.
         let mut partial_mmr = Store::get_current_partial_mmr(&store).await.unwrap();
-        let removed_nodes = partial_mmr.untrack(30);
-        let removed_indices: Vec<InOrderIndex> =
-            removed_nodes.iter().map(|(idx, _)| *idx).collect();
+        let removed: Vec<InOrderIndex> =
+            partial_mmr.untrack(3).into_iter().map(|(idx, _)| idx).collect();
+        assert!(!removed.is_empty(), "untracking should remove at least one node");
 
-        // Execute the store operation.
-        let block_nums_to_untrack = vec![BlockNumber::from(30u32)];
         store
-            .prune_irrelevant_blocks(&block_nums_to_untrack, &removed_indices)
+            .prune_irrelevant_blocks(&[BlockNumber::from(3u32)], &removed)
             .await
             .unwrap();
 
-        // Verify: fewer nodes in the table.
-        let final_node_count: i64 = store
-            .interact_with_connection(|conn| {
-                Ok(conn
-                    .query_row("SELECT COUNT(*) FROM partial_blockchain_nodes", [], |r| r.get(0))
-                    .unwrap())
-            })
-            .await
-            .unwrap();
-        assert!(
-            final_node_count < initial_node_count,
-            "expected fewer nodes after untrack, got {final_node_count} vs {initial_node_count}"
-        );
+        // Block 3 header should be deleted, block 10 should still be provable.
+        let rebuilt = Store::get_current_partial_mmr(&store).await.unwrap();
+        assert_eq!(rebuilt.peaks().hash_peaks(), mmr.peaks().hash_peaks());
 
-        // Verify: block 30 header was deleted (it had has_client_notes set to false and
-        // was below sync_height, so prune_irrelevant_blocks removed it).
-        let block_30_exists: bool = store
-            .interact_with_connection(|conn| {
-                Ok(conn
-                    .query_row("SELECT COUNT(*) FROM block_headers WHERE block_num = 30", [], |r| {
-                        r.get::<_, i64>(0)
-                    })
-                    .unwrap()
-                    > 0)
-            })
-            .await
-            .unwrap();
-        assert!(!block_30_exists, "block 30 should have been pruned");
+        let proof_10 = rebuilt.open(10).expect("open succeeds");
+        assert!(proof_10.is_some(), "block 10 should still be provable");
 
-        // Verify: the PartialMmr can be rebuilt and remaining tracked blocks (10, 50)
-        // still have valid authentication paths.
-        let rebuilt_mmr = Store::get_current_partial_mmr(&store).await.unwrap();
-        assert_eq!(rebuilt_mmr.peaks().hash_peaks(), mmr.peaks().hash_peaks());
-
-        for &block_num in &[10, 50] {
-            let partial_proof = rebuilt_mmr.open(block_num).expect("partial mmr query succeeds");
-            assert!(partial_proof.is_some(), "block {block_num} should still be provable");
-            assert_eq!(
-                partial_proof.unwrap().merkle_path(),
-                mmr.open(block_num).unwrap().merkle_path()
-            );
-        }
-
-        // Verify: block 30 is no longer provable.
-        let block_30_proof = rebuilt_mmr.open(30).expect("open should not error");
-        assert!(block_30_proof.is_none(), "block 30 should no longer be provable");
+        let proof_3 = rebuilt.open(3).expect("open succeeds");
+        assert!(proof_3.is_none(), "block 3 should no longer be provable");
     }
 }

--- a/crates/sqlite-store/src/chain_data.rs
+++ b/crates/sqlite-store/src/chain_data.rs
@@ -592,7 +592,7 @@ mod test {
                 .unwrap();
 
             // Prune
-            store.prune_irrelevant_blocks(&[], &[]).await.unwrap();
+            store.untrack_and_prune_irrelevant_blocks(&[], &[]).await.unwrap();
 
             // Assert blocks
             let remaining_headers: i64 = store
@@ -648,8 +648,8 @@ mod test {
         nodes.into_iter().collect()
     }
 
-    /// Tests that `prune_irrelevant_blocks` removes redundant authentication nodes for
-    /// untracked blocks while preserving nodes needed by blocks that remain tracked.
+    /// Tests that `untrack_and_prune_irrelevant_blocks` removes redundant authentication nodes
+    /// for untracked blocks while preserving nodes needed by blocks that remain tracked.
     #[tokio::test]
     async fn prune_irrelevant_blocks_removes_redundant_auth_nodes() {
         let store = create_test_store().await;
@@ -703,7 +703,7 @@ mod test {
         assert!(!removed.is_empty(), "untracking should remove at least one node");
 
         store
-            .prune_irrelevant_blocks(&[BlockNumber::from(3u32)], &removed)
+            .untrack_and_prune_irrelevant_blocks(&[BlockNumber::from(3u32)], &removed)
             .await
             .unwrap();
 

--- a/crates/sqlite-store/src/lib.rs
+++ b/crates/sqlite-store/src/lib.rs
@@ -284,6 +284,19 @@ impl Store for SqliteStore {
         self.interact_with_connection(SqliteStore::prune_irrelevant_blocks).await
     }
 
+    async fn untrack_blocks(
+        &self,
+        block_nums: &[BlockNumber],
+        node_indices: &[InOrderIndex],
+    ) -> Result<(), StoreError> {
+        let block_nums = block_nums.to_vec();
+        let node_indices = node_indices.to_vec();
+        self.interact_with_connection(move |conn| {
+            SqliteStore::untrack_blocks(conn, &block_nums, &node_indices)
+        })
+        .await
+    }
+
     async fn prune_account_history(
         &self,
         account_id: AccountId,

--- a/crates/sqlite-store/src/lib.rs
+++ b/crates/sqlite-store/src/lib.rs
@@ -280,7 +280,7 @@ impl Store for SqliteStore {
         .await
     }
 
-    async fn prune_irrelevant_blocks(
+    async fn untrack_and_prune_irrelevant_blocks(
         &self,
         blocks_to_untrack: &[BlockNumber],
         node_indices_to_remove: &[InOrderIndex],

--- a/crates/sqlite-store/src/lib.rs
+++ b/crates/sqlite-store/src/lib.rs
@@ -280,19 +280,15 @@ impl Store for SqliteStore {
         .await
     }
 
-    async fn prune_irrelevant_blocks(&self) -> Result<(), StoreError> {
-        self.interact_with_connection(SqliteStore::prune_irrelevant_blocks).await
-    }
-
-    async fn untrack_blocks(
+    async fn prune_irrelevant_blocks(
         &self,
-        block_nums: &[BlockNumber],
-        node_indices: &[InOrderIndex],
+        blocks_to_untrack: &[BlockNumber],
+        node_indices_to_remove: &[InOrderIndex],
     ) -> Result<(), StoreError> {
-        let block_nums = block_nums.to_vec();
-        let node_indices = node_indices.to_vec();
+        let blocks_to_untrack = blocks_to_untrack.to_vec();
+        let node_indices_to_remove = node_indices_to_remove.to_vec();
         self.interact_with_connection(move |conn| {
-            SqliteStore::untrack_blocks(conn, &block_nums, &node_indices)
+            SqliteStore::prune_irrelevant_blocks(conn, &blocks_to_untrack, &node_indices_to_remove)
         })
         .await
     }

--- a/crates/testing/miden-client-tests/src/tests.rs
+++ b/crates/testing/miden-client-tests/src/tests.rs
@@ -451,23 +451,22 @@ async fn sync_state_mmr() {
     let partial_mmr = client.test_store().get_current_partial_mmr().await.unwrap();
     assert!(partial_mmr.forest().num_leaves() >= 6);
     assert!(partial_mmr.open(0).unwrap().is_none());
+    // Block 1 holds the only unspent public note, so its leaf stays tracked.
     assert!(partial_mmr.open(1).unwrap().is_some());
     assert!(partial_mmr.open(2).unwrap().is_none());
     assert!(partial_mmr.open(3).unwrap().is_none());
-    assert!(partial_mmr.open(4).unwrap().is_some());
+    // Block 4's notes are all consumed externally, so pruning untracks its leaf.
+    assert!(partial_mmr.open(4).unwrap().is_none());
     assert!(partial_mmr.open(5).unwrap().is_none());
 
-    // // Ensure the proofs are valid
+    // Ensure the proof for the remaining tracked leaf is valid
     let mmr_proof = partial_mmr.open(1).unwrap().unwrap();
     let (block_1, _) = rpc_api.get_block_header_by_number(Some(1.into()), false).await.unwrap();
     partial_mmr.peaks().verify(block_1.commitment(), mmr_proof).unwrap();
 
-    let mmr_proof = partial_mmr.open(4).unwrap().unwrap();
-    let (block_4, _) = rpc_api.get_block_header_by_number(Some(4.into()), false).await.unwrap();
-    partial_mmr.peaks().verify(block_4.commitment(), mmr_proof).unwrap();
-
-    // the blocks for both notes should be stored as they are relevant for the client's accounts
-    assert_eq!(client.test_store().get_tracked_block_headers().await.unwrap().len(), 2);
+    // Only block 1 remains tracked after pruning; block 4 was untracked because all its
+    // notes are already consumed externally.
+    assert_eq!(client.test_store().get_tracked_block_headers().await.unwrap().len(), 1);
 }
 
 /// Tests that MMR authentication nodes are persisted even when `include_block` is false
@@ -650,7 +649,9 @@ async fn sync_state_tags() {
 
     // as we are syncing with tags, the response should contain blocks for both notes
     assert_eq!(client.get_input_notes(NoteFilter::All).await.unwrap().len(), 2);
-    assert_eq!(client.test_store().get_tracked_block_headers().await.unwrap().len(), 2);
+    // Only the public note is unspent; the private note is consumed externally, so its
+    // block is pruned immediately after sync.
+    assert_eq!(client.test_store().get_tracked_block_headers().await.unwrap().len(), 1);
 }
 
 #[tokio::test]

--- a/crates/testing/miden-client-tests/src/tests.rs
+++ b/crates/testing/miden-client-tests/src/tests.rs
@@ -1286,6 +1286,114 @@ async fn input_note_reader_finds_externally_consumed_notes() {
 }
 
 #[tokio::test]
+async fn irrelevant_block_pruning_respects_sync_interval() {
+    let mut builder = MockChainBuilder::new();
+    let mock_account = builder.add_existing_mock_account(miden_testing::Auth::IncrNonce).unwrap();
+
+    let note_first =
+        NoteBuilder::new(mock_account.id(), RandomCoin::new([0, 0, 0, 0].map(Felt::new).into()))
+            .note_type(NoteType::Public)
+            .tag(NoteTag::new(0).into())
+            .build()
+            .unwrap();
+    let note_second =
+        NoteBuilder::new(mock_account.id(), RandomCoin::new([0, 0, 0, 1].map(Felt::new).into()))
+            .note_type(NoteType::Public)
+            .tag(NoteTag::new(0).into())
+            .build()
+            .unwrap();
+
+    let spawn_note_1 = builder.add_spawn_note(std::slice::from_ref(&note_first)).unwrap();
+    let spawn_note_2 = builder.add_spawn_note(std::slice::from_ref(&note_second)).unwrap();
+
+    let mut chain = builder.build().unwrap();
+
+    // Block 1: create the first unspent note.
+    let tx = Box::pin(
+        chain
+            .build_tx_context(TxContextInput::AccountId(mock_account.id()), &[], &[spawn_note_1])
+            .unwrap()
+            .extend_expected_output_notes(vec![RawOutputNote::Full(note_first)])
+            .build()
+            .unwrap()
+            .execute(),
+    )
+    .await
+    .unwrap();
+    chain.add_pending_executed_transaction(&tx).unwrap();
+    chain.prove_next_block().unwrap();
+
+    // Blocks 2 and 3: advance the chain without changing tracked notes.
+    chain.prove_next_block().unwrap();
+    chain.prove_next_block().unwrap();
+
+    // Block 4: create the second note, which will later become irrelevant.
+    let tx = Box::pin(
+        chain
+            .build_tx_context(TxContextInput::AccountId(mock_account.id()), &[], &[spawn_note_2])
+            .unwrap()
+            .extend_expected_output_notes(vec![RawOutputNote::Full(note_second.clone())])
+            .build()
+            .unwrap()
+            .execute(),
+    )
+    .await
+    .unwrap();
+    chain.add_pending_executed_transaction(&tx).unwrap();
+    chain.prove_next_block().unwrap();
+
+    let rng = RandomCoin::new(rand::random::<[u64; 4]>().map(Felt::new).into());
+    let keystore_path = std::env::temp_dir();
+    let keystore = FilesystemKeyStore::new(keystore_path).unwrap();
+    let mock_rpc = MockRpcApi::new(chain);
+
+    let mut client = ClientBuilder::new()
+        .rpc(Arc::new(mock_rpc.clone()))
+        .rng(Box::new(rng))
+        .sqlite_store(create_test_store_path())
+        .authenticator(Arc::new(keystore))
+        .in_debug_mode(DebugMode::Enabled)
+        .tx_discard_delta(None)
+        .irrelevant_block_prune_interval(Some(2))
+        .build()
+        .await
+        .unwrap();
+    client.ensure_genesis_in_place().await.unwrap();
+    client.add_note_tag(NoteTag::new(0)).await.unwrap();
+
+    client.sync_state().await.unwrap();
+    assert_eq!(client.test_store().get_tracked_block_headers().await.unwrap().len(), 2);
+
+    let tx = {
+        let tx_context = mock_rpc
+            .mock_chain
+            .write()
+            .build_tx_context(TxContextInput::AccountId(mock_account.id()), &[], &[note_second])
+            .unwrap()
+            .build()
+            .unwrap();
+        Box::pin(tx_context.execute()).await.unwrap()
+    };
+    mock_rpc.mock_chain.write().add_pending_executed_transaction(&tx).unwrap();
+    mock_rpc.prove_block();
+
+    client.sync_state().await.unwrap();
+    assert_eq!(
+        client.test_store().get_tracked_block_headers().await.unwrap().len(),
+        2,
+        "pruning should be deferred until the configured sync interval elapses",
+    );
+
+    mock_rpc.prove_block();
+    client.sync_state().await.unwrap();
+    assert_eq!(
+        client.test_store().get_tracked_block_headers().await.unwrap().len(),
+        1,
+        "the irrelevant block should be pruned once the sync interval is reached",
+    );
+}
+
+#[tokio::test]
 async fn p2id_transfer_failing_not_enough_balance() {
     let (mut client, mock_rpc_api, authenticator) = Box::pin(create_test_client()).await;
 

--- a/crates/testing/miden-client-tests/src/tests.rs
+++ b/crates/testing/miden-client-tests/src/tests.rs
@@ -1417,8 +1417,7 @@ async fn irrelevant_block_pruning_respects_sync_interval() {
 
 #[tokio::test]
 async fn irrelevant_block_pruning_disabled_when_interval_is_none() {
-    let (mut client, mock_rpc, account_id, note_second) =
-        setup_prunable_block_scenario(None).await;
+    let (mut client, mock_rpc, account_id, note_second) = setup_prunable_block_scenario(None).await;
 
     consume_note_and_prove(&mock_rpc, account_id, note_second).await;
 

--- a/crates/testing/miden-client-tests/src/tests.rs
+++ b/crates/testing/miden-client-tests/src/tests.rs
@@ -1285,8 +1285,12 @@ async fn input_note_reader_finds_externally_consumed_notes() {
     assert_eq!(collected[0].consumer_account(), Some(consumer_id));
 }
 
-#[tokio::test]
-async fn irrelevant_block_pruning_respects_sync_interval() {
+/// Builds a chain with two blocks relevant to a tracked account (blocks 1 and 4) and a client
+/// synced up to block 4 with `prune_interval` configured. Returns the consuming pieces needed to
+/// make block 4 irrelevant on demand.
+async fn setup_prunable_block_scenario(
+    prune_interval: Option<u32>,
+) -> (MockClient<FilesystemKeyStore>, MockRpcApi, AccountId, Note) {
     let mut builder = MockChainBuilder::new();
     let mock_account = builder.add_existing_mock_account(miden_testing::Auth::IncrNonce).unwrap();
 
@@ -1308,7 +1312,7 @@ async fn irrelevant_block_pruning_respects_sync_interval() {
 
     let mut chain = builder.build().unwrap();
 
-    // Block 1: create the first unspent note.
+    // Block 1: create the first unspent note (keeps block 1 permanently relevant).
     let tx = Box::pin(
         chain
             .build_tx_context(TxContextInput::AccountId(mock_account.id()), &[], &[spawn_note_1])
@@ -1327,7 +1331,8 @@ async fn irrelevant_block_pruning_respects_sync_interval() {
     chain.prove_next_block().unwrap();
     chain.prove_next_block().unwrap();
 
-    // Block 4: create the second note, which will later become irrelevant.
+    // Block 4: create the second note, which the caller will later consume to make block 4
+    // irrelevant.
     let tx = Box::pin(
         chain
             .build_tx_context(TxContextInput::AccountId(mock_account.id()), &[], &[spawn_note_2])
@@ -1343,8 +1348,7 @@ async fn irrelevant_block_pruning_respects_sync_interval() {
     chain.prove_next_block().unwrap();
 
     let rng = RandomCoin::new(rand::random::<[u64; 4]>().map(Felt::new).into());
-    let keystore_path = std::env::temp_dir();
-    let keystore = FilesystemKeyStore::new(keystore_path).unwrap();
+    let keystore = FilesystemKeyStore::new(std::env::temp_dir()).unwrap();
     let mock_rpc = MockRpcApi::new(chain);
 
     let mut client = ClientBuilder::new()
@@ -1354,7 +1358,7 @@ async fn irrelevant_block_pruning_respects_sync_interval() {
         .authenticator(Arc::new(keystore))
         .in_debug_mode(DebugMode::Enabled)
         .tx_discard_delta(None)
-        .irrelevant_block_prune_interval(Some(2))
+        .irrelevant_block_prune_interval(prune_interval)
         .build()
         .await
         .unwrap();
@@ -1362,13 +1366,23 @@ async fn irrelevant_block_pruning_respects_sync_interval() {
     client.add_note_tag(NoteTag::new(0)).await.unwrap();
 
     client.sync_state().await.unwrap();
-    assert_eq!(client.test_store().get_tracked_block_headers().await.unwrap().len(), 2);
+    assert_eq!(
+        client.test_store().get_tracked_block_headers().await.unwrap().len(),
+        2,
+        "setup precondition: two relevant blocks tracked",
+    );
 
+    (client, mock_rpc, mock_account.id(), note_second)
+}
+
+/// Consumes `note` against `account_id` on the mocked chain and proves the resulting block, so the
+/// block that originally carried the note becomes irrelevant from the client's perspective.
+async fn consume_note_and_prove(mock_rpc: &MockRpcApi, account_id: AccountId, note: Note) {
     let tx = {
         let tx_context = mock_rpc
             .mock_chain
             .write()
-            .build_tx_context(TxContextInput::AccountId(mock_account.id()), &[], &[note_second])
+            .build_tx_context(TxContextInput::AccountId(account_id), &[], &[note])
             .unwrap()
             .build()
             .unwrap();
@@ -1376,6 +1390,14 @@ async fn irrelevant_block_pruning_respects_sync_interval() {
     };
     mock_rpc.mock_chain.write().add_pending_executed_transaction(&tx).unwrap();
     mock_rpc.prove_block();
+}
+
+#[tokio::test]
+async fn irrelevant_block_pruning_respects_sync_interval() {
+    let (mut client, mock_rpc, account_id, note_second) =
+        setup_prunable_block_scenario(Some(2)).await;
+
+    consume_note_and_prove(&mock_rpc, account_id, note_second).await;
 
     client.sync_state().await.unwrap();
     assert_eq!(
@@ -1391,6 +1413,25 @@ async fn irrelevant_block_pruning_respects_sync_interval() {
         1,
         "the irrelevant block should be pruned once the sync interval is reached",
     );
+}
+
+#[tokio::test]
+async fn irrelevant_block_pruning_disabled_when_interval_is_none() {
+    let (mut client, mock_rpc, account_id, note_second) =
+        setup_prunable_block_scenario(None).await;
+
+    consume_note_and_prove(&mock_rpc, account_id, note_second).await;
+
+    // With pruning disabled, both tracked blocks must remain across repeated syncs.
+    for _ in 0..5 {
+        mock_rpc.prove_block();
+        client.sync_state().await.unwrap();
+        assert_eq!(
+            client.test_store().get_tracked_block_headers().await.unwrap().len(),
+            2,
+            "no pruning should occur when the prune interval is None",
+        );
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Description

After each sync, the client now identifies tracked blocks whose input notes have all been consumed and prunes their MMR authentication nodes from storage. Previously, `partial_blockchain_nodes` grew unboundedly because nodes were inserted but never removed.

The pruning is integrated into [prune_irrelevant_blocks](https://github.com/0xMiden/miden-client/blob/517ece389c3fe01585229bd31d62bb4ca3bd37f5/crates/rust-client/src/sync/mod.rs#L208-L247), which now also handles MMR cleanup:

1. Rebuilds `PartialMmr` from the store (this may change after addressing #1779).
2. Gets tracked blocks (`has_client_notes = true`).
3. Gets blocks with live notes: `get_input_notes(Unspent)` -> extract inclusion block numbers.
4. `blocks_to_untrack = tracked - live`.
5. For each block: `removed_nodes += partial_mmr.untrack(block_pos)`.
6. Delegates to [Store::prune_irrelevant_blocks](https://github.com/0xMiden/miden-client/blob/517ece389c3fe01585229bd31d62bb4ca3bd37f5/crates/rust-client/src/store/mod.rs#L273-L277) which:
   - Deletes the stale authentication nodes from `partial_blockchain_nodes`.
   - Sets `has_client_notes = false` for the untracked blocks.
   - Deletes block headers with `has_client_notes = false` (same as before).

Closes #2001

---
## Benchmarks

I've measured in 3 places, next, this branch and the branch on top of this that has the PartialMMR in memory instead of rebuilding it every time.
The third branch shows dramatic improvements over the other two, especially the bigger the MMR becomes.
In this branch the sync itself is slower because we've added logic for pruning the MMR nodes and this executes on every sync. An alternative that we should consider if we care a lot about sync speeds would be to decouple the sync from the pruning and perhaps we could prune periodically instead of on every sync, that way we'll get the benefits of having a smaller MMR without affecting the sync at all. I think it's pretty reasonable but we'll have to see.

I'll leave current info about the bench down below. I will keep it up to date. Note that the total time of `sync_state` is almost the best in next for these measurements because the pruning added overhead to it. But anyway if we had a huge MMR the cache branch would definitely win on performance.

#### `sync_state` cross-branch bench

Local `NodeBuilder` node. Faucet mints N P2ID notes (one per block) to a tracked wallet; wallet consumes first 30% contiguously. Then 2 warmup + 10 sampled `sync_state` calls per branch. Release, Apple M4 MAX. All branches measured at a common base (merges of `origin/next` @ `dca43cb4`).

| N | Branch | `sync_state` p50 | `get_mmr` p50 | tracked |
|---:|---|---:|---:|---:|
|  10 | next         |   606.0µs |  74.0µs |  10 |
|  10 | prune-merged |   730.3µs |  72.6µs |   8 |
|  10 | cache-merged | **585.2µs** | **26.1µs** |   8 |
|  50 | next         |  1160.4µs | 119.8µs |  50 |
|  50 | prune-merged |  1240.6µs | 104.5µs |  36 |
|  50 | cache-merged |  1245.6µs | **27.2µs** |  36 |
| 200 | next         |  3558.6µs | 322.1µs | 200 |
| 200 | prune-merged |  4033.4µs | 247.0µs | 141 |
| 200 | cache-merged | **3525.3µs** | **30.3µs** | 141 |

**Cache**: `get_current_partial_mmr` is almost flat at ~30µs vs next scaling linearly (74 → 322µs). At N=200, ~11× faster, and top-level `sync_state` reaches parity with next. Pulls further ahead at larger N.

**Prune**: ~80–475µs regression on `sync_state`, growing with N. Root cause is a redundant `get_input_notes(Unspent)` inside `untrack_and_prune_irrelevant_blocks` that deserializes full records just to read inclusion block numbers (~500µs at N=200). There's a cheap fix that needs a Store trait addition, but I didn't add it for now because I didn't want to create a Store method just for this.
