### PR TITLE
feat(web): expose stable errorCode on thrown JS errors for variant dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 * [FEATURE] Distinct `ApplyTransactionAfterSubmitFailed` error variant with one apply retry, so callers know a submitted tx landed on-chain and should not be re-submitted ([#2059](https://github.com/0xMiden/miden-client/pull/2059)).
+* [FEATURE][web] Stable `errorCode` string property on thrown JS errors for variant dispatch without message-string parsing ([#2060](https://github.com/0xMiden/miden-client/pull/2060)).
 * [FEATURE][web] Added `"custom"` operation to `preview()` so users can dry-run any pre-built `TransactionRequest`, not just send/mint/consume/swap ([#2052](https://github.com/0xMiden/miden-client/pull/2052)).
 
 ## 0.14.3 (2026-04-16)

--- a/crates/web-client/src/lib.rs
+++ b/crates/web-client/src/lib.rs
@@ -349,10 +349,19 @@ where
     }
 
     let help = hint_from_error(&err);
+    let code = error_code_from_error(&err);
     let js_error: JsValue = JsError::new(&error_string).into();
 
     if let Some(help) = help {
         let _ = Reflect::set(&js_error, &JsValue::from_str("help"), &JsValue::from_str(&help));
+    }
+
+    // Stable, machine-readable code for consumers that need to react
+    // differently based on the specific ClientError variant. The string
+    // text is load-bearing — see `error_code_from_client_error` for the
+    // list of codes and their contract.
+    if let Some(code) = code {
+        let _ = Reflect::set(&js_error, &JsValue::from_str("errorCode"), &JsValue::from_str(code));
     }
 
     js_error
@@ -364,4 +373,33 @@ fn hint_from_error(err: &(dyn Error + 'static)) -> Option<String> {
     }
 
     err.source().and_then(hint_from_error)
+}
+
+/// Walks the error chain looking for a [`ClientError`] and returns a
+/// stable, machine-readable code for it. Used by [`js_error_with_context`]
+/// to attach an `errorCode` string to the JS Error — consumers can
+/// pattern-match on it to trigger failure-mode-specific handling
+/// (e.g. treat a submitted-but-not-applied tx as Completed rather than
+/// Failed). Codes are the variant names; the contract is that they
+/// don't change across releases.
+fn error_code_from_error(err: &(dyn Error + 'static)) -> Option<&'static str> {
+    if let Some(client_error) = err.downcast_ref::<ClientError>() {
+        return error_code_from_client_error(client_error);
+    }
+    err.source().and_then(error_code_from_error)
+}
+
+fn error_code_from_client_error(err: &ClientError) -> Option<&'static str> {
+    // Only include variants consumers are known to dispatch on. Others
+    // can be added as new callers need them — the stability contract is
+    // "code string never changes once added."
+    match err {
+        ClientError::ApplyTransactionAfterSubmitFailed { .. } => {
+            Some("ApplyTransactionAfterSubmitFailed")
+        },
+        ClientError::AccountLocked(_) => Some("AccountLocked"),
+        ClientError::NoteNotFoundOnChain(_) => Some("NoteNotFoundOnChain"),
+        ClientError::RpcError(_) => Some("RpcError"),
+        _ => None,
+    }
 }


### PR DESCRIPTION
Closes 0xMiden/web-sdk#123

## Summary

- Adds a stable `errorCode` string property to JS errors thrown by the WebClient
- Consumers can dispatch on `err.errorCode === 'ApplyTransactionAfterSubmitFailed'` instead of parsing error message strings
- Stability contract: code strings never change once added

### Background

JS consumers of the SDK need to programmatically dispatch on error types. Parsing error message strings is fragile (not stable across versions, verbose, localization-unfriendly). During wallet hardening, every `catch` block needed to determine the error variant — string matching broke across SDK updates and was unreliable for multi-line messages.

### Changes

- `crates/web-client/src/lib.rs`: New `error_code_from_client_error()` function that maps `ClientError` variants to stable string codes. Currently exposed:
  - `ApplyTransactionAfterSubmitFailed` — tx on chain, apply failed locally
  - `AccountLocked` — account state out of sync
  - `NoteNotFoundOnChain` — note not committed yet
  - `RpcError` — network/node issue

  The code is attached as a property on the thrown `JsValue` error object. New codes can be added as consumers need them — the contract is that existing codes never change.

### How the wallet uses it

The wallet's TransactionProcessor dispatches on `err.errorCode === 'ApplyTransactionAfterSubmitFailed'` to mark submitted-but-unapplied transactions as Completed rather than Failed. This replaced fragile string matching and is resilient to SDK error message changes.

**Depends on** 0xMiden/miden-client#2059 which adds the `ApplyTransactionAfterSubmitFailed` error variant that this PR dispatches on.

## Test plan

- [ ] Existing tests pass
- [ ] Error thrown from `ApplyTransactionAfterSubmitFailed` path has `errorCode` property set to `"ApplyTransactionAfterSubmitFailed"`
- [ ] Error thrown from `AccountLocked` path has `errorCode === "AccountLocked"`
- [ ] Error from an unmapped variant has no `errorCode` property (or `undefined`)

---

> [!NOTE]
> The web-sdk parts of this PR have been migrated to https://github.com/0xMiden/web-sdk/pull/25 as part of the web-sdk split (#1992 / 0xMiden/miden-client#2135). The miden-client side stays here. The web-sdk PR depends on 0xMiden/miden-client#2059 landing first.
