### PR TITLE
fix(web): take TransactionProver by reference in proveTransaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [FEATURE][web] Added `"custom"` operation to `preview()` so users can dry-run any pre-built `TransactionRequest`, not just send/mint/consume/swap ([#2052](https://github.com/0xMiden/miden-client/pull/2052)).
 
+### Fixes
+
+* [FIX][web] `proveTransactionWithProver` now takes `&TransactionProver` by reference instead of consuming by value — the old signature invalidated the JS handle after one use, silently falling back to local proving on subsequent calls ([#2062](https://github.com/0xMiden/miden-client/pull/2062)).
+
 ## 0.14.3 (2026-04-16)
 
 ### Fixes

--- a/crates/web-client/js/index.js
+++ b/crates/web-client/js/index.js
@@ -773,7 +773,12 @@ class WebClient {
     try {
       if (!this.worker) {
         const wasmWebClient = await this.getWasmWebClient();
-        return await wasmWebClient.proveTransaction(transactionResult, prover);
+        return prover
+          ? await wasmWebClient.proveTransactionWithProver(
+              transactionResult,
+              prover
+            )
+          : await wasmWebClient.proveTransaction(transactionResult);
       }
 
       const wasm = await getWasmOrThrow();
@@ -793,6 +798,10 @@ class WebClient {
       console.error("INDEX.JS: Error in proveTransaction:", error);
       throw error;
     }
+  }
+
+  async proveTransactionWithProver(transactionResult, prover) {
+    return this.proveTransaction(transactionResult, prover);
   }
 
   async applyTransaction(transactionResult, submissionHeight) {

--- a/crates/web-client/js/resources/transactions.js
+++ b/crates/web-client/js/resources/transactions.js
@@ -522,8 +522,13 @@ export class TransactionsResource {
   async #submitOrSubmitWithProver(accountId, request, perCallProver) {
     const result = await this.#inner.executeTransaction(accountId, request);
     const prover = perCallProver ?? this.#client.defaultProver;
+    // Use proveTransactionWithProver (by-reference) when a prover is
+    // provided, so the JS-side handle is NOT consumed by wasm-bindgen.
+    // The old proveTransaction(result, prover) took the prover by value,
+    // which transferred ownership and invalidated the JS object after one
+    // call — causing silent fallback to local proving on reuse.
     const proven = prover
-      ? await this.#inner.proveTransaction(result, prover)
+      ? await this.#inner.proveTransactionWithProver(result, prover)
       : await this.#inner.proveTransaction(result);
     const txId = result.id();
     const height = await this.#inner.submitProvenTransaction(proven, result);

--- a/crates/web-client/js/resources/transactions.js
+++ b/crates/web-client/js/resources/transactions.js
@@ -524,9 +524,9 @@ export class TransactionsResource {
     const prover = perCallProver ?? this.#client.defaultProver;
     // Use proveTransactionWithProver (by-reference) when a prover is
     // provided, so the JS-side handle is NOT consumed by wasm-bindgen.
-    // The old proveTransaction(result, prover) took the prover by value,
-    // which transferred ownership and invalidated the JS object after one
-    // call — causing silent fallback to local proving on reuse.
+    // Passing the prover by value would transfer ownership and invalidate
+    // the JS object after one call, causing silent fallback to local
+    // proving on reuse.
     const proven = prover
       ? await this.#inner.proveTransactionWithProver(result, prover)
       : await this.#inner.proveTransaction(result);

--- a/crates/web-client/js/workers/web-client-methods-worker.js
+++ b/crates/web-client/js/workers/web-client-methods-worker.js
@@ -205,12 +205,14 @@ const methodHandlers = {
 
     const prover = proverPayload
       ? wasm.TransactionProver.deserialize(proverPayload)
-      : undefined;
+      : null;
 
-    const proven = await wasmWebClient.proveTransaction(
-      transactionResult,
-      prover
-    );
+    const proven = prover
+      ? await wasmWebClient.proveTransactionWithProver(
+          transactionResult,
+          prover
+        )
+      : await wasmWebClient.proveTransaction(transactionResult);
     const serializedProven = proven.serialize();
     return serializedProven.buffer;
   },
@@ -263,7 +265,7 @@ const methodHandlers = {
     // Deserialize the prover from the serialized payload
     const prover = proverPayload
       ? wasm.TransactionProver.deserialize(proverPayload)
-      : undefined;
+      : null;
 
     const result = await wasmWebClient.executeTransaction(
       accountId,
@@ -272,7 +274,9 @@ const methodHandlers = {
 
     const transactionId = result.id().toHex();
 
-    const proven = await wasmWebClient.proveTransaction(result, prover);
+    const proven = prover
+      ? await wasmWebClient.proveTransactionWithProver(result, prover)
+      : await wasmWebClient.proveTransaction(result);
     const submissionHeight = await wasmWebClient.submitProvenTransaction(
       proven,
       result

--- a/crates/web-client/src/new_transactions.rs
+++ b/crates/web-client/src/new_transactions.rs
@@ -207,12 +207,12 @@ impl WebClient {
 
     /// Generates a transaction proof using the provided prover.
     ///
-    /// Takes the prover by reference so the JS-side handle is NOT consumed.
-    /// Previous versions took `Option<TransactionProver>` by value, which
-    /// transferred ownership via wasm-bindgen on each call — invalidating
-    /// the JS object's internal WASM handle. After one use, subsequent
-    /// calls from JS would pass a dangling handle that wasm-bindgen
-    /// interpreted as `None`, silently falling back to the local prover.
+    /// Takes the prover by reference so the JS-side handle is NOT consumed
+    /// by wasm-bindgen. Taking `TransactionProver` by value would transfer
+    /// ownership on each call, invalidating the JS object's internal WASM
+    /// handle; after one use, subsequent calls from JS would pass a dangling
+    /// handle that wasm-bindgen interprets as `None`, silently falling back
+    /// to the local prover.
     #[wasm_bindgen(js_name = "proveTransactionWithProver")]
     pub async fn prove_transaction_with_prover(
         &mut self,

--- a/crates/web-client/src/new_transactions.rs
+++ b/crates/web-client/src/new_transactions.rs
@@ -225,7 +225,9 @@ impl WebClient {
     async fn prove_transaction_impl(
         &mut self,
         transaction_result: &TransactionResult,
-        prover_arc: Option<alloc::sync::Arc<dyn miden_client::transaction::TransactionProver + Send + Sync>>,
+        prover_arc: Option<
+            alloc::sync::Arc<dyn miden_client::transaction::TransactionProver + Send + Sync>,
+        >,
     ) -> Result<ProvenTransaction, JsValue> {
         #[cfg(feature = "testing")]
         if prover_arc.is_none() && self.mock_rpc_api.is_some() {

--- a/crates/web-client/src/new_transactions.rs
+++ b/crates/web-client/src/new_transactions.rs
@@ -55,7 +55,7 @@ impl WebClient {
 
         let tx_id = transaction_result.id();
 
-        let proven_transaction = self.prove_transaction(&transaction_result, None).await?;
+        let proven_transaction = self.prove_transaction(&transaction_result).await?;
 
         let submission_height =
             self.submit_proven_transaction(&proven_transaction, &transaction_result).await?;
@@ -82,7 +82,7 @@ impl WebClient {
         let tx_id = transaction_result.id();
 
         let proven_transaction =
-            self.prove_transaction(&transaction_result, Some(prover.clone())).await?;
+            self.prove_transaction_with_prover(&transaction_result, prover).await?;
 
         let submission_height =
             self.submit_proven_transaction(&proven_transaction, &transaction_result).await?;
@@ -196,16 +196,39 @@ impl WebClient {
         }
     }
 
-    /// Generates a transaction proof using either the provided prover or the client's default
-    /// prover if none is supplied.
+    /// Generates a transaction proof using the client's default (local) prover.
     #[wasm_bindgen(js_name = "proveTransaction")]
     pub async fn prove_transaction(
         &mut self,
         transaction_result: &TransactionResult,
-        prover: Option<TransactionProver>,
+    ) -> Result<ProvenTransaction, JsValue> {
+        self.prove_transaction_impl(transaction_result, None).await
+    }
+
+    /// Generates a transaction proof using the provided prover.
+    ///
+    /// Takes the prover by reference so the JS-side handle is NOT consumed.
+    /// Previous versions took `Option<TransactionProver>` by value, which
+    /// transferred ownership via wasm-bindgen on each call — invalidating
+    /// the JS object's internal WASM handle. After one use, subsequent
+    /// calls from JS would pass a dangling handle that wasm-bindgen
+    /// interpreted as `None`, silently falling back to the local prover.
+    #[wasm_bindgen(js_name = "proveTransactionWithProver")]
+    pub async fn prove_transaction_with_prover(
+        &mut self,
+        transaction_result: &TransactionResult,
+        prover: &TransactionProver,
+    ) -> Result<ProvenTransaction, JsValue> {
+        self.prove_transaction_impl(transaction_result, Some(prover.get_prover())).await
+    }
+
+    async fn prove_transaction_impl(
+        &mut self,
+        transaction_result: &TransactionResult,
+        prover_arc: Option<alloc::sync::Arc<dyn miden_client::transaction::TransactionProver + Send + Sync>>,
     ) -> Result<ProvenTransaction, JsValue> {
         #[cfg(feature = "testing")]
-        if prover.is_none() && self.mock_rpc_api.is_some() {
+        if prover_arc.is_none() && self.mock_rpc_api.is_some() {
             return LocalTransactionProver::default()
                 .prove_dummy(transaction_result.native().executed_transaction().clone())
                 .map(Into::into)
@@ -213,10 +236,9 @@ impl WebClient {
         }
 
         if let Some(client) = self.get_mut_inner() {
-            let prover_arc =
-                prover.map_or_else(|| client.prover(), |custom_prover| custom_prover.get_prover());
+            let prover = prover_arc.unwrap_or_else(|| client.prover());
 
-            Box::pin(client.prove_transaction_with(transaction_result.native(), prover_arc))
+            Box::pin(client.prove_transaction_with(transaction_result.native(), prover))
                 .await
                 .map(Into::into)
                 .map_err(|err| js_error_with_context(err, "failed to prove transaction"))

--- a/crates/web-client/test/playwright.global.setup.ts
+++ b/crates/web-client/test/playwright.global.setup.ts
@@ -169,7 +169,10 @@ export const test = base.extend<{ forEachTest: void }>({
                 )
               : window.TransactionProver.newLocalProver();
 
-            const proven = await client.proveTransactionWithProver(result, proverToUse);
+            const proven = await client.proveTransactionWithProver(
+              result,
+              proverToUse
+            );
             const submissionHeight = await client.submitProvenTransaction(
               proven,
               result

--- a/crates/web-client/test/playwright.global.setup.ts
+++ b/crates/web-client/test/playwright.global.setup.ts
@@ -169,7 +169,7 @@ export const test = base.extend<{ forEachTest: void }>({
                 )
               : window.TransactionProver.newLocalProver();
 
-            const proven = await client.proveTransaction(result, proverToUse);
+            const proven = await client.proveTransactionWithProver(result, proverToUse);
             const submissionHeight = await client.submitProvenTransaction(
               proven,
               result

--- a/packages/react-sdk/src/__tests__/mocks/miden-sdk.ts
+++ b/packages/react-sdk/src/__tests__/mocks/miden-sdk.ts
@@ -370,6 +370,7 @@ export const createMockWebClient = (
       .fn()
       .mockResolvedValue(createMockTransactionResult()),
     proveTransaction: vi.fn().mockResolvedValue({}),
+    proveTransactionWithProver: vi.fn().mockResolvedValue({}),
     submitProvenTransaction: vi.fn().mockResolvedValue(0),
     applyTransaction: vi.fn().mockResolvedValue({}),
     sendPrivateNote: vi.fn().mockResolvedValue(undefined),
@@ -422,6 +423,7 @@ export type MockWebClientType = {
   submitNewTransactionWithProver: ReturnType<typeof vi.fn>;
   executeTransaction: ReturnType<typeof vi.fn>;
   proveTransaction: ReturnType<typeof vi.fn>;
+  proveTransactionWithProver: ReturnType<typeof vi.fn>;
   submitProvenTransaction: ReturnType<typeof vi.fn>;
   applyTransaction: ReturnType<typeof vi.fn>;
   sendPrivateNote: ReturnType<typeof vi.fn>;

--- a/packages/react-sdk/src/__tests__/setup.ts
+++ b/packages/react-sdk/src/__tests__/setup.ts
@@ -40,6 +40,7 @@ vi.mock("@miden-sdk/miden-sdk", () => {
       .mockResolvedValue({ toString: vi.fn(() => "0xtx") }),
     executeTransaction: vi.fn().mockResolvedValue({}),
     proveTransaction: vi.fn().mockResolvedValue({}),
+    proveTransactionWithProver: vi.fn().mockResolvedValue({}),
     submitProvenTransaction: vi.fn().mockResolvedValue(0),
     applyTransaction: vi.fn().mockResolvedValue({}),
     sendPrivateNote: vi.fn().mockResolvedValue(undefined),

--- a/packages/react-sdk/src/hooks/useMultiSend.ts
+++ b/packages/react-sdk/src/hooks/useMultiSend.ts
@@ -152,7 +152,9 @@ export function useMultiSend(): UseMultiSendResult {
         const provenTransaction = await proveWithFallback(
           (resolvedProver) =>
             runExclusiveDirect(() =>
-              client.proveTransaction(txResult, resolvedProver)
+              resolvedProver
+                ? client.proveTransactionWithProver(txResult, resolvedProver)
+                : client.proveTransaction(txResult)
             ),
           proverConfig
         );

--- a/packages/react-sdk/src/hooks/useSend.ts
+++ b/packages/react-sdk/src/hooks/useSend.ts
@@ -243,7 +243,9 @@ export function useSend(): UseSendResult {
         const provenTransaction = await proveWithFallback(
           (resolvedProver) =>
             runExclusiveSafe(() =>
-              client.proveTransaction(txResult, resolvedProver)
+              resolvedProver
+                ? client.proveTransactionWithProver(txResult, resolvedProver)
+                : client.proveTransaction(txResult)
             ),
           proverConfig
         );

--- a/packages/react-sdk/src/hooks/useTransaction.ts
+++ b/packages/react-sdk/src/hooks/useTransaction.ts
@@ -125,7 +125,9 @@ export function useTransaction(): UseTransactionResult {
         const provenTransaction = await proveWithFallback(
           (resolvedProver) =>
             runExclusiveSafe(() =>
-              client.proveTransaction(txResult, resolvedProver)
+              resolvedProver
+                ? client.proveTransactionWithProver(txResult, resolvedProver)
+                : client.proveTransaction(txResult)
             ),
           proverConfig
         );


### PR DESCRIPTION
Closes #2068

## Summary

- Splits `proveTransaction(Option<TransactionProver>)` into two methods:
  - `proveTransaction()`: no prover arg, uses client's internal default (local prover)
  - `proveTransactionWithProver(&TransactionProver)`: takes prover **by reference**, JS handle preserved across calls
- The JS glue (`#submitOrSubmitWithProver`) now calls `proveTransactionWithProver` when a prover is available
- This is a bug fix for silent 10× performance degradation when using a long-lived `MidenClient` singleton

### Root cause

`proveTransaction` took `prover: Option<TransactionProver>` **by value** through wasm-bindgen. Each call transferred ownership of the JS-side WASM handle to the Rust function. After the first use:

1. The JS object's internal WASM handle is invalidated (wasm-bindgen marks it as consumed)
2. Subsequent calls from JS pass a dangling handle
3. wasm-bindgen interprets the dangling handle as `None`
4. The SDK silently falls back to `LocalTransactionProver` (~30s WASM proving instead of ~1s remote)
5. No error is thrown — the transaction succeeds, just 10× slower

### How we found it

After migrating the Miden Wallet from a dispose-recreate-per-tx pattern to a long-lived singleton `MidenClient`, stress tests showed:

- First 2 transactions: ~1.5s each (remote prover, normal)
- All subsequent transactions: ~30s each (silent local proving)

Investigation sequence:
1. ❌ Ruled out AutoSync contention (disabled → same slowness)
2. ❌ Ruled out `getKey` callback (changed to undefined → same slowness)
3. ✅ Added fetch instrumentation → slow ops had NO `remote_prover.Api/Prove` fetch calls
4. ✅ Added `[PROVE_TX] has_custom_prover` tracing in Rust → WASM side received `None` after first 2 uses despite JS always passing the prover
5. ✅ Root cause: wasm-bindgen by-value transfer consuming the JS handle

The bug was invisible in the old wallet architecture because each transaction disposed and recreated the `MidenClient` — fresh client, fresh prover handle, no dangling reference.

### Changes

- `crates/web-client/src/new_transactions.rs`:
  - `prove_transaction(&mut self, result: &TransactionResult)` — public, no prover arg, uses client default
  - `prove_transaction_with_prover(&mut self, result: &TransactionResult, prover: &TransactionProver)` — public, takes prover **by reference**
  - `prove_transaction_impl(...)` — private, shared logic taking an `Option<Arc<dyn TransactionProver>>` (already-resolved)
  - Internal caller `submit_new_transaction_with_prover` updated to use the by-reference method
- `crates/web-client/js/resources/transactions.js`:
  - `#submitOrSubmitWithProver` calls `proveTransactionWithProver(result, prover)` when a prover is present, `proveTransaction(result)` when not

### Validation

Stress-tested with the wallet's singleton design: all operations consistently use remote proving at ~1.3–2.2s per op across the entire run (vs ~30s degradation before the fix). Balance conservation held across all configurations.

## Test plan

- [ ] Existing integration tests pass
- [ ] `proveTransactionWithProver` called 10+ times with the same prover object → all use remote prover (no fallback to local)
- [ ] `proveTransaction` (no args) → uses client's internal local prover
- [ ] Stress test with long-lived singleton: sendMs stays ~1–2s for all ops, no degradation