### PR TITLE
fix(web): ship module worker variant for webpack consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 * [FIX][web] Fixed `syncState` deterministically failing with `mmr peaks are invalid: number of one bits in leaves is N which does not equal peak length M` after importing a private note whose inclusion block pre-dates the wallet's current sync height. `get_and_store_authenticated_block` was overwriting the correct historical peaks (written by `applyStateSync`) with peaks from the caller's current `PartialMmr` forest, so subsequent reads at the same block hit the `InvalidPeaks` validation. The IndexedDB `insertBlockHeader` now uses add-if-not-exists semantics, matching the SQLite store's `INSERT OR IGNORE` in `insert_block_header_tx` ([#2037](https://github.com/0xMiden/miden-client/issues/2037)).
+* [FIX][web] Fixed WASM worker loading under webpack 5 / Next.js consumers. v0.14.1's single classic worker rewrote `import.meta.url` → `self.location.href` (needed for Safari/WKWebView cold-start performance), which webpack's asset tracer cannot follow — consumers hit a 404 on `miden_client_web.wasm` and the SDK silently fell back to a main-thread mode that hung on `sync()`. The SDK now ships BOTH variants (`web-client-methods-worker.js` classic for Safari, `web-client-methods-worker.module.js` ES module for webpack/Vite/Parcel) and `WebClient` picks at runtime via UA detection, configurable via the new `WebClient.workerMode` (`"auto"` / `"module"` / `"classic"`) static. No consumer config changes needed for auto ([#2046](https://github.com/0xMiden/miden-client/issues/2046)).
 
 ## 0.14.1 (2026-04-14)
 

--- a/crates/web-client/js/index.js
+++ b/crates/web-client/js/index.js
@@ -238,6 +238,46 @@ function createClientProxy(instance) {
 
 class WebClient {
   /**
+   * Controls which worker variant is spawned when a WebClient is constructed.
+   *
+   * - `"auto"` (default): pick `classic` on Safari/WKWebView (where module
+   *   workers have a very slow cold start), `module` everywhere else.
+   * - `"module"`: always use the `.mjs` ES-module worker. Required for webpack
+   *   5 / Next.js consumers so the asset tracer can see the WASM URL.
+   * - `"classic"`: always use the `.js` classic-script worker. Required on
+   *   Safari/WKWebView. Set this if your consumer bundler (or your host app)
+   *   does not support module workers.
+   *
+   * Set before the first `WebClient.createClient(...)` call.
+   */
+  static workerMode = "auto";
+
+  /**
+   * Decide between the module and classic worker variants based on
+   * `WebClient.workerMode` and (when `auto`) the current user agent.
+   * @returns {boolean} true when the classic script should be used.
+   * @private
+   */
+  static _shouldUseClassicWorker() {
+    const mode = WebClient.workerMode;
+    if (mode === "module") return false;
+    if (mode === "classic") return true;
+    // auto: classic on Safari/WKWebView, module everywhere else.
+    const ua =
+      typeof navigator !== "undefined" && navigator.userAgent
+        ? navigator.userAgent
+        : "";
+    // Chromium-based browsers (Chrome, Edge, Brave, Opera, Chromium-based
+    // Android WebView) handle module workers fine.
+    if (/Chrome\/|Chromium\//.test(ua)) return false;
+    // Safari (desktop + iOS) and WKWebView-without-Chrome (e.g. Capacitor host)
+    // both have AppleWebKit but no Chrome/Chromium in the UA. Prefer classic.
+    if (/AppleWebKit/.test(ua)) return true;
+    // Firefox, jsdom, node without navigator, etc. — module worker is fine.
+    return false;
+  }
+
+  /**
    * Create a WebClient wrapper.
    *
    * @param {string | undefined} rpcUrl - RPC endpoint URL used by the client.
@@ -283,13 +323,36 @@ class WebClient {
     // Check if Web Workers are available.
     if (typeof Worker !== "undefined") {
       console.log("WebClient: Web Workers are available.");
-      // Create the worker.
-      // Classic worker (not module) — the worker is built as a self-contained
-      // async-IIFE by the rollup config, compatible with all browsers including
-      // Safari/WKWebView which is extremely slow with module workers.
-      this.worker = new Worker(
-        new URL("./workers/web-client-methods-worker.js", import.meta.url)
-      );
+      // Pick between the module and classic worker variants at runtime — see
+      // `WebClient.workerMode` below. Both branches keep the
+      // `new Worker(new URL("...", import.meta.url), ...)` form fully literal:
+      // webpack 5's new-worker detector is PURELY SYNTACTIC and only triggers
+      // a proper worker sub-compilation (with asset+chunk tracing into the
+      // Cargo glue and the sibling WASM) when it sees that exact pattern
+      // spelled inline. Hoisting either URL into a variable downgrades the
+      // detection to a plain "copy file as asset" — which in turn makes the
+      // worker's `await import("./Cargo-*.js")` 404 because webpack never
+      // emitted a chunk for it. The bit of duplication here is load-bearing.
+      //
+      // - module (`.module.js` with `{ type: "module" }`): `import.meta.url`
+      //   inside the Cargo glue is preserved so webpack/Vite can resolve the
+      //   WASM URL statically. Preferred everywhere EXCEPT Safari/WKWebView.
+      // - classic (`.js`, no options): self-contained async IIFE with
+      //   `import.meta.url` rewritten to `self.location.href`; the only form
+      //   Safari/WKWebView can cold-start in a reasonable time.
+      if (WebClient._shouldUseClassicWorker()) {
+        this.worker = new Worker(
+          new URL("./workers/web-client-methods-worker.js", import.meta.url)
+        );
+      } else {
+        this.worker = new Worker(
+          new URL(
+            "./workers/web-client-methods-worker.module.js",
+            import.meta.url
+          ),
+          { type: "module" }
+        );
+      }
 
       // Map to track pending worker requests.
       this.pendingRequests = new Map();

--- a/crates/web-client/rollup.config.js
+++ b/crates/web-client/rollup.config.js
@@ -133,10 +133,15 @@ export default [
       },
     ],
   },
-  // Build the worker file as a self-contained classic script.
-  // Safari/WKWebView is extremely slow with module workers ({type: "module"}).
-  // Using format: "es" + inlineDynamicImports ensures everything is in one file.
-  // The wrap-worker-classic plugin converts it to an async-IIFE classic script.
+  // Classic worker build.
+  //
+  // Safari/WKWebView is extremely slow with module workers ({type: "module"}),
+  // so we ship a self-contained async-IIFE classic script alongside the module
+  // variant below. `wrap-worker-classic` rewrites `import.meta.url` →
+  // `self.location.href` (the only form a classic worker can see at runtime),
+  // strips `export` clauses, and wraps the rollup ESM output in an async IIFE.
+  //
+  // Output: dist/workers/web-client-methods-worker.js
   {
     input: "./js/workers/web-client-methods-worker.js",
     output: {
@@ -184,5 +189,44 @@ export default [
         },
       },
     ],
+  },
+  // Module worker build.
+  //
+  // Same input as above, but emitted as a plain ES module (.mjs) without the
+  // classic IIFE wrapping. `import.meta.url` is preserved, which lets webpack
+  // 5's asset tracer statically resolve `new URL("assets/miden_client_web.wasm",
+  // import.meta.url)` inside the Cargo-bindgen glue and copy the WASM file into
+  // the bundler's output correctly. Issue #2046: v0.14.1's classic-only worker
+  // rewrites that reference to `self.location.href`, which webpack cannot trace,
+  // producing a 404 on the WASM file for Next.js/webpack consumers.
+  //
+  // Output: dist/workers/web-client-methods-worker.mjs
+  {
+    input: "./js/workers/web-client-methods-worker.js",
+    output: {
+      dir: `dist/workers`,
+      format: "es",
+      sourcemap: true,
+      // Two deliberate choices here:
+      //
+      // 1. NOT inlining dynamic imports. Keeping the
+      //    `await import("./Cargo-*.js")` as a real dynamic ESM import
+      //    lets webpack's module-graph analysis follow the Cargo glue and
+      //    copy the sibling `miden_client_web.wasm` that the glue references
+      //    via `new URL("assets/...", import.meta.url)`. With
+      //    `inlineDynamicImports`, the URL literal ends up buried inside the
+      //    worker bundle and webpack's worker sub-compilation never sees it
+      //    as a graph dependency.
+      //
+      // 2. `.js` extension, not `.mjs`. Webpack 5 routes `.mjs` worker files
+      //    through `type: "asset/resource"` (copy-only, no sub-compilation),
+      //    so dynamic imports inside them never get chunked and runtime fetch
+      //    404s on the Cargo glue. `.js` with `{ type: "module" }` on the
+      //    Worker constructor triggers the proper worker sub-compilation and
+      //    all chunking works. The `.module` infix disambiguates this file
+      //    from the classic worker output that sits alongside it.
+      entryFileNames: "[name].module.js",
+    },
+    plugins: [resolve(), commonjs()],
   },
 ];


### PR DESCRIPTION
Closes #2046.

## Summary

v0.14.1 (#2010) switched the web worker from an ES module to a self-contained classic IIFE for Safari/WKWebView cold-start performance. The classic wrap rewrites `import.meta.url` → `self.location.href` — a runtime-only value that webpack 5's asset tracer cannot follow. Consequence for webpack/Next.js consumers: `new URL("assets/miden_client_web.wasm", self.location.href)` inside the worker fetches a path webpack never copied → 404 → silent main-thread fallback → `client.sync()` hangs indefinitely.

This PR keeps PR #2010's Safari fix and restores pre-v0.14.1 behavior for webpack consumers by shipping both variants and picking one at runtime.

## What's in

### Two worker outputs from the same source

`rollup.config.js` now emits:

- `dist/workers/web-client-methods-worker.js` — classic IIFE, `self.location.href`. Unchanged from 0.14.1. Safari/WKWebView path.
- `dist/workers/web-client-methods-worker.module.js` — plain ES module, `import.meta.url` preserved, `await import("./Cargo-*.js")` kept as a real dynamic ESM edge (explicitly NO `inlineDynamicImports`). Webpack/Vite/Parcel asset tracing follows the import to the Cargo glue and the sibling WASM.

Both variants share the same `dist/workers/assets/miden_client_web.wasm` peer — no duplicate WASM compile, no duplicate WASM in consumer bundles.

### Runtime picker

`WebClient` constructor:

```js
if (WebClient._shouldUseClassicWorker()) {
  this.worker = new Worker(
    new URL("./workers/web-client-methods-worker.js", import.meta.url)
  );
} else {
  this.worker = new Worker(
    new URL("./workers/web-client-methods-worker.module.js", import.meta.url),
    { type: "module" }
  );
}
```

Both `new Worker(new URL(...literal..., import.meta.url), ...)` expressions are spelled inline in each branch. This is load-bearing: webpack 5's new-worker detector is purely syntactic — hoisting the URL into a variable downgrades detection to asset-copy mode and the dynamic `await import` inside the worker never chunks, reintroducing the 404. Commented inline.

### Configuration

New `WebClient.workerMode` static, defaults to `"auto"`:

| Value | Behaviour |
|---|---|
| `"auto"` (default) | classic on AppleWebKit UA without Chrome/Chromium; module everywhere else |
| `"module"` | force module worker — use if you need webpack/Vite asset tracing and your runtime isn't Safari |
| `"classic"` | force classic worker — use if auto-detection misclassifies your host |

### UA heuristic

Only `navigator.userAgent` — no bundler hooks, nothing Next.js-specific.
Covers: Chrome, Edge, Brave, Opera, Android WebView, Electron (→ module); Safari desktop/iOS, iOS WKWebView, Capacitor host, Chrome-on-iOS which is WKWebView under the hood (→ classic); Firefox, node/jsdom (→ module).

## Verification

### Webpack reproduction (issue #2046)

Created the Next.js repro from the issue body, linked local SDK, confirmed before/after:

**Before (v0.14.1 shipped tarball):**
```
WORKER: Error occurred - Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok
```

**After this PR:**
```
WebClient: Web Workers are available.
WORKERLOAD 200 /_next/static/chunks/_app-pages-browser_node_modules_miden-sdk_miden-sdk_dist_workers_web-client-methods-worker_mo-d99da7.js
Opening database repro-devnet-db for client version 0.14.1...
Database opened successfully
```

Worker path moved from `/_next/static/media/` (asset-copy, no tracing) to `/_next/static/chunks/` (webpack sub-compilation with full graph tracing). WASM + Cargo glue both resolve. No fallback, no hang.

### Safari/WKWebView (auto-detection sanity check)

Ran the Miden wallet's iOS Simulator E2E suite (`wallet-lifecycle.ios.spec.ts`, WKWebView via Capacitor):

- Test 1 — create two wallets: ✅ 26.4s
- Test 2 — lock and unlock wallet: ✅ 19.0s
- Total: 46.7s, on par with the v0.14.1 baseline

Bundle inspection confirms `_shouldUseClassicWorker` and the UA check are present and pick the classic variant on `AppleWebKit`-no-`Chrome` UA. If the module variant had been taken by mistake, wallet creation would have stalled on WKWebView's slow module-worker cold start (which is exactly why #2010 introduced the classic wrap).

## Build cost impact

Negligible. `cargo` + `wasm-bindgen` + `wasm-opt` run once. The new module-worker output is just a second rollup pass on the already-bundled JS tree with `resolve` + `commonjs` — seconds, not minutes. Output size on disk: one additional ~20 KB wrapper file (Cargo glue stays a single shared chunk, not duplicated).

## Test plan

- [x] Reproduce issue #2046 on v0.14.1 shipped tarball (error: WebAssembly compile HTTP status not ok)
- [x] Verify same repro passes with this branch (worker in chunks path, WASM + Cargo resolve, no fallback)
- [x] Run iOS Simulator E2E wallet-lifecycle to confirm WKWebView takes classic path and performs normally
- [ ] One more smoke via Vite consumer (Miden wallet's Chrome extension build, already on `file:` link, covered by the stress suite currently running separately)
- [ ] Review: `WebClient.workerMode` as a static on the class vs an option on `createClient()` — happy to change if preferred