### PR TITLE
feat: make `TransactionStoreUpdate` serialization lossless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fixed the faucet token symbol display when showing account details ([#1985](https://github.com/0xMiden/miden-client/pull/1985)).
 * [FEATURE][rust,cli,web] Added `get_network_note_status` to `NodeRpcClient` trait for querying the processing status of notes submitted to the network (pending, nullifier-inflight, discarded, nullifier-committed), along with attempt count and error details. Exposed as `miden-client network-note-status <note_id>` CLI command and `RpcClient.getNetworkNoteStatus()` in the web client. ([#1981](https://github.com/0xMiden/miden-client/pull/1981))
 * Added `miden-cli call` command for invoking account procedures directly from the CLI.
+* Made `TransactionStoreUpdate` serialization lossless ([#2112](https://github.com/0xMiden/miden-client/pull/2112)).
 
 ## 0.14.4 (TBA)
 

--- a/crates/rust-client/src/note/note_update_tracker.rs
+++ b/crates/rust-client/src/note/note_update_tracker.rs
@@ -3,6 +3,13 @@ use alloc::collections::BTreeMap;
 use miden_protocol::account::AccountId;
 use miden_protocol::block::{BlockHeader, BlockNumber};
 use miden_protocol::note::{NoteId, NoteInclusionProof, Nullifier};
+use miden_tx::utils::serde::{
+    ByteReader,
+    ByteWriter,
+    Deserializable,
+    DeserializationError,
+    Serializable,
+};
 
 use crate::ClientError;
 use crate::rpc::RpcError;
@@ -27,7 +34,7 @@ pub enum NoteUpdateType {
 }
 
 /// Represents the possible states of an input note record in a [`NoteUpdateTracker`].
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct InputNoteUpdate {
     /// Input note being updated.
     note: InputNoteRecord,
@@ -92,7 +99,7 @@ impl InputNoteUpdate {
 }
 
 /// Represents the possible states of an output note record in a [`NoteUpdateTracker`].
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct OutputNoteUpdate {
     /// Output note being updated.
     note: OutputNoteRecord,
@@ -157,7 +164,7 @@ impl OutputNoteUpdate {
 /// This includes new notes that have been created and existing notes that have been updated. The
 /// tracker also lets state changes be applied to the contained notes, this allows for already
 /// updated notes to be further updated as new information is received.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct NoteUpdateTracker {
     /// A map of new and updated input note records to be upserted in the store.
     input_notes: BTreeMap<NoteId, InputNoteUpdate>,
@@ -509,5 +516,98 @@ impl NoteUpdateTracker {
             NoteUpdateType::Update => OutputNoteUpdate::new_update(note),
         };
         self.output_notes.insert(note_id, update);
+    }
+}
+
+// SERIALIZATION
+// ================================================================================================
+
+impl Serializable for NoteUpdateType {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        match self {
+            NoteUpdateType::None => target.write_u8(0),
+            NoteUpdateType::Insert => target.write_u8(1),
+            NoteUpdateType::Update => target.write_u8(2),
+        }
+    }
+}
+
+impl Deserializable for NoteUpdateType {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        match source.read_u8()? {
+            0 => Ok(NoteUpdateType::None),
+            1 => Ok(NoteUpdateType::Insert),
+            2 => Ok(NoteUpdateType::Update),
+            val => {
+                Err(DeserializationError::InvalidValue(format!("invalid note update type: {val}")))
+            },
+        }
+    }
+}
+
+impl Serializable for InputNoteUpdate {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.note.write_into(target);
+        self.update_type.write_into(target);
+    }
+}
+
+impl Deserializable for InputNoteUpdate {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let note = InputNoteRecord::read_from(source)?;
+        let update_type = NoteUpdateType::read_from(source)?;
+        Ok(Self { note, update_type })
+    }
+}
+
+impl Serializable for OutputNoteUpdate {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.note.write_into(target);
+        self.update_type.write_into(target);
+    }
+}
+
+impl Deserializable for OutputNoteUpdate {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let note = OutputNoteRecord::read_from(source)?;
+        let update_type = NoteUpdateType::read_from(source)?;
+        Ok(Self { note, update_type })
+    }
+}
+
+impl Serializable for NoteUpdateTracker {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        // `input_notes_by_nullifier` and `output_notes_by_nullifier` are lookup indices that can
+        // be reconstructed from `input_notes` and `output_notes`, so they are not serialized.
+        self.input_notes.write_into(target);
+        self.output_notes.write_into(target);
+        self.nullifier_order.write_into(target);
+    }
+}
+
+impl Deserializable for NoteUpdateTracker {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let input_notes = BTreeMap::<NoteId, InputNoteUpdate>::read_from(source)?;
+        let output_notes = BTreeMap::<NoteId, OutputNoteUpdate>::read_from(source)?;
+        let nullifier_order = BTreeMap::<Nullifier, u32>::read_from(source)?;
+
+        let input_notes_by_nullifier = input_notes
+            .iter()
+            .map(|(note_id, update)| (update.inner().nullifier(), *note_id))
+            .collect();
+        let output_notes_by_nullifier = output_notes
+            .iter()
+            .filter_map(|(note_id, update)| {
+                update.inner().nullifier().map(|nullifier| (nullifier, *note_id))
+            })
+            .collect();
+
+        Ok(Self {
+            input_notes,
+            output_notes,
+            input_notes_by_nullifier,
+            output_notes_by_nullifier,
+            nullifier_order,
+        })
     }
 }

