### PR TITLE
fix: defer prover instantiation until after WASM init in MidenProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Enhancements
 
+* Fixed panics in `get_sync_height()` by replacing `.expect()` calls with proper `StoreError` propagation for invalid block numbers and empty sync state ([#2049](https://github.com/0xMiden/miden-client/pull/2049)).
 * Fixed the faucet token symbol display when showing account details ([#1985](https://github.com/0xMiden/miden-client/pull/1985)).
 * [FEATURE][rust,cli,web] Added `get_network_note_status` to `NodeRpcClient` trait for querying the processing status of notes submitted to the network (pending, processed, discarded, committed), along with attempt count and error details. Exposed as `miden-client network-note-status <note_id>` CLI command and `RpcClient.getNetworkNoteStatus()` in the web client. (#TBD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 * Fixed the faucet token symbol display when showing account details ([#1985](https://github.com/0xMiden/miden-client/pull/1985)).
 * [FEATURE][rust,cli,web] Added `get_network_note_status` to `NodeRpcClient` trait for querying the processing status of notes submitted to the network (pending, processed, discarded, committed), along with attempt count and error details. Exposed as `miden-client network-note-status <note_id>` CLI command and `RpcClient.getNetworkNoteStatus()` in the web client. (#TBD)
 
+### Bug Fixes
+
+* Fixed `MidenProvider` crashing on first render when a remote prover is configured by deferring prover instantiation until after WASM initialization ([#2072](https://github.com/0xMiden/miden-client/pull/2072)).
+
 ## 0.14.0 (2026-04-07)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 
 ### Enhancements
 
-* Fixed panics in `get_sync_height()` by replacing `.expect()` calls with proper `StoreError` propagation for invalid block numbers and empty sync state ([#2049](https://github.com/0xMiden/miden-client/pull/2049)).
 * Fixed the faucet token symbol display when showing account details ([#1985](https://github.com/0xMiden/miden-client/pull/1985)).
 * [FEATURE][rust,cli,web] Added `get_network_note_status` to `NodeRpcClient` trait for querying the processing status of notes submitted to the network (pending, processed, discarded, committed), along with attempt count and error details. Exposed as `miden-client network-note-status <note_id>` CLI command and `RpcClient.getNetworkNoteStatus()` in the web client. (#TBD)
 

--- a/crates/idxdb-store/src/transaction/mod.rs
+++ b/crates/idxdb-store/src/transaction/mod.rs
@@ -67,7 +67,10 @@ impl IdxdbStore {
                         .tx_script
                         .map(|script| TransactionScript::read_from_bytes(&script))
                         .transpose()?
-                        .expect("Transaction script should be included in the row");
+                        .ok_or(StoreError::DatabaseError(
+                            "transaction script missing from store despite script_root being set"
+                                .into(),
+                        ))?;
 
                     Some(tx_script)
                 } else {

--- a/crates/rust-client/src/rpc/domain/account.rs
+++ b/crates/rust-client/src/rpc/domain/account.rs
@@ -662,7 +662,8 @@ impl TryFrom<proto::account::AccountWitness> for AccountWitness {
             .ok_or(proto::account::AccountWitness::missing_field(stringify!(witness_id)))?
             .try_into()?;
 
-        let witness = AccountWitness::new(account_id, state_commitment, merkle_path).unwrap();
+        let witness = AccountWitness::new(account_id, state_commitment, merkle_path)
+            .map_err(|err| RpcError::InvalidResponse(format!("{err}")))?;
         Ok(witness)
     }
 }

--- a/crates/sqlite-store/src/sync.rs
+++ b/crates/sqlite-store/src/sync.rs
@@ -91,10 +91,10 @@ impl SqliteStore {
             .expect("no binding parameters used in query")
             .map(|result| {
                 let v: i64 = result.into_store_error()?;
-                Ok(BlockNumber::from(u32::try_from(v).expect("block number is always positive")))
+                Ok(BlockNumber::from(u32::try_from(v).map_err(StoreError::InvalidInt)?))
             })
             .next()
-            .expect("state sync block number exists")
+            .ok_or_else(|| StoreError::QueryError("state sync block number not found".to_string()))?
     }
 
     pub(super) fn apply_state_sync(

--- a/crates/sqlite-store/src/sync.rs
+++ b/crates/sqlite-store/src/sync.rs
@@ -94,7 +94,9 @@ impl SqliteStore {
                 Ok(BlockNumber::from(u32::try_from(v).map_err(StoreError::InvalidInt)?))
             })
             .next()
-            .ok_or_else(|| StoreError::QueryError("state sync block number not found".to_string()))?
+            .ok_or_else(|| {
+                StoreError::QueryError("state sync block number not found".to_string())
+            })?
     }
 
     pub(super) fn apply_state_sync(

--- a/packages/react-sdk/CHANGELOG.md
+++ b/packages/react-sdk/CHANGELOG.md
@@ -15,6 +15,10 @@
 * [FEATURE][web] `ProverConfig` now supports fallback configuration with `primary`/`fallback` targets, `disableFallback` predicate, and `onFallback` callback. Transaction hooks automatically retry with the fallback prover on failure. ([#1861](https://github.com/0xMiden/miden-client/pull/1861))
 * [FEATURE][web] Added `useSyncControl` hook to pause and resume auto-sync intervals. ([#1861](https://github.com/0xMiden/miden-client/pull/1861))
 
+### Bug Fixes
+
+* [FIX][web] Fixed `MidenProvider` crashing on first render when a remote prover is configured by deferring prover instantiation until after WASM initialization ([#2072](https://github.com/0xMiden/miden-client/pull/2072)).
+
 ## 0.13.4 (TBD)
 
 ### Features

--- a/packages/react-sdk/src/context/MidenProvider.tsx
+++ b/packages/react-sdk/src/context/MidenProvider.tsx
@@ -87,15 +87,24 @@ export function MidenProvider({
     }),
     [config]
   );
-  const defaultProver = useMemo(
-    () => resolveTransactionProver(resolvedConfig),
-    [
-      resolvedConfig.prover,
-      resolvedConfig.proverTimeoutMs,
-      resolvedConfig.proverUrls?.devnet,
-      resolvedConfig.proverUrls?.testnet,
-    ]
-  );
+  const [defaultProver, setDefaultProver] = useState<
+    ReturnType<typeof resolveTransactionProver>
+  >(null);
+
+  // Defer prover construction until WASM is ready — resolveTransactionProver
+  // calls TransactionProver.newLocalProver() / newRemoteProver() which touch
+  // the WASM module.  Running this synchronously in useMemo before the module
+  // is initialized causes a crash on first render (wasm.__wbindgen_malloc).
+  useEffect(() => {
+    if (!isReady) return;
+    setDefaultProver(resolveTransactionProver(resolvedConfig));
+  }, [
+    isReady,
+    resolvedConfig.prover,
+    resolvedConfig.proverTimeoutMs,
+    resolvedConfig.proverUrls?.devnet,
+    resolvedConfig.proverUrls?.testnet,
+  ]);
 
   // Exposed for advanced consumers who need to serialize custom multi-step
   // operations against the client. Built-in hooks no longer use this since

--- a/packages/react-sdk/src/context/MidenProvider.tsx
+++ b/packages/react-sdk/src/context/MidenProvider.tsx
@@ -87,9 +87,8 @@ export function MidenProvider({
     }),
     [config]
   );
-  const [defaultProver, setDefaultProver] = useState<
-    ReturnType<typeof resolveTransactionProver>
-  >(null);
+  const [defaultProver, setDefaultProver] =
+    useState<ReturnType<typeof resolveTransactionProver>>(null);
 
   // Defer prover construction until WASM is ready — resolveTransactionProver
   // calls TransactionProver.newLocalProver() / newRemoteProver() which touch


### PR DESCRIPTION
Fixes #2069

## Summary

`MidenProvider` crashes on first render when a remote prover is configured because `defaultProver` was computed in a `useMemo` — which runs synchronously before WASM initializes.

## Root Cause

`resolveTransactionProver` calls `TransactionProver.newRemoteProver()` which accesses `wasm.__wbindgen_malloc`. This variable is only set after `__wbg_init()` resolves inside `useEffect`. Since `useMemo` always runs before `useEffect`, the prover was always instantiated before WASM was ready.

## Fix

Moved `defaultProver` from `useMemo` to `useState` + `useEffect` gated on `isReady`. This matches the existing pattern already used for the client itself in `MidenProvider`.

Downstream hooks already handle `prover === null` by falling back to the built-in local prover, so no other changes are needed.