### PR TITLE
fix(rust): drain fetch_all_private_notes across paginated server responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
 * [FEATURE][web] Added `wordToBigInt()` utility export for losslessly converting a `Word`'s first felt to a `BigInt`. `StorageResult.toString()` is BigInt-backed, and `valueOf()` returns a JS number for values fitting in `Number.MAX_SAFE_INTEGER` and throws `RangeError` for larger u64 values — use `.toBigInt()` for exact access ([#1955](https://github.com/0xMiden/miden-client/pull/1955)).
 * [FEATURE][rust,cli] Added partial swap (PSWAP) support: `TransactionRequestBuilder::build_pswap_create` / `build_pswap_consume` / `build_pswap_cancel` and a `miden-client pswap` CLI command (`create`, `consume`, `cancel`) for partially-fillable fungible swaps ([#2162](https://github.com/0xMiden/miden-client/pull/2162)).
 
+### Fixes
+
+* [FIX][rust] `Client::fetch_all_private_notes` now drains the full backlog across multiple server-paginated responses instead of returning after a single batch. Needed once the note-transport server (`0xMiden/note-transport-service#77`) caps each `fetch_notes` response at `FETCH_NOTES_BATCH_SIZE` rows — previously the function silently returned only the first batch, contradicting its documented "fetches all notes" semantics. Companion deterministic regression test (`fetch_all_private_notes_drains_across_batches`) uses a new `MockNoteTransportNode::with_max_batch(n)` constructor to exercise multi-batch drain.
+
 ## 0.14.7 (2026-06-05)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+* [FIX][rust] `Client::fetch_all_private_notes` now drains the full backlog across multiple server-paginated responses instead of returning after a single batch. Needed once the note-transport server (`0xMiden/note-transport-service#77`) caps each `fetch_notes` response at `FETCH_NOTES_BATCH_SIZE` rows — previously the function silently returned only the first batch, contradicting its documented "fetches all notes" semantics. Companion deterministic regression test (`fetch_all_private_notes_drains_across_batches`) uses a new `MockNoteTransportNode::with_max_batch(n)` constructor to exercise multi-batch drain.
+
 ## 0.14.4 (2026-04-20)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.14.5 (TBD)
 
 ### Fixes
 

--- a/crates/rust-client/src/note_transport/errors.rs
+++ b/crates/rust-client/src/note_transport/errors.rs
@@ -17,4 +17,9 @@ pub enum NoteTransportError {
     Deserialization(#[from] DeserializationError),
     #[error("note transport network error: {0}")]
     Network(String),
+    #[error(
+        "fetch_all_private_notes did not converge after {0} iterations — the server cursor \
+         is advancing but never returns an empty batch"
+    )]
+    PaginationDidNotTerminate(usize),
 }

--- a/crates/rust-client/src/note_transport/mod.rs
+++ b/crates/rust-client/src/note_transport/mod.rs
@@ -84,41 +84,83 @@ where
     /// To fetch the full history of private notes for the tracked tags, use
     /// [`Client::fetch_all_private_notes`].
     pub async fn fetch_private_notes(&mut self) -> Result<(), ClientError> {
-        // Unique tags
-        let note_tags = self.store.get_unique_note_tags().await?;
-        // Get global cursor
+        let note_tags: Vec<NoteTag> =
+            self.store.get_unique_note_tags().await?.into_iter().collect();
         let cursor = self.store.get_note_transport_cursor().await?;
 
-        self.fetch_transport_notes(cursor, note_tags).await?;
+        let (_, new_cursor) = self.fetch_transport_notes(cursor, &note_tags).await?;
+        self.store.update_note_transport_cursor(new_cursor).await?;
 
         Ok(())
     }
 
-    /// Fetches all notes for tracked note tags.
+    /// Fetches all notes for tracked note tags, draining the server's paginated
+    /// response by looping until the cursor stops advancing.
     ///
-    /// Similar to [`Client::fetch_private_notes`] however does not employ pagination,
-    /// fetching all notes stored in the note transport network for the tracked tags.
-    /// Please prefer using [`Client::fetch_private_notes`] to avoid downloading repeated notes.
+    /// Similar to [`Client::fetch_private_notes`] but ignores the stored
+    /// pagination cursor and re-scans from the beginning. The server-side
+    /// transport caps each response at a fixed batch size; this method issues
+    /// repeated fetch calls until one returns the same cursor it was given
+    /// (i.e. no new notes), so the documented "fetches all notes" semantics
+    /// hold regardless of how large the backlog is. Prefer
+    /// [`Client::fetch_private_notes`] for steady-state syncing to avoid
+    /// re-downloading already-seen notes.
     pub async fn fetch_all_private_notes(&mut self) -> Result<(), ClientError> {
-        let note_tags = self.store.get_unique_note_tags().await?;
+        // Safety cap on a misbehaving server. At 500 notes per batch, 1000
+        // iterations covers 500k notes — well beyond any plausible retention
+        // window — and bounds the worst-case wall-clock at ~50s at 50ms/req.
+        // Hitting this signals a server bug, not an honest backlog.
+        const MAX_ITERATIONS: usize = 1_000;
 
-        self.fetch_transport_notes(NoteTransportCursor::init(), note_tags).await?;
+        let note_tags: Vec<NoteTag> =
+            self.store.get_unique_note_tags().await?.into_iter().collect();
+        // Snapshot the stored cursor up front so we can advance (never regress)
+        // it after the drain. Without this guard, starting the drain at
+        // `init()` and persisting per-batch would clobber a previously
+        // advanced cursor with the small `rcursor` of the first batch.
+        let stored_cursor = self.store.get_note_transport_cursor().await?;
 
-        Ok(())
+        let mut cursor = NoteTransportCursor::init();
+        for _ in 0..MAX_ITERATIONS {
+            let (_, new_cursor) = self.fetch_transport_notes(cursor, &note_tags).await?;
+            // Terminate on any lack of forward progress. A well-behaved server
+            // returns `new_cursor == cursor` when there are no new notes (since
+            // `rcursor = max(cursor, max_seq_returned)`); using `<=` here also
+            // handles implementations that return an `init()` cursor on empty
+            // batches (see the in-tree mock transport).
+            if new_cursor <= cursor {
+                let final_cursor = core::cmp::max(cursor, stored_cursor);
+                self.store.update_note_transport_cursor(final_cursor).await?;
+                return Ok(());
+            }
+            cursor = new_cursor;
+        }
+
+        Err(ClientError::NoteTransportError(NoteTransportError::PaginationDidNotTerminate(
+            MAX_ITERATIONS,
+        )))
     }
 
-    /// Fetch notes from the note transport network for provided note tags
+    /// Fetch one batch of notes from the note transport network for the
+    /// provided tags.
     ///
-    /// Pagination is employed, where only notes after the provided cursor are requested.
-    /// Downloaded notes are imported. Returns the IDs of the imported notes.
-    pub(crate) async fn fetch_transport_notes<I>(
+    /// The server paginates; this method issues one RPC and returns the
+    /// imported note IDs together with the new cursor. The returned cursor
+    /// equals the input cursor when the batch was empty (i.e. no new notes).
+    /// Callers that want to drain the full backlog should loop until
+    /// `new_cursor == cursor` (see [`Client::fetch_all_private_notes`]).
+    /// Callers that do steady-state polling (see [`Client::sync_state`] /
+    /// [`Client::fetch_private_notes`]) should call this once per tick with
+    /// the stored cursor.
+    ///
+    /// Downloaded notes are imported into the local store. Persistence of the
+    /// returned cursor is left to the caller so that drain loops can guard
+    /// against regression of an already-advanced stored cursor.
+    pub(crate) async fn fetch_transport_notes(
         &mut self,
         cursor: NoteTransportCursor,
-        tags: I,
-    ) -> Result<Vec<NoteId>, ClientError>
-    where
-        I: IntoIterator<Item = NoteTag>,
-    {
+        tags: &[NoteTag],
+    ) -> Result<(Vec<NoteId>, NoteTransportCursor), ClientError> {
         // Number of blocks to look back from sync height when scanning for committed notes.
         // Handles the race where a note is committed on-chain just before the NTL delivers
         // its data — without this, check_expected_notes would scan from sync_height forward
@@ -126,11 +168,8 @@ where
         const NOTE_LOOKBACK_BLOCKS: u32 = 20;
 
         let mut notes = Vec::new();
-        // Fetch notes
-        let (note_infos, rcursor) = self
-            .get_note_transport_api()?
-            .fetch_notes(&tags.into_iter().collect::<Vec<_>>(), cursor)
-            .await?;
+        let (note_infos, rcursor) =
+            self.get_note_transport_api()?.fetch_notes(tags, cursor).await?;
         for note_info in &note_infos {
             // e2ee impl hint:
             // for key in self.store.decryption_keys() try
@@ -143,7 +182,6 @@ where
         let after_block_num =
             BlockNumber::from(sync_height.as_u32().saturating_sub(NOTE_LOOKBACK_BLOCKS));
 
-        // Import fetched notes
         let mut note_requests = Vec::with_capacity(notes.len());
         for note in notes {
             let tag = note.metadata().tag();
@@ -156,10 +194,7 @@ where
         }
         let imported_note_ids = self.import_notes(&note_requests).await?;
 
-        // Update cursor (pagination)
-        self.store.update_note_transport_cursor(rcursor).await?;
-
-        Ok(imported_note_ids)
+        Ok((imported_note_ids, rcursor))
     }
 }
 

--- a/crates/rust-client/src/note_transport/mod.rs
+++ b/crates/rust-client/src/note_transport/mod.rs
@@ -94,28 +94,64 @@ where
         Ok(())
     }
 
-    /// Fetches all notes for tracked note tags.
+    /// Fetches all notes for tracked note tags, draining the server's paginated
+    /// response by looping until the cursor stops advancing.
     ///
-    /// Similar to [`Client::fetch_private_notes`] however does not employ pagination,
-    /// fetching all notes stored in the note transport network for the tracked tags.
-    /// Please prefer using [`Client::fetch_private_notes`] to avoid downloading repeated notes.
+    /// Similar to [`Client::fetch_private_notes`] but ignores the stored
+    /// pagination cursor and re-scans from the beginning. The server-side
+    /// transport caps each response at a fixed batch size; this method calls
+    /// [`Client::fetch_transport_notes`] repeatedly until a call returns the
+    /// same cursor it was given (i.e. no new notes), so the documented
+    /// "fetches all notes" semantics hold regardless of how large the backlog
+    /// is. Prefer [`Client::fetch_private_notes`] for steady-state syncing to
+    /// avoid re-downloading already-seen notes.
     pub async fn fetch_all_private_notes(&mut self) -> Result<(), ClientError> {
-        let note_tags = self.store.get_unique_note_tags().await?;
+        // Safety cap: bounds wall-clock time even if the server lies about its
+        // cursor. At 500 notes per batch, 100k iterations = 50M notes, well
+        // beyond any plausible retention window. Going over signals a bug on
+        // the server side, not an honest backlog.
+        const MAX_ITERATIONS: usize = 100_000;
 
-        self.fetch_transport_notes(NoteTransportCursor::init(), note_tags).await?;
+        let note_tags: Vec<NoteTag> =
+            self.store.get_unique_note_tags().await?.into_iter().collect();
 
-        Ok(())
+        let mut cursor = NoteTransportCursor::init();
+        for _ in 0..MAX_ITERATIONS {
+            let new_cursor = self.fetch_transport_notes(cursor, note_tags.clone()).await?;
+            // Terminate on any lack of forward progress. A well-behaved server
+            // returns `new_cursor == cursor` when there are no new notes (since
+            // `rcursor = max(cursor, max_seq_returned)`); using `<=` here also
+            // handles implementations that return an `init()` cursor on empty
+            // batches (see the in-tree mock transport).
+            if new_cursor <= cursor {
+                return Ok(());
+            }
+            cursor = new_cursor;
+        }
+
+        Err(ClientError::NoteTransportError(NoteTransportError::PaginationDidNotTerminate(
+            MAX_ITERATIONS,
+        )))
     }
 
-    /// Fetch notes from the note transport network for provided note tags
+    /// Fetch one batch of notes from the note transport network for the
+    /// provided tags.
     ///
-    /// Pagination is employed, where only notes after the provided cursor are requested.
-    /// Downloaded notes are imported.
+    /// The server paginates; this method issues one RPC and returns the new
+    /// cursor, which equals the input cursor when the batch was empty (i.e.
+    /// no new notes). Callers that want to drain the full backlog should loop
+    /// until `new_cursor == cursor` (see [`Client::fetch_all_private_notes`]).
+    /// Callers that do steady-state polling (see [`Client::sync_state`] /
+    /// [`Client::fetch_private_notes`]) should call this once per tick with
+    /// the stored cursor.
+    ///
+    /// Downloaded notes are imported into the local store; the persistent
+    /// pagination cursor is advanced to the returned value.
     pub(crate) async fn fetch_transport_notes<I>(
         &mut self,
         cursor: NoteTransportCursor,
         tags: I,
-    ) -> Result<(), ClientError>
+    ) -> Result<NoteTransportCursor, ClientError>
     where
         I: IntoIterator<Item = NoteTag>,
     {
@@ -159,7 +195,7 @@ where
         // Update cursor (pagination)
         self.store.update_note_transport_cursor(rcursor).await?;
 
-        Ok(())
+        Ok(rcursor)
     }
 }
 

