### PR TITLE
fix(integration-tests): share SourceManager in COUNTER_CONTRACT_LIBRARY init

### DIFF
--- a/bin/integration-tests/src/tests/network_transaction.rs
+++ b/bin/integration-tests/src/tests/network_transaction.rs
@@ -282,21 +282,22 @@ pub async fn test_recall_note_before_ntx_consumes_it(client_config: ClientConfig
 
 // Initialize the Basic Fungible Faucet library only once.
 static COUNTER_CONTRACT_LIBRARY: LazyLock<Arc<Library>> = LazyLock::new(|| {
-    let assembler = TransactionKernel::assembler();
+    // Share a SourceManager between the parser and the assembler so spans emitted during
+    // parsing resolve in the file table the assembler uses for debug-info registration.
+    // Using separate SourceManagers causes DebugInfoSections::register_procedure_debug_info
+    // to panic in miden-debug-types::SourceFile::location when a span's byte range isn't
+    // present in the assembler's SourceManager.
     let source_manager = Arc::new(DefaultSourceManager::default());
     let module = Module::parser(ModuleKind::Library)
         .parse_str(
             Path::new("external_contract::counter_contract"),
             COUNTER_CONTRACT,
-            source_manager,
+            source_manager.clone(),
         )
         .map_err(|err| anyhow!(err))
         .unwrap();
-    assembler
-        .clone()
-        .assemble_library([module])
-        .map_err(|err| anyhow!(err))
-        .unwrap()
+    let assembler = TransactionKernel::assembler_with_source_manager(source_manager);
+    assembler.assemble_library([module]).map_err(|err| anyhow!(err)).unwrap()
 });
 
 /// Returns the Basic Fungible Faucet Library.


### PR DESCRIPTION
## Summary

- The counter contract library in `bin/integration-tests/src/tests/network_transaction.rs` was parsed against a local `DefaultSourceManager` that was then discarded. The assembler was built separately with its own `SourceManager`, so when `DebugInfoSections::register_procedure_debug_info` ran during `assemble_library`, span lookup panicked inside `miden-debug-types::SourceFile::location` with `"invalid source span: starting byte is out of bounds"` — the byte range referenced a file missing from the assembler's own `SourceManager`.
- Fix: build the assembler with `TransactionKernel::assembler_with_source_manager` using the same `Arc<DefaultSourceManager>` passed to the parser, so both share one file table.

## Impact

Unbreaks three testnet integration tests that currently panic before doing any real work:

- `network_fpi::test_network_fpi`
- `network_transaction::test_counter_contract_ntx`
- `network_transaction::test_recall_note_before_ntx_consumes_it`

All three shared the `COUNTER_CONTRACT_LIBRARY` `LazyLock`, so initializing it once anywhere in the process tripped the panic; once fixed, `test_network_fpi` passes in ~20s on testnet locally.

## Test plan

- [x] `cargo build --release --locked --package miden-client-integration-tests`
- [x] `cargo run -p miden-client-integration-tests --release -- --network testnet --contains test_network_fpi --jobs 1 --retry-count 0` → PASS in 20.12s
- [ ] Full `make integration-test` against a local node
- [ ] CI run to confirm no regressions in non-network-tx tests