### PR TITLE
ci: add shear, workspace inheritance, and zizmor checks, and move heavy GitHub Actions jobs to WarpBuild

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - warp-ubuntu-latest-x64-8x

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -24,14 +24,16 @@ permissions:
 jobs:
   build-docs:
     name: Build Documentation
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
 name: Build
+
 on:
   push:
     branches: [main, next]
@@ -26,16 +27,20 @@ env:
 jobs:
   build:
     name: Build Client and CLI
-    runs-on: ubuntu-24.04
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Cleanup large tools for build space
+        uses: ./.github/actions/cleanup-runner
       - name: Install Rust toolchain
         run: rustup update --no-self-update
       - name: Add Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           shared-key: rust-release
           prefix-key: ${{ env.RUST_CACHE_KEY }}
-          save-if: ${{ github.ref == 'refs/heads/next' }}
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: make - build
         run: make build

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,17 +7,21 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled, unlabeled]
 
+permissions:
+  contents: read
+
 jobs:
   changelog:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Check for changes in changelog
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           NO_CHANGELOG_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'no changelog') }}
-        run: ./scripts/check-changelog.sh "${{ inputs.changelog }}"
+        run: ./scripts/check-changelog.sh
         shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,8 @@
 name: Lint
+
 permissions:
   contents: read
+
 on:
   push:
     branches: [main, next]
@@ -12,43 +14,66 @@ concurrency:
 
 env:
   CARGO_PROFILE_DEV_DEBUG: 0
+  RUST_CACHE_KEY: rust-cache-2026.02.18
 
 jobs:
   unused_deps:
     name: Check for unused dependencies
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - name: machete
-        uses: bnjbvr/cargo-machete@main
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Install cargo-shear
+        run: cargo install cargo-shear --version 1.11.2 --locked
+      - name: Check for unused dependencies
+        run: make shear
 
   typos:
     name: Spellcheck
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
-      - uses: taiki-e/install-action@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      # Keep this on a released install-action commit with an explicit tool; shortcut tags can
+      # trip zizmor's impostor-commit audit when they are later retagged.
+      - uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:
           tool: typos@1.42.0
       - run: make typos-check
 
   toml:
     name: Toml formatting
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
-      - uses: taiki-e/install-action@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      # Keep this on a released install-action commit with an explicit tool; shortcut tags can
+      # trip zizmor's impostor-commit audit when they are later retagged.
+      - uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:
           tool: taplo-cli@0.10.0
       - run: make toml-check
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-24.04
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Cleanup large tools for build space
+        uses: ./.github/actions/cleanup-runner
+      - name: Add Rust Cache
+        uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
+        with:
+          shared-key: rust-release
+          prefix-key: ${{ env.RUST_CACHE_KEY }}
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Install Rust with nightly clippy
         run: |
           rustup update --no-self-update nightly
@@ -58,9 +83,19 @@ jobs:
 
   format:
     name: Format check
-    runs-on: ubuntu-24.04
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Cleanup large tools for build space
+        uses: ./.github/actions/cleanup-runner
+      - name: Add Rust Cache
+        uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
+        with:
+          shared-key: rust-format
+          prefix-key: ${{ env.RUST_CACHE_KEY }}
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Install Rust with rustfmt
         run: |
           rustup update --no-self-update nightly
@@ -70,9 +105,19 @@ jobs:
 
   rustdocs:
     name: Build rust documentation
-    runs-on: ubuntu-24.04
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Cleanup large tools for build space
+        uses: ./.github/actions/cleanup-runner
+      - name: Add Rust Cache
+        uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
+        with:
+          shared-key: rust-docs
+          prefix-key: ${{ env.RUST_CACHE_KEY }}
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Install Rust
         run: rustup update --no-self-update
       - name: make - doc

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,6 +29,25 @@ jobs:
       - name: Check for unused dependencies
         run: make shear
 
+  workspace_inheritance:
+    name: Workspace inheritance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      # Do not pin taiki-e's moving tool shortcut tags by hash. Pin a released
+      # install-action commit and set tool explicitly, or zizmor's
+      # impostor-commit audit can flag stale shortcut-tag hashes.
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
+        with:
+          tool: cargo-binstall
+      - name: Install workspace inheritance checker
+        run: cargo binstall --no-confirm cargo-workspace-inheritance-check@1.2.0
+      - name: Check workspace inheritance
+        run: cargo workspace-inheritance-check --promotion-threshold 2 --promotion-failure
+
   typos:
     name: Spellcheck
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,9 @@ jobs:
         with:
           persist-credentials: false
       - name: Install cargo-shear
-        run: cargo install cargo-shear --version 1.11.2 --locked
+        uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
+        with:
+          tool: cargo-shear@1.11.2
       - name: Check for unused dependencies
         run: make shear
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Install Rust with nightly clippy
         run: |
           rustup update --no-self-update nightly
-          rustup +nightly component add clippy
+          rustup +nightly component add clippy rustfmt
       - name: make - clippy
         run: make clippy
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,15 +15,18 @@ jobs:
   # Run tests on the beta channel to provide feedback for Rust team.
   beta-test:
     name: Test on beta channel
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: "next"
+          persist-credentials: false
       - name: Rustup
         run: rustup install beta && rustup default beta
-      - uses: taiki-e/install-action@v2
+      # Keep this on a released install-action commit with an explicit tool; shortcut tags can
+      # trip zizmor's impostor-commit audit when they are later retagged.
+      - uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:
           tool: nextest@0.9.122
       - name: Run tests
@@ -33,7 +36,7 @@ jobs:
   # Each workspace package is verified independently via a matrix for clear per-package errors.
   workspace-packages:
     name: List packages
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       packages: ${{ steps.package-matrix.outputs.packages }}
     # Deliberately use stable rust instead of the toolchain.toml version.