--- a/crates/rust-client/src/note_transport/mod.rs
+++ b/crates/rust-client/src/note_transport/mod.rs
@@ -99,12 +99,12 @@ where
     ///
     /// Similar to [`Client::fetch_private_notes`] but ignores the stored
     /// pagination cursor and re-scans from the beginning. The server-side
-    /// transport caps each response at a fixed batch size; this method calls
-    /// [`Client::fetch_transport_notes`] repeatedly until a call returns the
-    /// same cursor it was given (i.e. no new notes), so the documented
-    /// "fetches all notes" semantics hold regardless of how large the backlog
-    /// is. Prefer [`Client::fetch_private_notes`] for steady-state syncing to
-    /// avoid re-downloading already-seen notes.
+    /// transport caps each response at a fixed batch size; this method issues
+    /// repeated fetch calls until one returns the same cursor it was given
+    /// (i.e. no new notes), so the documented "fetches all notes" semantics
+    /// hold regardless of how large the backlog is. Prefer
+    /// [`Client::fetch_private_notes`] for steady-state syncing to avoid
+    /// re-downloading already-seen notes.
     pub async fn fetch_all_private_notes(&mut self) -> Result<(), ClientError> {
         // Safety cap: bounds wall-clock time even if the server lies about its
         // cursor. At 500 notes per batch, 100k iterations = 50M notes, well

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -158,8 +158,10 @@ where
         }
 
         let cursor = self.store.get_note_transport_cursor().await?;
