### PR TITLE
feat(integration-tests): check account vault contents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3001,6 +3007,7 @@ name = "miden-client-integration-tests"
 version = "0.14.3"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "async-trait",
  "clap",
  "miden-client",

--- a/bin/integration-tests/Cargo.toml
+++ b/bin/integration-tests/Cargo.toml
@@ -24,6 +24,7 @@ miden-client-sqlite-store = { workspace = true }
 
 # External dependencies
 anyhow             = { features = ["std"], workspace = true }
+assert_matches     = { version = "1.5.0" }
 async-trait        = { workspace = true }
 clap               = { features = ["derive", "env"], version = "4.0" }
 num_cpus           = { version = "1.0" }

--- a/bin/integration-tests/src/tests/client.rs
+++ b/bin/integration-tests/src/tests/client.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use assert_matches::assert_matches;
 use miden_client::account::component::{AccountComponent, AccountComponentMetadata};
 use miden_client::account::{
     Account,
@@ -451,7 +452,7 @@ pub async fn test_get_account_update(client_config: ClientConfig) -> Result<()> 
     let details2 = rpc_api.get_account_details(basic_wallet_2.id()).await.unwrap();
 
     assert!(matches!(details1, FetchedAccount::Private(_, _)));
-    assert!(matches!(details2, FetchedAccount::Public(_, _)));
+    assert_matches!(details2, FetchedAccount::Public(account, _) if account.vault().get_balance(faucet_account.id()).unwrap() == MINT_AMOUNT);
     Ok(())
 }
 
@@ -1679,8 +1680,8 @@ pub async fn test_get_account_proof_returns_vault_details(
     let vault_root = details.header.vault_root();
 
     assert_eq!(
-        details.vault_details.assets.len(),
-        1,
+        details.vault_details.assets,
+        vec![Asset::Fungible(FungibleAsset::new(faucet.id(), MINT_AMOUNT).unwrap())],
         "expected exactly 1 asset (the minted fungible token)"
     );
 

--- a/crates/rust-client/src/rpc/domain/account.rs
+++ b/crates/rust-client/src/rpc/domain/account.rs
@@ -29,6 +29,7 @@ use crate::rpc::generated::{self as proto};
 // ================================================================================================
 
 /// Describes the possible responses from the `GetAccountDetails` endpoint for an account.
+#[derive(Debug)]
 pub enum FetchedAccount {
     /// Private accounts are stored off-chain. Only a commitment to the state of the account is
     /// shared with the network. The full account state is to be tracked locally.
@@ -87,6 +88,7 @@ impl From<FetchedAccount> for Option<Account> {
 // ================================================================================================
 
 /// Contains public updated information about the account requested.
+#[derive(Debug)]
 pub struct AccountUpdateSummary {
     /// Commitment of the account, that represents a commitment to its updated state.
     pub commitment: Word,


### PR DESCRIPTION
As part of an [ongoing effort](https://github.com/0xMiden/node/issues/1978) in the node to improve the `GetAccount` gRPC method performance I was running the integration tests against some account vault related changes in the node.

I've noticed that `test_get_account_update` and `test_get_account_proof_returns_vault_details` don't actually check that the account vault contains the expected assets. This PR adds some checks that make sure that the response contains the minted tokens from the faucet.