@@ -41,9 +44,10 @@ jobs:
     env:
       RUSTUP_TOOLCHAIN: stable
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: "next"
+          persist-credentials: false
       - name: Extract workspace packages
         id: package-matrix
         run: |
@@ -59,7 +63,7 @@ jobs:
 
   msrv:
     needs: workspace-packages
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         package: ${{ fromJson(needs.workspace-packages.outputs.packages) }}
@@ -68,28 +72,40 @@ jobs:
     env:
       RUSTUP_TOOLCHAIN: stable
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: "next"
-      - name: Install binstall
-        uses: cargo-bins/cargo-binstall@main
+          persist-credentials: false
+      # Keep this on a released install-action commit with an explicit tool; shortcut tags can
+      # trip zizmor's impostor-commit audit when they are later retagged.
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
+        with:
+          tool: cargo-binstall
       - name: Install cargo-msrv
         run: cargo binstall --no-confirm cargo-msrv
       - name: Get manifest path for package
         id: pkg
+        env:
+          PACKAGE_NAME: ${{ matrix.package }}
         run: |
           MANIFEST_PATH=$(cargo metadata --format-version 1 --no-deps \
-            | jq -r '
+            | jq -r --arg package "$PACKAGE_NAME" '
               .packages[]
-              | select(.name == "${{ matrix.package }}")
+              | select(.name == $package)
               | .manifest_path
             ')
           echo "manifest_path=$MANIFEST_PATH" >> "$GITHUB_OUTPUT"
       - name: Show package info
+        env:
+          MANIFEST_PATH: ${{ steps.pkg.outputs.manifest_path }}
+          PACKAGE_NAME: ${{ matrix.package }}
         run: |
-          echo "Package: ${{ matrix.package }}"
-          echo "Manifest path: ${{ steps.pkg.outputs.manifest_path }}"
-          cargo msrv show --manifest-path "${{ steps.pkg.outputs.manifest_path }}"
+          echo "Package: $PACKAGE_NAME"
+          echo "Manifest path: $MANIFEST_PATH"
+          cargo msrv show --manifest-path "$MANIFEST_PATH"
       - name: Check MSRV
+        env:
+          MANIFEST_PATH: ${{ steps.pkg.outputs.manifest_path }}
         run: |
-          cargo msrv verify --manifest-path "${{ steps.pkg.outputs.manifest_path }}"
+          cargo msrv verify --manifest-path "$MANIFEST_PATH"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           ref: "next"
           persist-credentials: false
+      - name: Cleanup large tools for build space
+        uses: ./.github/actions/cleanup-runner
       - name: Rustup
         run: rustup install beta && rustup default beta
       # Keep this on a released install-action commit with an explicit tool; shortcut tags can
@@ -76,6 +78,8 @@ jobs:
         with:
           ref: "next"
           persist-credentials: false
+      - name: Cleanup large tools for build space
+        uses: ./.github/actions/cleanup-runner
       # Keep this on a released install-action commit with an explicit tool; shortcut tags can
       # trip zizmor's impostor-commit audit when they are later retagged.
       - name: Install cargo-binstall

--- a/.github/workflows/publish-crates-dry-run.yml
+++ b/.github/workflows/publish-crates-dry-run.yml
@@ -14,9 +14,10 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner

--- a/.github/workflows/publish-crates-release.yml
+++ b/.github/workflows/publish-crates-release.yml
@@ -18,17 +18,20 @@ jobs:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
 
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
 
       - name: Log release info
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          echo "Publishing release ${{ github.event.release.tag_name }}"
+          echo "Publishing release $RELEASE_TAG"
           echo "Commit: $(git rev-parse HEAD)"
 
       - name: Update Rust toolchain
@@ -73,10 +76,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
       - uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: |
@@ -92,7 +96,7 @@ jobs:
         run: |
           mv target/${{ matrix.target }}/release/miden-client miden-client-${{ matrix.target }}
       - name: Attest miden-client-cli
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
         with:
           subject-path: miden-client-${{ matrix.target }}
       - name: Upload
@@ -101,4 +105,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
-          gh release upload ${RELEASE_TAG} miden-client-${{ matrix.target }}
+          gh release upload "$RELEASE_TAG" "miden-client-${{ matrix.target }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -241,15 +241,9 @@ jobs:
       - name: Restore note-transport permissions
         run: chmod +x target/release/miden-note-transport-node-bin
       - name: Start test node
-        run: |
-          RUST_LOG=none target/release/testing-node-builder &
-          sleep 4
-          pgrep -f testing-node-builder || (echo "Failed to start node" && exit 1)
+        run: ./scripts/start-ci-service.sh testing-node-builder 57291 target/release/testing-node-builder
       - name: Start note transport
-        run: |
-          RUST_LOG=none target/release/miden-note-transport-node-bin &
-          sleep 4
-          pgrep -f miden-note-transport-node-bin || (echo "Failed to start note transport" && exit 1)
+        run: ./scripts/start-ci-service.sh miden-note-transport-node-bin 57292 target/release/miden-note-transport-node-bin
       - name: Run integration tests
         run: make integration-test-full
       - name: Stop test node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Test
+
 permissions:
   contents: read
+
 on:
   push:
     branches: [main, next]
@@ -14,7 +16,6 @@ on:
       - "**.txt"
       - "docs/**"
 
-# Only latest commit (per PR) should run
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
   cancel-in-progress: true
@@ -26,18 +27,24 @@ env:
 jobs:
   test:
     name: Unit tests
-    runs-on: ubuntu-24.04
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Cleanup large tools for build space
+        uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: rustup update --no-self-update
       - name: Add Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           shared-key: rust-release
           prefix-key: ${{ env.RUST_CACHE_KEY }}
           save-if: false
-      - uses: taiki-e/install-action@v2
+      # Keep this on a released install-action commit with an explicit tool; shortcut tags can
+      # trip zizmor's impostor-commit audit when they are later retagged.
+      - uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:
           tool: nextest@0.9.122
       - name: make - test
@@ -45,31 +52,45 @@ jobs:
 
   doc-tests:
     name: Documentation tests
-    runs-on: ubuntu-24.04
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Cleanup large tools for build space
+        uses: ./.github/actions/cleanup-runner
       - name: Install rust
         run: rustup update --no-self-update
+      - name: Add Rust Cache
+        uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
+        with:
+          shared-key: rust-release
+          prefix-key: ${{ env.RUST_CACHE_KEY }}
+          save-if: false
       - name: Run doc-tests
         run: make test-docs
 
   build-node-builder:
     name: Build node-builder
-    runs-on: ubuntu-24.04
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Cleanup large tools for build space
+        uses: ./.github/actions/cleanup-runner
       - name: Restore node-builder binary
         id: cache-node-builder
-        uses: actions/cache@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: target/release/testing-node-builder
-          key: ${{ runner.os }}-node-builder-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'crates/testing/node-builder/**/*') }}
+          key: ${{ runner.os }}-node-builder-${{ hashFiles('.cargo/config.toml', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'crates/testing/node-builder/**/*') }}
       - name: Install Rust
         if: steps.cache-node-builder.outputs.cache-hit != 'true'
         run: rustup update --no-self-update
       - name: Add Rust Cache
         if: steps.cache-node-builder.outputs.cache-hit != 'true'
