### PR TITLE
fix(web): stop `insertBlockHeader` from overwriting historical peaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.14.2 (TBD)
+
+### Fixes
+
+* [FIX][web] Fixed `syncState` deterministically failing with `mmr peaks are invalid: number of one bits in leaves is N which does not equal peak length M` after importing a private note whose inclusion block pre-dates the wallet's current sync height. `get_and_store_authenticated_block` was overwriting the correct historical peaks (written by `applyStateSync`) with peaks from the caller's current `PartialMmr` forest, so subsequent reads at the same block hit the `InvalidPeaks` validation. The IndexedDB `insertBlockHeader` now uses add-if-not-exists semantics, matching the SQLite store's `INSERT OR IGNORE` in `insert_block_header_tx` ([#2037](https://github.com/0xMiden/miden-client/issues/2037)).
+
 ## 0.14.1 (2026-04-14)
 
 ### Enhancements

--- a/crates/idxdb-store/src/js/chainData.js
+++ b/crates/idxdb-store/src/js/chainData.js
@@ -9,7 +9,20 @@ export async function insertBlockHeader(dbId, blockNum, header, partialBlockchai
             partialBlockchainPeaks,
             hasClientNotes: hasClientNotes.toString(),
         };
-        await db.blockHeaders.put(data);
+        // Add-if-not-exists semantics, matching SQLite's `INSERT OR IGNORE` in
+        // `insert_block_header_tx`. `insertBlockHeader` is called both by the
+        // genesis flow (no existing row) and by `get_and_store_authenticated_block`
+        // for backfilled past blocks. In the backfill case, overwriting the row
+        // previously written by `applyStateSync` would replace the correct
+        // historical peaks (popcount == block_num) with peaks for the caller's
+        // current PartialMmr forest (popcount == current sync height). Later
+        // reads of those peaks trip the `InvalidPeaks` validation and can wedge
+        // sync for the rest of the session.
+        await db.blockHeaders.add(data).catch((err) => {
+            if (err?.name === "ConstraintError")
+                return; // row already exists, keep it
+            throw err;
+        });
     }
     catch (err) {
         logWebStoreError(err);

--- a/crates/idxdb-store/src/js/chainData.js
+++ b/crates/idxdb-store/src/js/chainData.js
@@ -9,24 +9,39 @@ export async function insertBlockHeader(dbId, blockNum, header, partialBlockchai
             partialBlockchainPeaks,
             hasClientNotes: hasClientNotes.toString(),
         };
-        // Add-if-not-exists semantics, matching SQLite's `INSERT OR IGNORE` in
-        // `insert_block_header_tx`. `insertBlockHeader` is called both by the
-        // genesis flow (no existing row) and by `get_and_store_authenticated_block`
-        // for backfilled past blocks. In the backfill case, overwriting the row
-        // previously written by `applyStateSync` would replace the correct
-        // historical peaks (popcount == block_num) with peaks for the caller's
-        // current PartialMmr forest (popcount == current sync height). Later
-        // reads of those peaks trip the `InvalidPeaks` validation and can wedge
-        // sync for the rest of the session.
-        await db.blockHeaders.add(data).catch((err) => {
-            if (err?.name === "ConstraintError")
-                return; // row already exists, keep it
-            throw err;
+        // Mirror SQLite's `insert_block_header_tx`: do an INSERT OR IGNORE on the
+        // row, then explicitly upgrade `has_client_notes` to true if the caller
+        // says so. Two callers hit this:
+        //   - Genesis flow — no existing row; the add succeeds.
+        //   - `get_and_store_authenticated_block` for a past block — a row
+        //     written by `applyStateSync` typically already exists. Overwriting
+        //     it would clobber the correct historical peaks (popcount ==
+        //     block_num) with peaks from the caller's current `PartialMmr`
+        //     forest (popcount == current sync height). Later reads of those
+        //     peaks trip `MmrPeaks::new`'s InvalidPeaks validation and wedge
+        //     sync for the rest of the session.
+        //
+        // The `has_client_notes` upgrade is load-bearing: `get_tracked_block_
+        // header_numbers` filters by this flag to seed `tracked_leaves`, which
+        // `get_partial_blockchain_nodes(Forest)` relies on. A private-note
+        // import at a block previously synced as irrelevant must flip the flag
+        // to true or the auth paths won't be tracked.
+        await db.blockHeaders.add(data).catch(async (err) => {
+            if (!isConstraintError(err))
+                throw err;
+            if (hasClientNotes) {
+                await db.blockHeaders.update(blockNum, { hasClientNotes: "true" });
+            }
         });
     }
     catch (err) {
         logWebStoreError(err);
     }
+}
+/** Detect Dexie's primary-key collision error across sync + bulk wrappings. */
+function isConstraintError(err) {
+    const e = err;
+    return e?.name === "ConstraintError" || e?.inner?.name === "ConstraintError";
 }
 export async function insertPartialBlockchainNodes(dbId, ids, nodes) {
     try {

--- a/crates/idxdb-store/src/ts/chainData.test.ts
+++ b/crates/idxdb-store/src/ts/chainData.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  getPartialBlockchainPeaksByBlockNum,
+  insertBlockHeader,
+} from "./chainData.js";
+import { getDatabase, openDatabase } from "./schema.js";
+import { uniqueDbName } from "./test-utils.js";
+
+// Track opened DB ids for per-test cleanup so suites don't leak state into
+// each other (fake-indexeddb is process-global).
+const openDbIds: string[] = [];
+
+afterEach(async () => {
+  for (const dbId of openDbIds) {
+    const db = getDatabase(dbId);
+    db.dexie.close();
+    await db.dexie.delete();
+  }
+  openDbIds.length = 0;
+});
+
+async function openTestDb(): Promise<string> {
+  const name = uniqueDbName();
+  await openDatabase(name, "0.1.0");
+  openDbIds.push(name);
+  return name;
+}
+
+const BLOCK_NUM = 100;
+const HEADER_V1 = new Uint8Array([1, 2, 3]);
+const HEADER_V2 = new Uint8Array([9, 9, 9]);
+const PEAKS_FROM_SYNC = new Uint8Array([10, 11, 12]);
+const PEAKS_FROM_BACKFILL = new Uint8Array([99, 98, 97]);
+
+describe("insertBlockHeader: add-if-not-exists semantics", () => {
+  it("inserts a brand-new row when none exists (genesis path)", async () => {
+    const dbId = await openTestDb();
+
+    await insertBlockHeader(
+      dbId,
+      BLOCK_NUM,
+      HEADER_V1,
+      PEAKS_FROM_SYNC,
+      false
+    );
+
+    const stored = await getDatabase(dbId).blockHeaders.get(BLOCK_NUM);
+    expect(stored).toBeDefined();
+    expect(stored!.header).toEqual(HEADER_V1);
+    expect(stored!.partialBlockchainPeaks).toEqual(PEAKS_FROM_SYNC);
+    expect(stored!.hasClientNotes).toBe("false");
+  });
+
+  it("does NOT overwrite existing peaks when called a second time for the same block", async () => {
+    // This is the core regression test for #2037. `applyStateSync` writes the
+    // correct historical peaks first. Later `get_and_store_authenticated_block`
+    // calls `insertBlockHeader` with a DIFFERENT peaks payload (peaks for the
+    // caller's current PartialMmr forest). The old `put` behavior clobbered
+    // the first write; we must keep it.
+    const dbId = await openTestDb();
+
+    // Step 1: sync writes correct peaks for block N.
+    await insertBlockHeader(
+      dbId,
+      BLOCK_NUM,
+      HEADER_V1,
+      PEAKS_FROM_SYNC,
+      false
+    );
+
+    // Step 2: authenticated-block backfill tries to overwrite with wrong peaks.
+    await insertBlockHeader(
+      dbId,
+      BLOCK_NUM,
+      HEADER_V2,
+      PEAKS_FROM_BACKFILL,
+      true
+    );
+
+    // Peaks and header from the first write must still be there.
+    const stored = await getDatabase(dbId).blockHeaders.get(BLOCK_NUM);
+    expect(stored!.header).toEqual(HEADER_V1);
+    expect(stored!.partialBlockchainPeaks).toEqual(PEAKS_FROM_SYNC);
+
+    // The peaks reader uses the same table lookup — double-check it serves the
+    // preserved bytes (it base64-encodes them so we decode).
+    const peaks = await getPartialBlockchainPeaksByBlockNum(dbId, BLOCK_NUM);
+    expect(peaks).toBeDefined();
+    const decoded = Uint8Array.from(
+      atob(peaks!.peaks!),
+      (c) => c.charCodeAt(0)
+    );
+    expect(decoded).toEqual(PEAKS_FROM_SYNC);
+  });
+
+  it("upgrades has_client_notes from false to true on a second call (matches SQLite set_block_header_has_client_notes)", async () => {
+    // Scenario: block N was synced as irrelevant (hasClientNotes=false).
+    // Later a private note with inclusion block N arrives via the transport
+    // layer, `get_and_store_authenticated_block` fires with hasClientNotes=true.
+    // SQLite does an explicit upgrade after its INSERT OR IGNORE; the IndexedDB
+    // path must match or `get_tracked_block_header_numbers` misses this block.
+    const dbId = await openTestDb();
+
+    await insertBlockHeader(
+      dbId,
+      BLOCK_NUM,
+      HEADER_V1,
+      PEAKS_FROM_SYNC,
+      false
+    );
+
+    let stored = await getDatabase(dbId).blockHeaders.get(BLOCK_NUM);
+    expect(stored!.hasClientNotes).toBe("false");
+
+    // Second insert with hasClientNotes=true.
+    await insertBlockHeader(
+      dbId,
+      BLOCK_NUM,
+      HEADER_V2, // (ignored — header stays HEADER_V1)
+      PEAKS_FROM_BACKFILL, // (ignored — peaks stay PEAKS_FROM_SYNC)
+      true
+    );
+
+    stored = await getDatabase(dbId).blockHeaders.get(BLOCK_NUM);
+    // Header + peaks preserved...
+    expect(stored!.header).toEqual(HEADER_V1);
+    expect(stored!.partialBlockchainPeaks).toEqual(PEAKS_FROM_SYNC);
+    // ...but has_client_notes upgraded to true.
+    expect(stored!.hasClientNotes).toBe("true");
+  });
+
+  it("does NOT downgrade has_client_notes from true to false on a second call with false", async () => {
+    // Mirror SQLite's semantics: `set_block_header_has_client_notes` only sets
+    // the flag to true; there is no downgrade path. Once a block is known to
+    // contain a client note, subsequent writes should not flip that back.
+    const dbId = await openTestDb();
+
+    await insertBlockHeader(
+      dbId,
+      BLOCK_NUM,
+      HEADER_V1,
+      PEAKS_FROM_SYNC,
+      true
+    );
+
+    await insertBlockHeader(
+      dbId,
+      BLOCK_NUM,
+      HEADER_V2,
+      PEAKS_FROM_BACKFILL,
+      false
+    );
+
+    const stored = await getDatabase(dbId).blockHeaders.get(BLOCK_NUM);
+    expect(stored!.hasClientNotes).toBe("true");
+  });
+});

--- a/crates/idxdb-store/src/ts/chainData.test.ts
+++ b/crates/idxdb-store/src/ts/chainData.test.ts
@@ -37,13 +37,7 @@ describe("insertBlockHeader: add-if-not-exists semantics", () => {
   it("inserts a brand-new row when none exists (genesis path)", async () => {
     const dbId = await openTestDb();
 
-    await insertBlockHeader(
-      dbId,
-      BLOCK_NUM,
-      HEADER_V1,
-      PEAKS_FROM_SYNC,
-      false
-    );
+    await insertBlockHeader(dbId, BLOCK_NUM, HEADER_V1, PEAKS_FROM_SYNC, false);
 
     const stored = await getDatabase(dbId).blockHeaders.get(BLOCK_NUM);
     expect(stored).toBeDefined();
@@ -61,13 +55,7 @@ describe("insertBlockHeader: add-if-not-exists semantics", () => {
     const dbId = await openTestDb();
 
     // Step 1: sync writes correct peaks for block N.
-    await insertBlockHeader(
-      dbId,
-      BLOCK_NUM,
-      HEADER_V1,
-      PEAKS_FROM_SYNC,
-      false
-    );
+    await insertBlockHeader(dbId, BLOCK_NUM, HEADER_V1, PEAKS_FROM_SYNC, false);
 
     // Step 2: authenticated-block backfill tries to overwrite with wrong peaks.
     await insertBlockHeader(
@@ -87,9 +75,8 @@ describe("insertBlockHeader: add-if-not-exists semantics", () => {
     // preserved bytes (it base64-encodes them so we decode).
     const peaks = await getPartialBlockchainPeaksByBlockNum(dbId, BLOCK_NUM);
     expect(peaks).toBeDefined();
-    const decoded = Uint8Array.from(
-      atob(peaks!.peaks!),
-      (c) => c.charCodeAt(0)
+    const decoded = Uint8Array.from(atob(peaks!.peaks!), (c) =>
+      c.charCodeAt(0)
     );
     expect(decoded).toEqual(PEAKS_FROM_SYNC);
   });
@@ -102,13 +89,7 @@ describe("insertBlockHeader: add-if-not-exists semantics", () => {
     // path must match or `get_tracked_block_header_numbers` misses this block.
     const dbId = await openTestDb();
 
-    await insertBlockHeader(
-      dbId,
-      BLOCK_NUM,
-      HEADER_V1,
-      PEAKS_FROM_SYNC,
-      false
-    );
+    await insertBlockHeader(dbId, BLOCK_NUM, HEADER_V1, PEAKS_FROM_SYNC, false);
 
     let stored = await getDatabase(dbId).blockHeaders.get(BLOCK_NUM);
     expect(stored!.hasClientNotes).toBe("false");
@@ -136,13 +117,7 @@ describe("insertBlockHeader: add-if-not-exists semantics", () => {
     // contain a client note, subsequent writes should not flip that back.
     const dbId = await openTestDb();
 
-    await insertBlockHeader(
-      dbId,
-      BLOCK_NUM,
-      HEADER_V1,
-      PEAKS_FROM_SYNC,
-      true
-    );
+    await insertBlockHeader(dbId, BLOCK_NUM, HEADER_V1, PEAKS_FROM_SYNC, true);
 
     await insertBlockHeader(
       dbId,

--- a/crates/idxdb-store/src/ts/chainData.ts
+++ b/crates/idxdb-store/src/ts/chainData.ts
@@ -47,7 +47,10 @@ export async function insertBlockHeader(
 
 /** Detect Dexie's primary-key collision error across sync + bulk wrappings. */
 function isConstraintError(err: unknown): boolean {
-  const e = err as { name?: string; inner?: { name?: string } } | null | undefined;
+  const e = err as
+    | { name?: string; inner?: { name?: string } }
+    | null
+    | undefined;
   return e?.name === "ConstraintError" || e?.inner?.name === "ConstraintError";
 }
 

--- a/crates/idxdb-store/src/ts/chainData.ts
+++ b/crates/idxdb-store/src/ts/chainData.ts
@@ -17,7 +17,19 @@ export async function insertBlockHeader(
       hasClientNotes: hasClientNotes.toString(),
     };
 
-    await db.blockHeaders.put(data);
+    // Add-if-not-exists semantics, matching SQLite's `INSERT OR IGNORE` in
+    // `insert_block_header_tx`. `insertBlockHeader` is called both by the
+    // genesis flow (no existing row) and by `get_and_store_authenticated_block`
+    // for backfilled past blocks. In the backfill case, overwriting the row
+    // previously written by `applyStateSync` would replace the correct
+    // historical peaks (popcount == block_num) with peaks for the caller's
+    // current PartialMmr forest (popcount == current sync height). Later
+    // reads of those peaks trip the `InvalidPeaks` validation and can wedge
+    // sync for the rest of the session.
+    await db.blockHeaders.add(data).catch((err: { name?: string }) => {
+      if (err?.name === "ConstraintError") return; // row already exists, keep it
+      throw err;
+    });
   } catch (err) {
     logWebStoreError(err);
   }

--- a/crates/idxdb-store/src/ts/chainData.ts
+++ b/crates/idxdb-store/src/ts/chainData.ts
@@ -17,22 +17,38 @@ export async function insertBlockHeader(
       hasClientNotes: hasClientNotes.toString(),
     };
 
-    // Add-if-not-exists semantics, matching SQLite's `INSERT OR IGNORE` in
-    // `insert_block_header_tx`. `insertBlockHeader` is called both by the
-    // genesis flow (no existing row) and by `get_and_store_authenticated_block`
-    // for backfilled past blocks. In the backfill case, overwriting the row
-    // previously written by `applyStateSync` would replace the correct
-    // historical peaks (popcount == block_num) with peaks for the caller's
-    // current PartialMmr forest (popcount == current sync height). Later
-    // reads of those peaks trip the `InvalidPeaks` validation and can wedge
-    // sync for the rest of the session.
-    await db.blockHeaders.add(data).catch((err: { name?: string }) => {
-      if (err?.name === "ConstraintError") return; // row already exists, keep it
-      throw err;
+    // Mirror SQLite's `insert_block_header_tx`: do an INSERT OR IGNORE on the
+    // row, then explicitly upgrade `has_client_notes` to true if the caller
+    // says so. Two callers hit this:
+    //   - Genesis flow — no existing row; the add succeeds.
+    //   - `get_and_store_authenticated_block` for a past block — a row
+    //     written by `applyStateSync` typically already exists. Overwriting
+    //     it would clobber the correct historical peaks (popcount ==
+    //     block_num) with peaks from the caller's current `PartialMmr`
+    //     forest (popcount == current sync height). Later reads of those
+    //     peaks trip `MmrPeaks::new`'s InvalidPeaks validation and wedge
+    //     sync for the rest of the session.
+    //
+    // The `has_client_notes` upgrade is load-bearing: `get_tracked_block_
+    // header_numbers` filters by this flag to seed `tracked_leaves`, which
+    // `get_partial_blockchain_nodes(Forest)` relies on. A private-note
+    // import at a block previously synced as irrelevant must flip the flag
+    // to true or the auth paths won't be tracked.
+    await db.blockHeaders.add(data).catch(async (err: unknown) => {
+      if (!isConstraintError(err)) throw err;
+      if (hasClientNotes) {
+        await db.blockHeaders.update(blockNum, { hasClientNotes: "true" });
+      }
     });
   } catch (err) {
     logWebStoreError(err);
   }
+}
+
+/** Detect Dexie's primary-key collision error across sync + bulk wrappings. */
+function isConstraintError(err: unknown): boolean {
+  const e = err as { name?: string; inner?: { name?: string } } | null | undefined;
+  return e?.name === "ConstraintError" || e?.inner?.name === "ConstraintError";
 }
 
 export async function insertPartialBlockchainNodes(

--- a/crates/rust-client/src/store/mod.rs
+++ b/crates/rust-client/src/store/mod.rs
@@ -253,10 +253,12 @@ pub trait Store: Send + Sync {
 
     /// Inserts a block header into the store, alongside peaks information at the block's height.
     ///
-    /// `has_client_notes` describes whether the block has relevant notes to the client; this means
-    /// the client might want to authenticate merkle paths based on this value.
-    /// If the block header exists and `has_client_notes` is `true` then the `has_client_notes`
-    /// column is updated to `true` to signify that the block now contains a relevant note.
+    /// Insert-if-not-exists with a one-way flag upgrade: on conflict with an existing row,
+    /// `header` and `partial_blockchain_peaks` are preserved (peaks are per-block and must
+    /// stay consistent with that block's forest), and `has_client_notes` is only upgraded
+    /// from `false` to `true`; never downgraded.
+    // TODO: this method's name only tells half the story. The insert is conditional and
+    // the flag has its own upgrade rule. Revisit the name in a follow-up.
     async fn insert_block_header(
         &self,
         block_header: &BlockHeader,


### PR DESCRIPTION
## Summary

Closes #2037.

Fixes a deterministic `syncState` failure on the IndexedDB store where a previously imported private note whose inclusion block pre-dated the wallet's current sync height could wedge sync for the rest of the session with:

```
failed to sync state: storage error: failed to construct Merkle Mountain Range (MMR):
mmr peaks are invalid: number of one bits in leaves is N which does not equal peak length M
```

The root cause is that `get_and_store_authenticated_block` backfills a past block via `self.store.insert_block_header(&block_header, current_partial_mmr.peaks(), true)`, using peaks from the caller's **current** `PartialMmr` forest. On the IndexedDB side, `insertBlockHeader` used `db.blockHeaders.put(data)` — an **overwrite** — so it clobbered the correct historical peaks that `applyStateSync` had written for that block (peaks whose popcount matches the block_num) with peaks whose popcount matches the caller's current sync height.

A later consumer at `build_partial_mmr_with_paths` (reading at `ref_block` — the last block in a tx's block_refs, which may be the just-backfilled one) then trips `MmrPeaks::new`'s validation:

```rust
if forest.num_trees() != peaks.len() {
    return Err(MmrError::InvalidPeaks(format!(
        "number of one bits in leaves is {} which does not equal peak length {}",
        forest.num_trees(),
        peaks.len()
    )));
}
```

## Fix

Mirror SQLite's `insert_block_header_tx` exactly in the IndexedDB store:

1. **Add-if-not-exists on the row itself** — matches SQLite's `INSERT OR IGNORE`:
   ```ts
   await db.blockHeaders.add(data).catch(async (err: unknown) => {
     if (!isConstraintError(err)) throw err;
     ...
   });
   ```
2. **Explicit `has_client_notes` upgrade on conflict** — matches SQLite's post-INSERT-OR-IGNORE `set_block_header_has_client_notes` call. Without this, a block first synced as irrelevant (`has_client_notes=false`) and later backfilled via `get_and_store_authenticated_block` because we're importing a note at that block would stay flagged as irrelevant. `get_tracked_block_header_numbers` filters by that flag, so the block would silently drop out of `tracked_leaves` — the same class of regression PR #1789 fixed. Upgrade direction is one-way (`false → true` only), matching the SQLite helper:
   ```ts
   if (hasClientNotes) {
     await db.blockHeaders.update(blockNum, { hasClientNotes: "true" });
   }
   ```
3. **Robust Dexie error detection** — `isConstraintError` handles both the direct `err.name === "ConstraintError"` surface and the wrapped `err.inner.name === "ConstraintError"` variant that appears in some bulk-op code paths.

### Callers — both remain correct

- **Genesis flow** (`block_header.rs:41`) — no existing row; the `add` succeeds. Unchanged.
- **`get_and_store_authenticated_block`** — when `applyStateSync` has already written the correct historical peaks for the block (which is the common case, because the branch that fires `get_and_store_authenticated_block` requires `block_height <= current_sync_height`), we keep the correct peaks and only upgrade `has_client_notes` if needed. The auth-nodes write (`insert_partial_blockchain_nodes` at `block_header.rs:83`) is a separate call and still happens unconditionally — this fix doesn't affect authentication-node persistence.

## Tests

`crates/idxdb-store/src/ts/chainData.test.ts` — four vitest cases using fake-indexeddb:

- **`inserts a brand-new row when none exists (genesis path)`** — the plain add case.
- **`does NOT overwrite existing peaks when called a second time for the same block`** — the regression test for #2037. Writes peaks via `insertBlockHeader`, then writes again with DIFFERENT peaks, then reads back via `getPartialBlockchainPeaksByBlockNum` and verifies the first-written peaks survived (base64-decoded comparison).
- **`upgrades has_client_notes from false to true on a second call`** — proves the explicit upgrade step added in (2) fires. Without this test, it's easy for a future refactor to drop the upgrade and only the full wallet E2E suite would catch it.
- **`does NOT downgrade has_client_notes from true to false on a second call with false`** — proves the upgrade is one-way, matching SQLite's `set_block_header_has_client_notes` semantics.

All four pass locally (`yarn test chainData` in `crates/idxdb-store/src`). Full `yarn test` has two pre-existing failures in `notes.test.ts` (`getInputNoteByOffset ordering`) that are unrelated to this PR.

## How I found it

Surfaced during a flake hunt of the miden-wallet E2E suite on devnet (see https://github.com/0xMiden/wallet/pull/182). The wallet's E2E suite drives two Chrome extension instances through a real send-private flow. 10 back-to-back runs showed 2 failures, both on `send-private`, with a very clear bimodal error-count distribution:

| Run(s) | MMR errors in send-private | Result |
|---|---|---|
| 4 runs | 0 | ✅ pass (bug not triggered — timing) |
| 4 runs | 24–44 | ✅ pass (bug fired but sync happened to recover) |
| **2 runs** | **720, 724** | **❌ FAIL — sync stuck on invalid peaks** |

The zero-error runs corresponded to executions where both wallets stayed in lockstep with devnet block production (`sync_wallet_a` step took ~4.7s, i.e. balance found on the first sync poll). When wallet B raced ahead of devnet between the send and the receipt — which in the harness corresponds to `sync_wallet_a` taking ~14s instead — the note's inclusion block was `≤` wallet B's current block, `get_and_store_authenticated_block` fired, and the write clobbered valid peaks.

## Verification

3-run verification loop against the wallet E2E suite after the fix, on devnet, with the local miden-client `file:` link. From the first-pass verification (peaks preservation only):

```
run 1 start: 01:15:57
  ✓  1 mint-and-balance (1.1m)
  ✓  2 multi-account (56.0s)
  ✓  3 multi-claim (1.0m)
  ✓  4 send-private (1.5m)
  ✓  5 send-public (1.5m)
  ✓  6 wallet-lifecycle (36.6s)
  ✓  7 wallet-lifecycle lock/unlock (25.6s)
  7 passed (7.1m)
run 1 PASSED at 01:23:04

run 2 start: 01:23:04
  ... 7 passed (6.4m)
run 2 PASSED at 01:29:28

run 3 start: 01:29:28
  ... 7 passed (6.6m)
run 3 PASSED at 01:36:07
```

Result: 21/21 spec runs pass, 0 MMR errors in any send-private timeline (versus 24–720 before).

| Metric | Before fix (10 runs) | After fix (3 runs) |
|---|---|---|
| Test pass rate | 8/10 runs (80%) | 3/3 (100%) |
| Spec-run pass rate | 68/70 (97.1%) | 21/21 (100%) |
| MMR errors per send-private | 0–724 | 0 |

A second 3-run verification loop is currently in-flight against the v2 commit (which adds the `has_client_notes` upgrade + tests); will update this PR with those results when it completes.



### v2 verification (against `5a4103c5` + `e7830a08`, after the `has_client_notes` upgrade was added)

```
run 1 start: 02:12:57
  ✓  1 mint-and-balance (57.0s)
  ✓  2 multi-account (52.7s)
  ✓  3 multi-claim (56.1s)
  ✓  4 send-private (1.3m)
  ✓  5 send-public (1.2m)
  ✓  6 wallet-lifecycle (35.9s)
  ✓  7 wallet-lifecycle lock/unlock (24.7s)
  7 passed (6.3m)
run 1 PASSED at 02:19:18

run 2 start: 02:19:18
  ... 7 passed (6.6m)
run 2 PASSED at 02:25:57

run 3 start: 02:25:57
  ... 7 passed (6.5m)
run 3 PASSED at 02:32:26
```

Same 21/21 spec runs pass, 0 MMR errors in send-private timelines.

(One earlier attempt at the v2 verification aborted on a devnet-side gRPC error during `submit_proven_transaction` — `HTTP 500 / grpc-status header missing`. Unrelated to this fix; rerunning was clean.)

## Test plan

- [x] `crates/idxdb-store/src`'s `yarn test chainData` — 4/4 new tests pass.
- [x] `crates/web-client`'s `yarn build` bundles the TS change into `dist/Cargo-*.js`.
- [x] Wallet E2E suite passed 3 consecutive runs on devnet against the initial fix (`932fa9ae`).
- [x] Wallet E2E suite passes 3 consecutive runs on devnet against the v2 fix (`5a4103c5` + formatting).
- [x] CI green.