--- a/crates/rust-client/src/note/note_update_tracker.rs
+++ b/crates/rust-client/src/note/note_update_tracker.rs
@@ -24,13 +24,27 @@ use crate::transaction::{TransactionRecord, TransactionStatus};
 /// Represents the possible types of updates that can be applied to a note in a
 /// [`NoteUpdateTracker`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
 pub enum NoteUpdateType {
     /// Indicates that the note was already tracked but it was not updated.
-    None,
+    None = 0,
     /// Indicates that the note is new and should be inserted in the store.
-    Insert,
+    Insert = 1,
     /// Indicates that the note was already tracked and should be updated.
-    Update,
+    Update = 2,
+}
+
+impl TryFrom<u8> for NoteUpdateType {
+    type Error = u8;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(NoteUpdateType::None),
+            1 => Ok(NoteUpdateType::Insert),
+            2 => Ok(NoteUpdateType::Update),
+            other => Err(other),
+        }
+    }
 }
 
 /// Represents the possible states of an input note record in a [`NoteUpdateTracker`].
@@ -524,24 +538,15 @@ impl NoteUpdateTracker {
 
 impl Serializable for NoteUpdateType {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        match self {
-            NoteUpdateType::None => target.write_u8(0),
-            NoteUpdateType::Insert => target.write_u8(1),
-            NoteUpdateType::Update => target.write_u8(2),
-        }
+        target.write_u8(*self as u8);
     }
 }
 
 impl Deserializable for NoteUpdateType {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        match source.read_u8()? {
-            0 => Ok(NoteUpdateType::None),
-            1 => Ok(NoteUpdateType::Insert),
-            2 => Ok(NoteUpdateType::Update),
-            val => {
-                Err(DeserializationError::InvalidValue(format!("invalid note update type: {val}")))
-            },
-        }
+        NoteUpdateType::try_from(source.read_u8()?).map_err(|val| {
+            DeserializationError::InvalidValue(format!("invalid note update type: {val}"))
+        })
     }
 }
 

--- a/crates/rust-client/src/store/note_record/output_note_record/mod.rs
+++ b/crates/rust-client/src/store/note_record/output_note_record/mod.rs
@@ -404,6 +404,34 @@ impl OutputNoteState {
     }
 }
 
+impl Serializable for OutputNoteRecord {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.recipient_digest.write_into(target);
+        self.assets.write_into(target);
+        self.metadata.write_into(target);
+        self.state.write_into(target);
+        self.expected_height.write_into(target);
+    }
+}
+
+impl Deserializable for OutputNoteRecord {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let recipient_digest = Word::read_from(source)?;
+        let assets = NoteAssets::read_from(source)?;
+        let metadata = NoteMetadata::read_from(source)?;
+        let state = OutputNoteState::read_from(source)?;
+        let expected_height = BlockNumber::read_from(source)?;
+
+        Ok(Self {
+            assets,
+            metadata,
+            recipient_digest,
+            state,
+            expected_height,
+        })
+    }
+}
+
 impl Serializable for OutputNoteState {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         self.discriminant().write_into(target);

--- a/crates/rust-client/src/sync/tag.rs
+++ b/crates/rust-client/src/sync/tag.rs
@@ -103,6 +103,21 @@ impl NoteTagRecord {
     }
 }
 