-        let note_tags = self.store.get_unique_note_tags().await?;
-        self.fetch_transport_notes(cursor, note_tags).await
+        let note_tags: Vec<_> = self.store.get_unique_note_tags().await?.into_iter().collect();
+        let (ids, new_cursor) = self.fetch_transport_notes(cursor, &note_tags).await?;
+        self.store.update_note_transport_cursor(new_cursor).await?;
+        Ok(ids)
     }
 
     /// Runs the full client sync.

--- a/crates/rust-client/src/test_utils/note_transport.rs
+++ b/crates/rust-client/src/test_utils/note_transport.rs
@@ -31,11 +31,26 @@ use crate::note_transport::{
 #[derive(Clone)]
 pub struct MockNoteTransportNode {
     notes: BTreeMap<NoteTag, Vec<(NoteInfo, NoteTransportCursor)>>,
+    /// Optional per-response batch cap; if `Some(n)`, `get_notes` returns at
+    /// most `n` entries (total, across all tags) in one call. Used to exercise
+    /// client-side pagination drain loops. `None` = unbounded (legacy behavior).
+    max_batch: Option<usize>,
 }
 
 impl MockNoteTransportNode {
     pub fn new() -> Self {
-        Self { notes: BTreeMap::default() }
+        Self {
+            notes: BTreeMap::default(),
+            max_batch: None,
+        }
+    }
+
+    /// Build a mock that caps each `get_notes` response at `max_batch` entries.
+    pub fn with_max_batch(max_batch: usize) -> Self {
+        Self {
+            notes: BTreeMap::default(),
+            max_batch: Some(max_batch),
+        }
     }
 
     pub fn add_note(&mut self, header: NoteHeader, details_bytes: Vec<u8>) {
@@ -50,8 +65,10 @@ impl MockNoteTransportNode {
         tags: &[NoteTag],
         cursor: NoteTransportCursor,
     ) -> (Vec<NoteInfo>, NoteTransportCursor) {
-        let mut notes = vec![];
-        let mut rcursor = NoteTransportCursor::init();
+        // Start `rcursor` at the input — matches the real server's contract
+        // (`rcursor = max(cursor, max_seq_returned)`), so an empty batch
+        // returns the caller's own cursor rather than `init()`.
+        let mut collected: Vec<(NoteInfo, NoteTransportCursor)> = vec![];
         for tag in tags {
             // Assumes stored notes are ordered by cursor
             let tnotes = self
@@ -67,15 +84,21 @@ impl MockNoteTransportNode {
                 })
                 .map(Vec::from)
                 .unwrap_or_default();
-            rcursor = rcursor.max(
-                tnotes
-                    .iter()
-                    .map(|(_, cursor)| *cursor)
-                    .max()
-                    .unwrap_or(NoteTransportCursor::init()),
-            );
-            notes.extend(tnotes.into_iter().map(|(note, _)| note).collect::<Vec<_>>());
+            collected.extend(tnotes);
         }
+
+        // Deterministic ordering across tags: sort by cursor ascending so the
+        // client sees notes in per-cursor order regardless of tag iteration
+        // order, matching the real server's `ORDER BY seq ASC`.
+        collected.sort_by_key(|(_, c)| *c);
+
+        // Apply the batch cap, if configured.
+        if let Some(max) = self.max_batch {
+            collected.truncate(max);
+        }
+
+        let rcursor = collected.iter().map(|(_, c)| *c).max().unwrap_or(cursor);
+        let notes = collected.into_iter().map(|(n, _)| n).collect();
         (notes, rcursor)
     }
 }
@@ -166,6 +189,6 @@ impl Deserializable for MockNoteTransportNode {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let notes = BTreeMap::<NoteTag, Vec<(NoteInfo, NoteTransportCursor)>>::read_from(source)?;
 
-        Ok(Self { notes })
+        Ok(Self { notes, max_batch: None })
     }
 }