-        uses: Swatinem/rust-cache@v2
+        uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           shared-key: rust-release
           prefix-key: ${{ env.RUST_CACHE_KEY }}
@@ -77,23 +98,32 @@ jobs:
       - name: Build node-builder
         if: steps.cache-node-builder.outputs.cache-hit != 'true'
         run: cargo build --release --package node-builder --locked
+      - name: Save node-builder binary
+        if: steps.cache-node-builder.outputs.cache-hit != 'true' && github.event_name == 'push' && github.ref == 'refs/heads/next'
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: target/release/testing-node-builder
+          key: ${{ runner.os }}-node-builder-${{ hashFiles('.cargo/config.toml', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'crates/testing/node-builder/**/*') }}
       - name: Check binary existance
-        run: |
-          file -E target/release/testing-node-builder
+        run: file -E target/release/testing-node-builder
 
   build-note-transport:
     name: Build note-transport
-    runs-on: ubuntu-24.04
+    runs-on: warp-ubuntu-latest-x64-8x
     outputs:
       note_transport_rev: ${{ steps.note-transport-rev.outputs.rev }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Cleanup large tools for build space
+        uses: ./.github/actions/cleanup-runner
       - name: Resolve note-transport revision
         id: note-transport-rev
         run: echo "rev=$(git ls-remote https://github.com/0xMiden/miden-note-transport HEAD | cut -f1)" >> "$GITHUB_OUTPUT"
       - name: Restore note-transport binary
         id: cache-note-transport
-        uses: actions/cache@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cargo/bin/miden-note-transport-node-bin
           key: ${{ runner.os }}-note-transport-${{ steps.note-transport-rev.outputs.rev }}
@@ -102,25 +132,42 @@ jobs:
         run: rustup update --no-self-update
       - name: Install note-transport
         if: steps.cache-note-transport.outputs.cache-hit != 'true'
-        run: cargo install --git https://github.com/0xMiden/miden-note-transport --rev ${{ steps.note-transport-rev.outputs.rev }} --locked
+        env:
+          NOTE_TRANSPORT_REV: ${{ steps.note-transport-rev.outputs.rev }}
+        run: |
+          [[ "$NOTE_TRANSPORT_REV" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "::error::Invalid note transport revision: $NOTE_TRANSPORT_REV"
+            exit 1
+          }
+          cargo install --git https://github.com/0xMiden/miden-note-transport --rev "$NOTE_TRANSPORT_REV" --locked
+      - name: Save note-transport binary
+        if: steps.cache-note-transport.outputs.cache-hit != 'true' && github.event_name == 'push' && github.ref == 'refs/heads/next'
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ~/.cargo/bin/miden-note-transport-node-bin
+          key: ${{ runner.os }}-note-transport-${{ steps.note-transport-rev.outputs.rev }}
 
   build-remote-prover:
     name: Build remote-prover
-    runs-on: ubuntu-24.04
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Cleanup large tools for build space
+        uses: ./.github/actions/cleanup-runner
       - name: Restore remote-prover binary
         id: cache-remote-prover
-        uses: actions/cache@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: target/release/testing-remote-prover
-          key: ${{ runner.os }}-prover-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'crates/testing/prover/**/*') }}
+          key: ${{ runner.os }}-prover-${{ hashFiles('.cargo/config.toml', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'crates/testing/prover/**/*') }}
       - name: Install Rust
         if: steps.cache-remote-prover.outputs.cache-hit != 'true'
         run: rustup update --no-self-update
       - name: Add Rust Cache
         if: steps.cache-remote-prover.outputs.cache-hit != 'true'
-        uses: Swatinem/rust-cache@v2
+        uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           shared-key: rust-release
           prefix-key: ${{ env.RUST_CACHE_KEY }}
@@ -128,34 +175,45 @@ jobs:
       - name: Build remote-prover
         if: steps.cache-remote-prover.outputs.cache-hit != 'true'
         run: cargo build --release --package testing-remote-prover --locked
+      - name: Save remote-prover binary
+        if: steps.cache-remote-prover.outputs.cache-hit != 'true' && github.event_name == 'push' && github.ref == 'refs/heads/next'
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: target/release/testing-remote-prover
+          key: ${{ runner.os }}-prover-${{ hashFiles('.cargo/config.toml', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'crates/testing/prover/**/*') }}
       - name: Check binary existance
-        run: |
-          file -E target/release/testing-remote-prover
+        run: file -E target/release/testing-remote-prover
 
   integration-tests:
     name: Integration tests
