### PR TITLE
feat(batch): add new method to node rpc client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [BREAKING][param][rust] `NodeRpcClient::get_block_by_number()` now takes an `include_proof: bool` parameter to control whether the block proof is included in the response. ([#1991](https://github.com/0xMiden/miden-client/pull/1991))
 * [BREAKING][param][rust] `NodeRpcClient::sync_chain_mmr()` replaced `block_to: Option<BlockNumber>` with `upper_bound: SyncTarget` to match the RPC definition. Use `SyncTarget::CommittedChainTip` for previous default behavior (`None`), or `SyncTarget::BlockNumber(num)` for a specific block number. ([#1991](https://github.com/0xMiden/miden-client/pull/1991))
+* [BREAKING][param][rust] Added `submit_proven_batch` to `NodeRpcClient` trait. (#TBD)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * [BREAKING][param][rust] `NodeRpcClient::get_block_by_number()` now takes an `include_proof: bool` parameter to control whether the block proof is included in the response. ([#1991](https://github.com/0xMiden/miden-client/pull/1991))
 * [BREAKING][param][rust] `NodeRpcClient::sync_chain_mmr()` replaced `block_to: Option<BlockNumber>` with `upper_bound: SyncTarget` to match the RPC definition. Use `SyncTarget::CommittedChainTip` for previous default behavior (`None`), or `SyncTarget::BlockNumber(num)` for a specific block number. ([#1991](https://github.com/0xMiden/miden-client/pull/1991))
-* [BREAKING][param][rust] Added `submit_proven_batch` to `NodeRpcClient` trait. ([#2075](https://github.com/0xMiden/miden-client/pull/2075))
+* [BREAKING][rust] Added `submit_proven_batch` to `NodeRpcClient` trait. ([#2075](https://github.com/0xMiden/miden-client/pull/2075))
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * [BREAKING][param][rust] `NodeRpcClient::get_block_by_number()` now takes an `include_proof: bool` parameter to control whether the block proof is included in the response. ([#1991](https://github.com/0xMiden/miden-client/pull/1991))
 * [BREAKING][param][rust] `NodeRpcClient::sync_chain_mmr()` replaced `block_to: Option<BlockNumber>` with `upper_bound: SyncTarget` to match the RPC definition. Use `SyncTarget::CommittedChainTip` for previous default behavior (`None`), or `SyncTarget::BlockNumber(num)` for a specific block number. ([#1991](https://github.com/0xMiden/miden-client/pull/1991))
-* [BREAKING][param][rust] Added `submit_proven_batch` to `NodeRpcClient` trait. (#TBD)
+* [BREAKING][param][rust] Added `submit_proven_batch` to `NodeRpcClient` trait. ([#2075](https://github.com/0xMiden/miden-client/pull/2075))
 
 ### Enhancements
 

--- a/crates/rust-client/src/rpc/errors/node/mod.rs
+++ b/crates/rust-client/src/rpc/errors/node/mod.rs
@@ -113,6 +113,7 @@ pub fn parse_node_error(
         RpcEndpoint::SyncChainMmr
         | RpcEndpoint::Status
         | RpcEndpoint::GetLimits
-        | RpcEndpoint::GetNetworkNoteStatus => None,
+        | RpcEndpoint::GetNetworkNoteStatus
+        | RpcEndpoint::SubmitProvenBatch => None,
     }
 }

--- a/crates/rust-client/src/rpc/mod.rs
+++ b/crates/rust-client/src/rpc/mod.rs
@@ -5,6 +5,7 @@
 //! to:
 //!
 //! - Submit proven transactions.
+//! - Submit proven batches.
 //! - Retrieve block headers (optionally with MMR proofs).
 //! - Sync state updates (including notes, nullifiers, and account updates).
 //! - Fetch details for specific notes and accounts.
@@ -53,6 +54,7 @@ use domain::sync::{ChainMmrInfo, SyncTarget};
 use miden_protocol::Word;
 use miden_protocol::account::{AccountCode, AccountId};
 use miden_protocol::address::NetworkId;
+use miden_protocol::batch::{ProposedBatch, ProvenBatch};
 use miden_protocol::block::{BlockHeader, BlockNumber, ProvenBlock};
 use miden_protocol::crypto::merkle::mmr::MmrProof;
 use miden_protocol::crypto::merkle::smt::SmtProof;
@@ -123,6 +125,18 @@ pub trait NodeRpcClient: Send + Sync {
         &self,
         proven_transaction: ProvenTransaction,
         transaction_inputs: TransactionInputs,
+    ) -> Result<BlockNumber, RpcError>;
+
+    /// Given a Proven Batch together with the corresponding [`ProposedBatch`] and the list of
+    /// [`TransactionInputs`] (one per transaction, matching the ordering of the batch), sends
+    /// the batch to the node for inclusion in a future block using the `/SubmitProvenBatch`
+    /// RPC endpoint. All transactions in the batch must build on the current mempool state
+    /// following normal transaction submission rules.
+    async fn submit_proven_batch(
+        &self,
+        proven_batch: ProvenBatch,
+        proposed_batch: ProposedBatch,
+        transaction_inputs: Vec<TransactionInputs>,
     ) -> Result<BlockNumber, RpcError>;
 
     /// Given a block number, fetches the block header corresponding to that height from the node
@@ -481,6 +495,7 @@ pub enum RpcEndpoint {
     GetNotesById,
     SyncChainMmr,
     SubmitProvenTx,
+    SubmitProvenBatch,
     SyncNotes,
     GetNoteScriptByRoot,
     SyncStorageMaps,
@@ -503,6 +518,7 @@ impl RpcEndpoint {
             RpcEndpoint::GetNotesById => "GetNotesById",
             RpcEndpoint::SyncChainMmr => "SyncChainMmr",
             RpcEndpoint::SubmitProvenTx => "SubmitProvenTransaction",
+            RpcEndpoint::SubmitProvenBatch => "SubmitProvenBatch",
             RpcEndpoint::SyncNotes => "SyncNotes",
             RpcEndpoint::GetNoteScriptByRoot => "GetNoteScriptByRoot",
             RpcEndpoint::SyncStorageMaps => "SyncStorageMaps",
@@ -530,6 +546,7 @@ impl fmt::Display for RpcEndpoint {
             RpcEndpoint::GetNotesById => write!(f, "get_notes_by_id"),
             RpcEndpoint::SyncChainMmr => write!(f, "sync_chain_mmr"),
             RpcEndpoint::SubmitProvenTx => write!(f, "submit_proven_transaction"),
+            RpcEndpoint::SubmitProvenBatch => write!(f, "submit_proven_batch"),
             RpcEndpoint::SyncNotes => write!(f, "sync_notes"),
             RpcEndpoint::GetNoteScriptByRoot => write!(f, "get_note_script_by_root"),
             RpcEndpoint::SyncStorageMaps => write!(f, "sync_storage_maps"),

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -15,6 +15,7 @@ use miden_protocol::account::{
     Account, AccountCode, AccountId, AccountStorage, StorageMap, StorageSlot, StorageSlotType,
 };
 use miden_protocol::address::NetworkId;
+use miden_protocol::batch::{ProposedBatch, ProvenBatch};
 use miden_protocol::block::account_tree::AccountWitness;
 use miden_protocol::block::{BlockHeader, BlockNumber, ProvenBlock};
 use miden_protocol::crypto::merkle::MerklePath;
@@ -503,6 +504,28 @@ impl NodeRpcClient for GrpcClient {
             .call_with_retry(RpcEndpoint::SubmitProvenTx, |mut rpc_api| {
                 let request = request.clone();
                 Box::pin(async move { rpc_api.submit_proven_transaction(request).await })
+            })
+            .await?;
+
+        Ok(BlockNumber::from(api_response.into_inner().block_num))
+    }
+
+    async fn submit_proven_batch(
+        &self,
+        proven_batch: ProvenBatch,
+        proposed_batch: ProposedBatch,
+        transaction_inputs: Vec<TransactionInputs>,
+    ) -> Result<BlockNumber, RpcError> {
+        let request = proto::transaction::TransactionBatch {
+            batch_proof: proven_batch.to_bytes(),
+            proposed_batch: Some(proposed_batch.to_bytes()),
+            transaction_inputs: transaction_inputs.iter().map(Serializable::to_bytes).collect(),
+        };
+
+        let api_response = self
+            .call_with_retry(RpcEndpoint::SubmitProvenBatch, |mut rpc_api| {
+                let request = request.clone();
+                Box::pin(async move { rpc_api.submit_proven_batch(request).await })
             })
             .await?;
 

--- a/crates/rust-client/src/test_utils/mock.rs
+++ b/crates/rust-client/src/test_utils/mock.rs
@@ -7,6 +7,7 @@ use miden_protocol::Word;
 use miden_protocol::account::delta::AccountUpdateDetails;
 use miden_protocol::account::{AccountCode, AccountId, StorageSlot, StorageSlotContent};
 use miden_protocol::address::NetworkId;
+use miden_protocol::batch::{ProposedBatch, ProvenBatch};
 use miden_protocol::block::{BlockHeader, BlockNumber, ProvenBlock};
 use miden_protocol::crypto::merkle::mmr::{Forest, Mmr, MmrProof};
 use miden_protocol::crypto::merkle::smt::SmtProof;
@@ -452,6 +453,25 @@ impl NodeRpcClient for MockRpcApi {
             let mut mock_chain = self.mock_chain.write();
             mock_chain.add_pending_proven_transaction(proven_transaction.clone());
         };
+
+        let block_num = self.get_chain_tip_block_num();
+
+        Ok(block_num)
+    }
+
+    /// Simulates the submission of a proven batch to the node by adding it to the mock chain's
+    /// pending batches. The `proposed_batch` and `transaction_inputs` arguments are accepted to
+    /// match the trait signature but are unused — the mock relies on the `ProvenBatch` alone,
+    /// matching how `submit_proven_transaction` ignores its `transaction_inputs`.
+    async fn submit_proven_batch(
+        &self,
+        proven_batch: ProvenBatch,
+        _proposed_batch: ProposedBatch,
+        _transaction_inputs: Vec<TransactionInputs>,
+    ) -> Result<BlockNumber, RpcError> {
+        let mut mock_chain = self.mock_chain.write();
+        mock_chain.add_pending_batch(proven_batch);
+        drop(mock_chain);
 
         let block_num = self.get_chain_tip_block_num();
 

--- a/crates/testing/miden-client-tests/src/tests.rs
+++ b/crates/testing/miden-client-tests/src/tests.rs
@@ -111,6 +111,7 @@ use miden_testing::{MockChain, MockChainBuilder, TxContextInput};
 use rand::rngs::StdRng;
 use rand::{Rng, RngCore, SeedableRng};
 
+mod batch;
 pub mod store;
 mod transaction;
 mod transport;

--- a/crates/testing/miden-client-tests/src/tests/batch.rs
+++ b/crates/testing/miden-client-tests/src/tests/batch.rs
@@ -1,0 +1,56 @@
+use miden_client::rpc::NodeRpcClient;
+use miden_client::transaction::LocalTransactionProver;
+use miden_testing::TxContextInput;
+
+use crate::tests::create_test_client;
+
+/// Exercises the mock `submit_proven_batch` path end-to-end: build a real
+/// `ProvenBatch` from a proven transaction produced against a `MockChain`, submit it via
+/// `MockRpcApi`, and verify the returned block number equals the chain tip. The mock
+/// ignores `proposed_batch` and `transaction_inputs`, so we pass a cloned
+/// `ProposedBatch` and an empty inputs vector — good enough to exercise the trait wiring.
+#[tokio::test]
+async fn submit_proven_batch_returns_chain_tip() {
+    let (_client, rpc_api, _keystore) = Box::pin(create_test_client()).await;
+
+    // Pick the first account recorded in the prebuilt mock chain.
+    let account_id = rpc_api
+        .mock_chain
+        .read()
+        .proven_blocks()
+        .iter()
+        .flat_map(|block| block.body().updated_accounts())
+        .next()
+        .unwrap()
+        .account_id();
+
+    // Execute and prove a trivial transaction against that account.
+    let tx_context = rpc_api
+        .mock_chain
+        .read()
+        .build_tx_context(TxContextInput::AccountId(account_id), &[], &[])
+        .unwrap()
+        .build()
+        .unwrap();
+    let executed_tx = Box::pin(tx_context.execute()).await.unwrap();
+
+    let proven_tx = LocalTransactionProver::default().prove_dummy(executed_tx).unwrap();
+
+    // Wrap the proven transaction into a ProvenBatch using MockChain helpers.
+    // ProposedBatch is Clone, so we clone it before consuming the original to produce the
+    // ProvenBatch.
+    let (proven_batch, proposed_for_submit) = {
+        let chain = rpc_api.mock_chain.read();
+        let proposed_batch = chain.propose_transaction_batch(vec![proven_tx]).unwrap();
+        let proposed_for_submit = proposed_batch.clone();
+        let proven_batch = chain.prove_transaction_batch(proposed_batch).unwrap();
+        (proven_batch, proposed_for_submit)
+    };
+
+    let expected_tip = rpc_api.get_chain_tip_block_num();
+    let returned = Box::pin(rpc_api.submit_proven_batch(proven_batch, proposed_for_submit, vec![]))
+        .await
+        .unwrap();
+
+    assert_eq!(returned, expected_tip);
+}


### PR DESCRIPTION
First part of adding batch transaction to the miden-client. Adds `submit_proven_batch` trait to the `NodeRpcClient` with a verifying mock test.

Closes [#2074](https://github.com/0xMiden/miden-client/issues/2074)