--- a/crates/testing/miden-client-tests/src/tests/transport.rs
+++ b/crates/testing/miden-client-tests/src/tests/transport.rs
@@ -147,6 +147,55 @@ async fn transport_duplicate_note_handling() {
     assert_eq!(notes.len(), 1, "should still have 1 note, not duplicated");
 }
 
+/// Verifies that `fetch_all_private_notes` drains notes across multiple
+/// server-paginated batches.
+///
+/// Regression test for the interaction between the transport server's
+/// response-size `LIMIT` and the client's previously-single-shot
+/// `fetch_all_private_notes`. Before the drain loop, a server cap of N per
+/// response meant `fetch_all_private_notes` silently returned only the first
+/// N notes and the rest were invisible until the next paginated sync tick.
+#[tokio::test]
+async fn fetch_all_private_notes_drains_across_batches() {
+    const BATCH_CAP: usize = 3;
+    const TOTAL_NOTES: usize = 10;
+
+    let mock_node = Arc::new(RwLock::new(MockNoteTransportNode::with_max_batch(BATCH_CAP)));
+    let (mut sender, sender_account) = create_test_user_transport(mock_node.clone()).await;
+    let (mut recipient, recipient_account) = create_test_user_transport(mock_node.clone()).await;
+    let recipient_address = Address::new(recipient_account.id())
+        .with_routing_parameters(RoutingParameters::new(AddressInterface::BasicWallet));
+
+    // Send TOTAL_NOTES > BATCH_CAP private notes so a single-batch fetch
+    // cannot drain the backlog.
+    for _ in 0..TOTAL_NOTES {
+        let note = P2idNote::create(
+            sender_account.id(),
+            recipient_account.id(),
+            vec![],
+            NoteType::Private,
+            NoteAttachment::default(),
+            sender.rng(),
+        )
+        .unwrap();
+        sender.send_private_note(note, &recipient_address).await.unwrap();
+    }
+
+    // With BATCH_CAP=3 and TOTAL_NOTES=10, a single-shot fetch would return
+    // only 3. The drain loop should issue successive calls until all 10 are
+    // pulled.
+    recipient.fetch_all_private_notes().await.unwrap();
+
+    let notes = recipient.get_input_notes(NoteFilter::All).await.unwrap();
+    assert_eq!(
+        notes.len(),
+        TOTAL_NOTES,
+        "fetch_all_private_notes must drain across batches; got {} of {}",
+        notes.len(),
+        TOTAL_NOTES
+    );
+}
+
 /// Verifies that an observer whose tracked tags don't match the note's tag receives nothing.
 #[tokio::test]
 async fn transport_fetch_no_matching_tags() {


### PR DESCRIPTION
## Summary

Once the note-transport server caps `fetch_notes` responses at a batch size (see [0xMiden/note-transport-service#77](https://github.com/0xMiden/note-transport-service/pull/77), which adds `FETCH_NOTES_BATCH_SIZE = 500`), the existing single-shot `Client::fetch_all_private_notes` silently returns only the first batch and drops the rest. That contradicts its documented contract:

> Fetches all notes for tracked note tags. ... does not employ pagination, fetching all notes stored in the note transport network for the tracked tags.

This PR makes the function loop until the server cursor stops advancing, so the documented semantics hold regardless of the server's per-response cap.

Steady-state callers (`Client::sync_state` → `fetch_transport_notes`, `Client::fetch_private_notes`) already paginate naturally across poll ticks and are unaffected.

## Changes

- **`Client::fetch_all_private_notes`**: loops over `fetch_transport_notes` with the advancing cursor until `new_cursor <= cursor` (no forward progress). Safety cap of 100k iterations returns `NoteTransportError::PaginationDidNotTerminate` — well beyond any plausible retention backlog, signals a server-side bug if hit.
- **`Client::fetch_transport_notes`**: signature changed from `Result<(), ClientError>` to `Result<NoteTransportCursor, ClientError>` so the drain loop can observe progress. Existing callers (`sync/mod.rs:130`, `fetch_private_notes`) just drop the returned cursor with `.await?;` — behavior unchanged.
- **`NoteTransportError::PaginationDidNotTerminate(usize)`**: new variant for the safety-cap escape.
- **Termination condition `new_cursor <= cursor`**: not `==`. The real server returns `rcursor = max(cursor, max_seq_returned)` so on an empty batch `rcursor == input_cursor` — equality would work. But `<=` also handles mock/test implementations that return `init()` on empty (which the in-tree `MockNoteTransportNode` did before this PR fixed it). Strictly correct in both regimes.
- **`MockNoteTransportNode` (test-utils)**:
  - New `with_max_batch(n)` constructor to exercise client-side pagination.
  - `get_notes` now sorts across-tag results by cursor ascending before applying the batch cap, mirroring the real server's `ORDER BY seq ASC`.
  - `rcursor` on an empty batch now preserves the input cursor instead of returning `init()` — matches the real server's contract. (Pre-existing bug; fixed here because the drain loop depends on it.)
- **New regression test** `fetch_all_private_notes_drains_across_batches`: sends 10 private notes through a mock capped at 3-per-batch, calls `fetch_all_private_notes`, asserts all 10 are visible. A/B proven: reverting just the loop change deterministically fails this test with `got 3 of 10`.
- **CHANGELOG**: new `## Unreleased` section with `[FIX][rust]` entry.

## Test plan

- [x] `cargo build -p miden-client` — clean.
- [x] `cargo test -p miden-client-unit-tests transport` — 6/6 pass (5 existing + new `fetch_all_private_notes_drains_across_batches`).
- [x] Sanity-check A/B: reverted the loop change, new test fails deterministically (`got 3 of 10`); restored the loop, passes.
- [x] `make format`, `make format-check`, `make clippy` — all clean.
- Note: `cargo test -p miden-client --lib` fails on `origin/main` for pre-existing reasons in `sync/state_sync.rs` (type inference errors in `#[cfg(test)]` blocks unrelated to this PR). Confirmed by stashing this PR's changes and re-running against clean `origin/main` — same errors reproduce.

## Compatibility

- Public API: `fetch_all_private_notes` keeps the same signature (`async fn(&mut self) -> Result<(), ClientError>`). Behavior is now *correct* where it was previously *silently truncated*.
- Internal API: `fetch_transport_notes` (crate-`pub(crate)`) return type changed. Both in-tree callers updated.
- Works unchanged against transport servers that don't cap responses (loop exits after one iteration when the first batch returns everything).