-    runs-on: ubuntu-24.04
+    runs-on: warp-ubuntu-latest-x64-8x
     needs: [build-node-builder, build-note-transport]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Cleanup large tools for build space
+        uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: rustup update --no-self-update
-      - uses: taiki-e/install-action@v2
+      # Keep this on a released install-action commit with an explicit tool; shortcut tags can
+      # trip zizmor's impostor-commit audit when they are later retagged.
+      - uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:
           tool: nextest@0.9.122
       - name: Add Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           shared-key: rust-release
           prefix-key: ${{ env.RUST_CACHE_KEY }}
           save-if: false
       - name: Restore node-builder binary
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: target/release/testing-node-builder
-          key: ${{ runner.os }}-node-builder-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'crates/testing/node-builder/**/*') }}
+          key: ${{ runner.os }}-node-builder-${{ hashFiles('.cargo/config.toml', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'crates/testing/node-builder/**/*') }}
       - name: Restore note-transport binary
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cargo/bin/miden-note-transport-node-bin
           key: ${{ runner.os }}-note-transport-${{ needs.build-note-transport.outputs.note_transport_rev }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,6 +104,11 @@ jobs:
         with:
           path: target/release/testing-node-builder
           key: ${{ runner.os }}-node-builder-${{ hashFiles('.cargo/config.toml', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'crates/testing/node-builder/**/*') }}
+      - name: Upload node-builder binary
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: node-builder-artifact
+          path: target/release/testing-node-builder
       - name: Check binary existance
         run: file -E target/release/testing-node-builder
 
@@ -146,6 +151,15 @@ jobs:
         with:
           path: ~/.cargo/bin/miden-note-transport-node-bin
           key: ${{ runner.os }}-note-transport-${{ steps.note-transport-rev.outputs.rev }}
+      - name: Stage note-transport binary
+        run: |
+          mkdir -p target/release
+          cp ~/.cargo/bin/miden-note-transport-node-bin target/release/miden-note-transport-node-bin
+      - name: Upload note-transport binary
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: note-transport-artifact
+          path: target/release/miden-note-transport-node-bin
 
   build-remote-prover:
     name: Build remote-prover
@@ -181,6 +195,11 @@ jobs:
         with:
           path: target/release/testing-remote-prover
           key: ${{ runner.os }}-prover-${{ hashFiles('.cargo/config.toml', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'crates/testing/prover/**/*') }}
+      - name: Upload remote-prover binary
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: remote-prover-artifact
+          path: target/release/testing-remote-prover
       - name: Check binary existance
         run: file -E target/release/testing-remote-prover
 
@@ -207,16 +226,16 @@ jobs:
           shared-key: rust-release
           prefix-key: ${{ env.RUST_CACHE_KEY }}
           save-if: false
-      - name: Restore node-builder binary
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Fetch node-builder binary
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          path: target/release/testing-node-builder
-          key: ${{ runner.os }}-node-builder-${{ hashFiles('.cargo/config.toml', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'crates/testing/node-builder/**/*') }}
-      - name: Restore note-transport binary
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+          name: node-builder-artifact
+          path: target/release
+      - name: Fetch note-transport binary
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          path: ~/.cargo/bin/miden-note-transport-node-bin
-          key: ${{ runner.os }}-note-transport-${{ needs.build-note-transport.outputs.note_transport_rev }}
+          name: note-transport-artifact
+          path: target/release
       - name: Start test node
         run: |
           RUST_LOG=none target/release/testing-node-builder &
@@ -224,7 +243,7 @@ jobs:
           pgrep -f testing-node-builder || (echo "Failed to start node" && exit 1)
       - name: Start note transport
         run: |
-          RUST_LOG=none miden-note-transport-node-bin &
+          RUST_LOG=none target/release/miden-note-transport-node-bin &
           sleep 4
           pgrep -f miden-note-transport-node-bin || (echo "Failed to start note transport" && exit 1)
       - name: Run integration tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -231,11 +231,15 @@ jobs:
         with:
           name: node-builder-artifact
           path: target/release
+      - name: Restore node-builder permissions
+        run: chmod +x target/release/testing-node-builder
       - name: Fetch note-transport binary
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: note-transport-artifact
           path: target/release
+      - name: Restore note-transport permissions
+        run: chmod +x target/release/miden-note-transport-node-bin
       - name: Start test node
         run: |
           RUST_LOG=none target/release/testing-node-builder &

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,39 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: [main, next]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - "zizmor.yml"
+  pull_request:
+    types: [opened, reopened, synchronize]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - "zizmor.yml"
+  merge_group:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        with:
+          advanced-security: false
+          config: zizmor.yml
+          version: 1.23.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2924,6 +2924,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures",
+ "getrandom 0.3.4",
  "gloo-timers",
  "hex",
  "miden-node-proto-build",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,6 +1039,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "codegen"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "573800db6c3319bc125ddbf9b9cb001ad1602957f53642ba8d09ff3ddd4da7f1"
+dependencies = [
+ "indexmap",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2662,6 +2671,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "lz4-sys",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -2914,7 +2924,6 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures",
- "getrandom 0.3.4",
  "gloo-timers",
  "hex",
  "miden-node-proto-build",
@@ -2940,7 +2949,6 @@ dependencies = [
  "tonic-web-wasm-client",
  "tracing",
  "uuid",
- "web-sys",
 ]
 
 [[package]]
@@ -2956,7 +2964,6 @@ dependencies = [
  "predicates",
  "rand 0.9.2",
  "rand_chacha",
- "serial_test",
  "tokio",
 ]
 
@@ -2984,7 +2991,6 @@ dependencies = [
  "toml 0.9.12+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
- "uuid",
 ]
 
 [[package]]
@@ -3178,7 +3184,7 @@ dependencies = [
 [[package]]
 name = "miden-large-smt-backend-rocksdb"
 version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?branch=next#8d3cee7c162a0f610ce7ba6c6dfc41af86e8f5cf"
+source = "git+https://github.com/0xMiden/node.git?branch=next#550f32f9e1761bd1f89056502351320504d80987"
 dependencies = [
  "miden-crypto",
  "miden-node-rocksdb-cxx-linkage-fix",
@@ -3240,7 +3246,7 @@ dependencies = [
 [[package]]
 name = "miden-node-block-producer"
 version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?branch=next#8d3cee7c162a0f610ce7ba6c6dfc41af86e8f5cf"
+source = "git+https://github.com/0xMiden/node.git?branch=next#550f32f9e1761bd1f89056502351320504d80987"
 dependencies = [
  "anyhow",
  "futures",
@@ -3266,7 +3272,7 @@ dependencies = [
 [[package]]
 name = "miden-node-db"
 version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?branch=next#8d3cee7c162a0f610ce7ba6c6dfc41af86e8f5cf"
+source = "git+https://github.com/0xMiden/node.git?branch=next#550f32f9e1761bd1f89056502351320504d80987"
 dependencies = [
  "deadpool",
  "deadpool-diesel",
@@ -3280,7 +3286,7 @@ dependencies = [
 [[package]]
 name = "miden-node-grpc-error-macro"
 version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?branch=next#8d3cee7c162a0f610ce7ba6c6dfc41af86e8f5cf"
+source = "git+https://github.com/0xMiden/node.git?branch=next#550f32f9e1761bd1f89056502351320504d80987"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -3289,7 +3295,7 @@ dependencies = [
 [[package]]
 name = "miden-node-ntx-builder"
 version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?branch=next#8d3cee7c162a0f610ce7ba6c6dfc41af86e8f5cf"
+source = "git+https://github.com/0xMiden/node.git?branch=next#550f32f9e1761bd1f89056502351320504d80987"
 dependencies = [
  "anyhow",
  "build-rs",
@@ -3308,7 +3314,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tokio-util",
  "tonic",
  "tonic-reflection",
  "tower-http",
@@ -3319,10 +3324,11 @@ dependencies = [
 [[package]]
 name = "miden-node-proto"
 version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?branch=next#8d3cee7c162a0f610ce7ba6c6dfc41af86e8f5cf"
+source = "git+https://github.com/0xMiden/node.git?branch=next#550f32f9e1761bd1f89056502351320504d80987"
 dependencies = [
  "anyhow",
  "build-rs",
+ "codegen",
  "fs-err",
  "hex",
  "http 1.4.0",
@@ -3333,6 +3339,7 @@ dependencies = [
  "miden-standards",
  "miette",
  "prost",
+ "prost-types",
  "thiserror 2.0.18",
  "tonic",
  "tonic-prost",
@@ -3343,9 +3350,10 @@ dependencies = [
 [[package]]
 name = "miden-node-proto-build"
 version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?branch=next#8d3cee7c162a0f610ce7ba6c6dfc41af86e8f5cf"
+source = "git+https://github.com/0xMiden/node.git?branch=next#550f32f9e1761bd1f89056502351320504d80987"
 dependencies = [
  "build-rs",
+ "codegen",
  "fs-err",
  "miette",
  "protox",
@@ -3355,12 +3363,12 @@ dependencies = [
 [[package]]
 name = "miden-node-rocksdb-cxx-linkage-fix"
 version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?branch=next#8d3cee7c162a0f610ce7ba6c6dfc41af86e8f5cf"
+source = "git+https://github.com/0xMiden/node.git?branch=next#550f32f9e1761bd1f89056502351320504d80987"
 
 [[package]]
 name = "miden-node-rpc"
 version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?branch=next#8d3cee7c162a0f610ce7ba6c6dfc41af86e8f5cf"
+source = "git+https://github.com/0xMiden/node.git?branch=next#550f32f9e1761bd1f89056502351320504d80987"
 dependencies = [
  "anyhow",
  "futures",
@@ -3388,7 +3396,7 @@ dependencies = [
 [[package]]
 name = "miden-node-store"
 version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?branch=next#8d3cee7c162a0f610ce7ba6c6dfc41af86e8f5cf"
+source = "git+https://github.com/0xMiden/node.git?branch=next#550f32f9e1761bd1f89056502351320504d80987"
 dependencies = [
  "anyhow",
  "build-rs",
@@ -3429,7 +3437,7 @@ dependencies = [
 [[package]]
 name = "miden-node-utils"
 version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?branch=next#8d3cee7c162a0f610ce7ba6c6dfc41af86e8f5cf"
+source = "git+https://github.com/0xMiden/node.git?branch=next#550f32f9e1761bd1f89056502351320504d80987"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3463,7 +3471,7 @@ dependencies = [
 [[package]]
 name = "miden-node-validator"
 version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?branch=next#8d3cee7c162a0f610ce7ba6c6dfc41af86e8f5cf"
+source = "git+https://github.com/0xMiden/node.git?branch=next#550f32f9e1761bd1f89056502351320504d80987"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -3610,7 +3618,7 @@ dependencies = [
 [[package]]
 name = "miden-remote-prover-client"
 version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?branch=next#8d3cee7c162a0f610ce7ba6c6dfc41af86e8f5cf"
+source = "git+https://github.com/0xMiden/node.git?branch=next#550f32f9e1761bd1f89056502351320504d80987"
 dependencies = [
  "build-rs",
  "fs-err",
@@ -7358,3 +7366,13 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,16 +55,28 @@ miden-remote-prover-client = { branch = "next", default-features = false, featur
 ], git = "https://github.com/0xMiden/node.git" }
 
 # External dependencies
-anyhow      = { default-features = false, version = "1.0" }
-async-trait = { version = "0.1" }
-chrono      = { version = "0.4" }
-hex         = { version = "0.4" }
-miette      = { features = ["fancy"], version = "7.6" }
-rand        = { version = "0.9" }
-serde       = { features = ["derive"], version = "1.0" }
-thiserror   = { default-features = false, version = "2.0" }
-tokio       = { features = ["macros", "rt-multi-thread"], version = "1.48" }
-tracing     = { version = "0.1" }
+anyhow             = { default-features = false, version = "1.0" }
+assert_cmd         = { version = "2.0" }
+async-trait        = { version = "0.1" }
+chrono             = { version = "0.4" }
+clap               = { version = "4.5" }
+comfy-table        = { version = "7.1" }
+hex                = { version = "0.4" }
+miette             = { features = ["fancy"], version = "7.6" }
+predicates         = { version = "3.0" }
+prost              = { default-features = false, version = "0.14" }
+rand               = { version = "0.9" }
+rand_chacha        = { version = "0.9" }
+regex              = { version = "1.0" }
+serde              = { features = ["derive"], version = "1.0" }
+serde_json         = { version = "1.0" }
+tempfile           = { version = "3.0" }
+thiserror          = { default-features = false, version = "2.0" }
+tokio              = { features = ["macros", "rt-multi-thread"], version = "1.48" }
+tonic              = { default-features = false, version = "0.14" }
+tracing            = { version = "0.1" }
+tracing-subscriber = { default-features = false, version = "0.3" }
+uuid               = { version = "1.10" }
 
 # Lints are set to warn for development, which are promoted to errors in CI.
 [workspace.lints.clippy]

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,12 @@ format: ## Run format using nightly toolchain
 format-check: ## Run format using nightly toolchain but only in check mode
 	cargo +nightly fmt --all --check
 
+.PHONY: shear
+shear: ## Run cargo-shear to find unused or misplaced dependencies
+	cargo shear
+
 .PHONY: lint
-lint: fix format toml clippy typos-check ## Run all linting tasks at once (clippy, fixing, formatting, typos)
+lint: fix format toml clippy typos-check shear ## Run all linting tasks at once (clippy, fixing, formatting, typos)
 
 .PHONY: toml
 toml: ## Runs Format for all TOML files
@@ -168,6 +172,7 @@ check-tools: ## Checks if development tools are installed
 	@command -v mdbook        >/dev/null 2>&1 && echo "[OK] mdbook is installed"        || echo "[MISSING] mdbook       (make install-tools)"
 	@command -v typos         >/dev/null 2>&1 && echo "[OK] typos is installed"         || echo "[MISSING] typos        (make install-tools)"
 	@command -v cargo nextest >/dev/null 2>&1 && echo "[OK] cargo-nextest is installed" || echo "[MISSING] cargo-nextest(make install-tools)"
+	@command -v cargo-shear   >/dev/null 2>&1 && echo "[OK] cargo-shear is installed"   || echo "[MISSING] cargo-shear  (make install-tools)"
 	@command -v taplo         >/dev/null 2>&1 && echo "[OK] taplo is installed"         || echo "[MISSING] taplo        (make install-tools)"
 
 .PHONY: install-tools
@@ -181,5 +186,6 @@ install-tools: ## Installs Rust tools required by the Makefile
 	cargo install mdbook --locked
 	cargo install typos-cli@1.42.3 --locked
 	cargo install cargo-nextest@0.9.128 --locked
+	cargo install cargo-shear@1.11.2 --locked
 	cargo install taplo-cli --locked
 	@echo "Development tools installation complete!"

--- a/bin/integration-tests/Cargo.toml
+++ b/bin/integration-tests/Cargo.toml
@@ -35,3 +35,7 @@ tokio              = { workspace = true }
 tracing            = { workspace = true }
 tracing-subscriber = { features = ["env-filter", "fmt", "json"], version = "0.3" }
 uuid               = { version = "1.10" }
+
+[lib]
+doctest = false
+test    = false

--- a/bin/integration-tests/Cargo.toml
+++ b/bin/integration-tests/Cargo.toml
@@ -25,16 +25,16 @@ miden-client-sqlite-store = { workspace = true }
 # External dependencies
 anyhow             = { features = ["std"], workspace = true }
 async-trait        = { workspace = true }
-clap               = { features = ["derive", "env"], version = "4.0" }
+clap               = { features = ["derive", "env"], workspace = true }
 num_cpus           = { version = "1.0" }
 rand               = { workspace = true }
-regex              = { version = "1.0" }
-serde              = { features = ["derive"], version = "1.0" }
-serde_json         = { version = "1.0" }
+regex              = { workspace = true }
+serde              = { workspace = true }
+serde_json         = { workspace = true }
 tokio              = { workspace = true }
 tracing            = { workspace = true }
-tracing-subscriber = { features = ["env-filter", "fmt", "json"], version = "0.3" }
-uuid               = { version = "1.10" }
+tracing-subscriber = { features = ["env-filter", "fmt", "json"], workspace = true }
+uuid               = { workspace = true }
 
 [lib]
 doctest = false

--- a/bin/miden-bench/Cargo.toml
+++ b/bin/miden-bench/Cargo.toml
@@ -23,15 +23,15 @@ miden-client-sqlite-store = { path = "../../crates/sqlite-store" }
 
 # External dependencies
 anyhow      = { features = ["std"], workspace = true }
-clap        = { features = ["derive", "env"], version = "4.0" }
-comfy-table = { version = "7.1" }
+clap        = { features = ["derive", "env"], workspace = true }
+comfy-table = { workspace = true }
 rand        = { workspace = true }
-rand_chacha = { version = "0.9" }
+rand_chacha = { workspace = true }
 tokio       = { workspace = true }
 
 [dev-dependencies]
-assert_cmd = { version = "2.0" }
-predicates = { version = "3.0" }
+assert_cmd = { workspace = true }
+predicates = { workspace = true }
 
 [lints]
 workspace = true

--- a/bin/miden-bench/Cargo.toml
+++ b/bin/miden-bench/Cargo.toml
@@ -30,9 +30,8 @@ rand_chacha = { version = "0.9" }
 tokio       = { workspace = true }
 
 [dev-dependencies]
-assert_cmd  = { version = "2.0" }
-predicates  = { version = "3.0" }
-serial_test = { features = ["file_locks"], version = "3.0" }
+assert_cmd = { version = "2.0" }
+predicates = { version = "3.0" }
 
 [lints]
 workspace = true

--- a/bin/miden-cli/Cargo.toml
+++ b/bin/miden-cli/Cargo.toml
@@ -22,29 +22,29 @@ miden-client              = { features = ["tonic"], workspace = true }
 miden-client-sqlite-store = { workspace = true }
 
 # External dependencies
-clap               = { features = ["derive"], version = "4.5" }
-comfy-table        = { version = "7.1" }
+clap               = { features = ["derive"], workspace = true }
+comfy-table        = { workspace = true }
 dirs               = { version = "6.0" }
 figment            = { features = ["env", "toml"], version = "0.10" }
 miette             = { workspace = true }
 rand               = { workspace = true }
-serde              = { features = ["derive"], version = "1.0" }
+serde              = { workspace = true }
 thiserror          = { workspace = true }
 tokio              = { workspace = true }
 toml               = { version = "0.9" }
 tracing            = { workspace = true }
-tracing-subscriber = { version = "0.3" }
+tracing-subscriber = { workspace = true }
 
 [build-dependencies]
 miden-client = { features = ["std"], workspace = true }
 
 [dev-dependencies]
 anyhow          = { workspace = true }
-assert_cmd      = { version = "2.0" }
+assert_cmd      = { workspace = true }
 miden-client    = { features = ["testing"], workspace = true }
 midenc-hir-type = "0.5"
-predicates      = { version = "3.0" }
-regex           = { version = "1.0" }
+predicates      = { workspace = true }
+regex           = { workspace = true }
 serial_test     = { features = ["file_locks"], version = "3.0" }
 
 [lints]

--- a/bin/miden-cli/Cargo.toml
+++ b/bin/miden-cli/Cargo.toml
@@ -46,7 +46,6 @@ midenc-hir-type = "0.5"
 predicates      = { version = "3.0" }
 regex           = { version = "1.0" }
 serial_test     = { features = ["file_locks"], version = "3.0" }
-uuid            = { features = ["serde", "v4"], version = "1.10" }
 
 [lints]
 workspace = true

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -20,6 +20,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 # "prost-types" and "tonic-prost" are ignored because they are needed by the generated proto bindings.
 ignored = ["getrandom", "prost-types", "tonic-prost"]
 
+[package.metadata.cargo-shear]
+# These are used by generated proto bindings and std-only keystore code that shear does not
+# fully resolve.
+ignored = ["prost-types", "serde", "serde_json", "tempfile", "tonic-prost"]
+
 [lib]
 crate-type = ["lib"]
 
@@ -68,10 +73,8 @@ tracing      = { workspace = true }
 uuid         = { features = ["js", "serde", "v4"], optional = true, version = "1.10" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom             = { features = ["wasm_js"], version = "0.3" }
 gloo-timers           = { features = ["futures"], version = "0.3" }
 tonic-web-wasm-client = { default-features = false, version = "0.9" }
-web-sys               = { features = ["Storage", "Window", "console"], version = "0.3" }
 
 [build-dependencies]
 miden-node-proto-build           = { workspace = true }
@@ -87,7 +90,6 @@ miden-protocol  = { default-features = false, features = ["testing"], workspace 
 miden-standards = { features = ["testing"], workspace = true }
 miden-testing   = { default-features = false, workspace = true }
 tokio           = { workspace = true }
-web-sys         = { features = ["console"], version = "0.3" }
 
 [lints]
 workspace = true

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -21,9 +21,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 ignored = ["getrandom", "prost-types", "tonic-prost"]
 
 [package.metadata.cargo-shear]
-# These are used by generated proto bindings and std-only keystore code that shear does not
-# fully resolve.
-ignored = ["prost-types", "serde", "serde_json", "tempfile", "tonic-prost"]
+# getrandom is used through rand's wasm backend selection. The other entries are used by
+# generated proto bindings and std-only keystore code that shear does not fully resolve.
+ignored = ["getrandom", "prost-types", "serde", "serde_json", "tempfile", "tonic-prost"]
 
 [lib]
 crate-type = ["lib"]
@@ -73,6 +73,7 @@ tracing      = { workspace = true }
 uuid         = { features = ["js", "serde", "v4"], optional = true, workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom             = { features = ["wasm_js"], version = "0.3" }
 gloo-timers           = { features = ["futures"], version = "0.3" }
 tonic-web-wasm-client = { default-features = false, version = "0.9" }
 

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -55,22 +55,22 @@ miden-tx                   = { workspace = true }
 # External dependencies
 anyhow       = { workspace = true }
 async-trait  = { workspace = true }
-chrono       = { optional = false, version = "0.4" }
+chrono       = { workspace = true }
 futures      = { version = "0.3" }
 hex          = { workspace = true }
-prost        = { default-features = false, features = ["derive"], version = "0.14" }
+prost        = { features = ["derive"], workspace = true }
 prost-types  = { version = "0.14" }
 rand         = { workspace = true }
 serde        = { workspace = true }
-serde_json   = { version = "1.0" }
-tempfile     = { optional = true, version = "3.0" }
+serde_json   = { workspace = true }
+tempfile     = { optional = true, workspace = true }
 thiserror    = { workspace = true }
 tokio        = { features = ["time"], optional = true, workspace = true }
-tonic        = { default-features = false, features = ["codegen"], version = "0.14" }
+tonic        = { features = ["codegen"], workspace = true }
 tonic-health = { version = "0.14" }
 tonic-prost  = { version = "0.14" }
 tracing      = { workspace = true }
-uuid         = { features = ["js", "serde", "v4"], optional = true, version = "1.10" }
+uuid         = { features = ["js", "serde", "v4"], optional = true, workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 gloo-timers           = { features = ["futures"], version = "0.3" }
@@ -82,7 +82,7 @@ miden-note-transport-proto-build = { workspace = true }
 miden-protocol                   = { workspace = true }
 miden-standards                  = { workspace = true }
 miette                           = { workspace = true }
-prost                            = { default-features = false, features = ["derive"], version = "0.14" }
+prost                            = { features = ["derive"], workspace = true }
 tonic-prost-build                = { version = "0.14" }
 
 [dev-dependencies]

--- a/crates/sqlite-store/Cargo.toml
+++ b/crates/sqlite-store/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace      = true
 
 [lib]
 crate-type = ["lib"]
+doctest    = false
 
 [dependencies]
 # Miden dependencies

--- a/crates/testing/miden-client-tests/Cargo.toml
+++ b/crates/testing/miden-client-tests/Cargo.toml
@@ -16,3 +16,6 @@ tokio                     = { workspace = true }
 
 [lints]
 workspace = true
+
+[lib]
+doctest = false

--- a/crates/testing/node-builder/Cargo.toml
+++ b/crates/testing/node-builder/Cargo.toml
@@ -38,3 +38,7 @@ tempfile = "3.0"
 
 [lints]
 workspace = true
+
+[lib]
+doctest = false
+test    = false

--- a/crates/testing/node-builder/Cargo.toml
+++ b/crates/testing/node-builder/Cargo.toml
@@ -29,12 +29,12 @@ miden-standards           = { workspace = true }
 # External dependencies
 anyhow      = { workspace = true }
 rand        = { workspace = true }
-rand_chacha = { version = "0.9" }
+rand_chacha = { workspace = true }
 tokio       = { features = ["signal"], workspace = true }
 url         = { features = ["serde"], version = "2.5" }
 
 [dev-dependencies]
-tempfile = "3.0"
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/testing/prover/Cargo.toml
+++ b/crates/testing/prover/Cargo.toml
@@ -20,10 +20,10 @@ anyhow             = { workspace = true }
 async-trait        = { workspace = true }
 tokio              = { features = ["net"], workspace = true }
 tokio-stream       = { features = ["net"], version = "0.1" }
-tonic              = { default-features = false, features = ["router", "transport"], version = "0.14" }
+tonic              = { features = ["router", "transport"], workspace = true }
 tonic-web          = { version = "0.14" }
-tracing            = { version = "0.1" }
-tracing-subscriber = { features = ["env-filter", "fmt", "json"], version = "0.3" }
+tracing            = { workspace = true }
+tracing-subscriber = { features = ["env-filter", "fmt", "json"], workspace = true }
 
 [lints]
 workspace = true

--- a/scripts/start-ci-service.sh
+++ b/scripts/start-ci-service.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -lt 3 ]; then
+  echo "Usage: $0 <name> <port> <command> [args...]"
+  exit 1
+fi
+
+service_name="$1"
+service_port="$2"
+shift 2
+
+log_path="${RUNNER_TEMP:-/tmp}/${service_name}.log"
+
+rm -f "$log_path"
+
+nohup env RUST_LOG=none "$@" >"$log_path" 2>&1 &
+service_pid=$!
+
+for _ in $(seq 1 30); do
+  if ! kill -0 "$service_pid" 2>/dev/null; then
+    echo "Failed to start $service_name"
+    sed -n '1,200p' "$log_path"
+    exit 1
+  fi
+
+  if python3 - "$service_port" <<'PY'
+import socket
+import sys
+
+sock = socket.socket()
+sock.settimeout(1)
+
+try:
+    sock.connect(("127.0.0.1", int(sys.argv[1])))
+except OSError:
+    sys.exit(1)
+else:
+    sys.exit(0)
+finally:
+    sock.close()
+PY
+  then
+    exit 0
+  fi
+
+  sleep 1
+done
+
+echo "Timed out waiting for $service_name on 127.0.0.1:$service_port"
+sed -n '1,200p' "$log_path"
+exit 1

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -4,3 +4,10 @@ rules:
       - publish-crates-release.yml
       - publish-web-client-next.yml
       - publish-web-client-release.yml
+  secrets-outside-env:
+    ignore:
+      - publish-crates-dry-run.yml
+      - publish-crates-release.yml
+      - publish-web-client-next.yml
+      - publish-web-client-release.yml
+      - trigger-deploy-docs.yml

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -2,12 +2,8 @@ rules:
   use-trusted-publishing:
     ignore:
       - publish-crates-release.yml
-      - publish-web-client-next.yml
-      - publish-web-client-release.yml
   secrets-outside-env:
     ignore:
       - publish-crates-dry-run.yml
       - publish-crates-release.yml
-      - publish-web-client-next.yml
-      - publish-web-client-release.yml
       - trigger-deploy-docs.yml

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,6 @@
+rules:
+  use-trusted-publishing:
+    ignore:
+      - publish-crates-release.yml
+      - publish-web-client-next.yml
+      - publish-web-client-release.yml


### PR DESCRIPTION
1. The dependency check now uses [`cargo-shear`](https://github.com/Boshen/cargo-shear), an upgrade from `cargo-machete`. `cargo shear` looks not only for unused dependencies (better than machete, as shown by this PR's removals), but also for those put in the wrong dependency section.
2. [`zizmor`](https://github.com/zizmorcore/zizmor) scans GitHub Actions files for risky patterns, like loose action pins or unsafe defaults. 
3. The heavier CI jobs now run on beefier [WarpBuild](https://www.warpbuild.com/) runners.
4. The dependency policy check now also uses cargo-workspace-inheritance-check. It makes sure crates that are shared across the workspace use one workspace-level dependency entry instead of repeating versions in many crate manifests.

The PR also removes the unused dependencies that `shear` found, pins action versions more tightly, and fixes feature-flag issues.