+impl Serializable for NoteTagRecord {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.tag.write_into(target);
+        self.source.write_into(target);
+    }
+}
+
+impl Deserializable for NoteTagRecord {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let tag = NoteTag::read_from(source)?;
+        let source = NoteTagSource::read_from(source)?;
+        Ok(Self { tag, source })
+    }
+}
+
 impl Serializable for NoteTagSource {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         match self {

--- a/crates/rust-client/src/transaction/store_update.rs
+++ b/crates/rust-client/src/transaction/store_update.rs
@@ -19,7 +19,7 @@ use crate::sync::NoteTagRecord;
 
 /// Represents the changes that need to be applied to the client store as a result of a
 /// transaction execution.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TransactionStoreUpdate {
     /// Details of the executed transaction to be inserted.
     executed_transaction: ExecutedTransaction,
@@ -90,6 +90,8 @@ impl Serializable for TransactionStoreUpdate {
         self.executed_transaction.write_into(target);
         self.submission_height.write_into(target);
         self.future_notes.write_into(target);
+        self.note_updates.write_into(target);
+        self.new_tags.write_into(target);
     }
 }
 
@@ -98,13 +100,91 @@ impl Deserializable for TransactionStoreUpdate {
         let executed_transaction = ExecutedTransaction::read_from(source)?;
         let submission_height = BlockNumber::read_from(source)?;
         let future_notes = Vec::<(NoteDetails, NoteTag)>::read_from(source)?;
+        let note_updates = NoteUpdateTracker::read_from(source)?;
+        let new_tags = Vec::<NoteTagRecord>::read_from(source)?;
 
         Ok(Self {
             executed_transaction,
             submission_height,
             future_notes,
-            note_updates: NoteUpdateTracker::default(),
-            new_tags: Vec::new(),
+            note_updates,
+            new_tags,
         })
+    }
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(all(test, feature = "testing"))]
+mod tests {
+    use alloc::boxed::Box;
+
+    use miden_protocol::asset::{Asset, FungibleAsset};
+    use miden_protocol::note::NoteType;
+    use miden_protocol::testing::account_id::{
+        ACCOUNT_ID_PRIVATE_FUNGIBLE_FAUCET,
+        ACCOUNT_ID_SENDER,
+    };
+    use miden_testing::{MockChainBuilder, TxContextInput};
+
+    use super::*;
+    use crate::note::NoteUpdateTracker;
+    use crate::store::InputNoteRecord;
+    use crate::sync::NoteTagRecord;
+
+    #[tokio::test]
+    async fn transaction_store_update_serialization_roundtrip() {
+        // Build a minimal MockChain with an account consuming a P2ID note so that we can
+        // produce a real `ExecutedTransaction`.
+        let sender_id = ACCOUNT_ID_SENDER.try_into().unwrap();
+        let faucet_id = ACCOUNT_ID_PRIVATE_FUNGIBLE_FAUCET.try_into().unwrap();
+        let asset = Asset::Fungible(FungibleAsset::new(faucet_id, 100u64).unwrap());
+
+        let mut builder = MockChainBuilder::new();
+        let account = builder.add_existing_mock_account(miden_testing::Auth::IncrNonce).unwrap();
+        let note = builder
+            .add_p2id_note(sender_id, account.id(), &[asset], NoteType::Public)
+            .unwrap();
+        let mut chain = builder.build().unwrap();
+        chain.prove_next_block().unwrap();
+
+        let executed_tx = Box::pin(
+            chain
+                .build_tx_context(
+                    TxContextInput::Account(account.clone()),
+                    &[],
+                    core::slice::from_ref(&note),
+                )
+                .unwrap()
+                .build()
+                .unwrap()
+                .execute(),
+        )
+        .await
+        .unwrap();
+
+        // Build non-trivial `note_updates` and `new_tags` so that the round-trip covers all
+        // fields that were previously dropped.
+        let input_note = InputNoteRecord::from(note.clone());
+        let note_updates = NoteUpdateTracker::for_transaction_updates([input_note], [], []);
+
+        let tag = miden_protocol::note::NoteTag::with_account_target(account.id());
+        let new_tags = vec![NoteTagRecord::with_account_source(tag, account.id())];
+
+        let future_notes = vec![(Into::<NoteDetails>::into(note.clone()), tag)];
+
+        let update = TransactionStoreUpdate::new(
+            executed_tx,
+            BlockNumber::from(42u32),
+            note_updates,
+            future_notes,
+            new_tags,
+        );
+
+        let bytes = update.to_bytes();
+        let deserialized = TransactionStoreUpdate::read_from_bytes(&bytes).unwrap();
+
+        assert_eq!(update, deserialized);
     }
 }

--- a/crates/rust-client/src/transaction/store_update.rs
+++ b/crates/rust-client/src/transaction/store_update.rs
@@ -116,7 +116,7 @@ impl Deserializable for TransactionStoreUpdate {
 // TESTS
 // ================================================================================================
 
-#[cfg(all(test, feature = "testing"))]
+#[cfg(all(test))]
 mod tests {
     use alloc::boxed::Box;
 

--- a/crates/rust-client/src/transaction/store_update.rs
+++ b/crates/rust-client/src/transaction/store_update.rs
@@ -169,7 +169,7 @@ mod tests {
         let input_note = InputNoteRecord::from(note.clone());
         let note_updates = NoteUpdateTracker::for_transaction_updates([input_note], [], []);
 
-        let tag = miden_protocol::note::NoteTag::with_account_target(account.id());
+        let tag = NoteTag::with_account_target(account.id());
         let new_tags = vec![NoteTagRecord::with_account_source(tag, account.id())];
 
         let future_notes = vec![(Into::<NoteDetails>::into(note.clone()), tag)];

--- a/crates/rust-client/src/transaction/store_update.rs
+++ b/crates/rust-client/src/transaction/store_update.rs
@@ -116,7 +116,7 @@ impl Deserializable for TransactionStoreUpdate {
 // TESTS
 // ================================================================================================
 
-#[cfg(all(test))]
+#[cfg(test)]
 mod tests {
     use alloc::boxed::Box;
 


### PR DESCRIPTION
Closes https://github.com/0xMiden/miden-client/issues/2103

This PR adds the missing `note_updates` and `new_tags` fields to the `TransactionStoreUpdate` serialization, so the roundtrip is lossless.