### PR TITLE
feat(webclient): expose BlockHeader.nativeAssetId()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 * [FEATURE][web] Added `"custom"` operation to `preview()` so users can dry-run any pre-built `TransactionRequest`, not just send/mint/consume/swap ([#2052](https://github.com/0xMiden/miden-client/pull/2052)).
+* [FEATURE][web] Exposed `BlockHeader.nativeAssetId()` so JavaScript consumers can read the native fungible-faucet account ID from a block header. The field already rides the RPC wire and is decoded into the Rust `BlockHeader`, but no WASM accessor existed, forcing wallets and dApps to hardcode the native faucet per network ([#2070](https://github.com/0xMiden/miden-client/issues/2070)).
 
 ## 0.14.3 (2026-04-16)
 

--- a/crates/web-client/src/models/block_header.rs
+++ b/crates/web-client/src/models/block_header.rs
@@ -2,6 +2,7 @@ use miden_client::block::BlockHeader as NativeBlockHeader;
 use wasm_bindgen::prelude::*;
 
 use super::word::Word;
+use crate::models::account_id::AccountId;
 
 /// Public header for a block, containing commitments to the chain state and the proof attesting to
 /// the block's validity.
@@ -90,6 +91,17 @@ impl BlockHeader {
     /// Returns the block timestamp.
     pub fn timestamp(&self) -> u32 {
         self.0.timestamp()
+    }
+
+    /// Returns the account ID of the fungible faucet whose assets are accepted as the native
+    /// asset of the blockchain (i.e. the asset used for paying transaction verification fees).
+    ///
+    /// This is stored on-chain as part of the block's fee parameters, which means consumers can
+    /// discover the native faucet by reading any block header rather than hardcoding it per
+    /// network.
+    #[wasm_bindgen(js_name = "nativeAssetId")]
+    pub fn native_asset_id(&self) -> AccountId {
+        self.0.fee_parameters().native_asset_id().into()
     }
 }
 


### PR DESCRIPTION
## Summary

Exposes `BlockHeader.nativeAssetId()` on the web-client WASM bindings so JavaScript consumers can discover the native fungible-faucet account ID directly from a block header, instead of hardcoding the native faucet ID per network.

The field is already on the RPC wire (`FeeParameters fee_parameters = 11;` on `BlockHeader` — non-optional) and is already decoded into the Rust `NativeBlockHeader` held by the WASM wrapper. Only the JS-facing accessor was missing.

## Usage

```ts
import { RpcClient, Endpoint } from '@miden-sdk/miden-sdk';

const rpc = new RpcClient(new Endpoint('https://rpc.testnet.miden.io'));
const header = await rpc.getBlockHeaderByNumber();            // latest block
const nativeAssetId = header.nativeAssetId();                 // AccountId
const fetched = await rpc.getAccountDetails(nativeAssetId);   // symbol / decimals live
```

## Changes

- `crates/web-client/src/models/block_header.rs` — added `nativeAssetId()` getter returning `AccountId`.
- `CHANGELOG.md` — new feature entry under `0.14.4 (TBA)`.

## Out of scope (deferred)

- `verificationBaseFee` accessor — unrelated to native asset discovery.
- `MidenClient.getNativeAssetId()` convenience (cache policy, latest-block fetching) — worth adding once this primitive is published.
- React SDK hook — trivial on top of the above.

## Test plan

- [x] `cargo check --target wasm32-unknown-unknown -p miden-client-web` succeeds.
- [ ] After merge + next SDK publish: verified end-to-end by calling `header.nativeAssetId()` against devnet and confirming the returned `AccountId.toBech32(NetworkId.devnet(), ...)` matches `mdev1aqt0djza2efvjgqg0y29hlw6jvn93r0a` (the ID exposed by devnet faucet's `/get_metadata` and the `faucet_metadata.id` field in the devnet status monitor).

Closes #2070
