### PR TITLE
fix: replace expect() with ? on note_type protobuf conversion in NoteMetadata and NoteHeader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 * [BREAKING][param][rust] `NodeRpcClient::sync_chain_mmr()` replaced `block_to: Option<BlockNumber>` with `upper_bound: SyncTarget` to match the RPC definition. Use `SyncTarget::CommittedChainTip` for previous default behavior (`None`), or `SyncTarget::BlockNumber(num)` for a specific block number. ([#1991](https://github.com/0xMiden/miden-client/pull/1991))
 * [BREAKING][rust] Added `submit_proven_batch` to `NodeRpcClient` trait. ([#2075](https://github.com/0xMiden/miden-client/pull/2075))
 
+### Bug Fixes
+
+* Fixed panics in `NoteMetadata` and `NoteHeader` RPC conversions when protobuf `note_type` field contains a negative `i32` value, by replacing `.expect()` with proper `?` error propagation.
+
 ### Enhancements
 
 * Made new-account construction use merged storage schema commitment (`build_with_schema_commitment`), re-exported `AccountBuilderSchemaCommitmentExt`, added WASM `buildWithoutSchemaCommitment()`, and fixed contract `accounts.create()` to require explicit `components` ([#1996](https://github.com/0xMiden/miden-client/pull/1996)).

--- a/crates/rust-client/src/rpc/domain/note.rs
+++ b/crates/rust-client/src/rpc/domain/note.rs
@@ -47,8 +47,7 @@ impl TryFrom<proto::note::NoteMetadata> for NoteMetadata {
             .sender
             .ok_or_else(|| proto::note::NoteMetadata::missing_field(stringify!(sender)))?
             .try_into()?;
-        let note_type =
-            NoteType::try_from(u64::try_from(value.note_type).expect("invalid note type"))?;
+        let note_type = NoteType::try_from(u64::try_from(value.note_type)?)?;
         let tag = NoteTag::new(value.tag);
 
         // Deserialize attachment if present
@@ -324,8 +323,7 @@ impl TryFrom<proto::note::NoteSyncRecord> for CommittedNote {
                 notes.metadata_header.sender
             )))?
             .try_into()?;
-        let note_type =
-            NoteType::try_from(u64::try_from(proto_header.note_type).expect("invalid note type"))?;
+        let note_type = NoteType::try_from(u64::try_from(proto_header.note_type)?)?;
         let tag = NoteTag::new(proto_header.tag);
         let attachment_kind = u8::try_from(proto_header.attachment_kind)
             .ok()


### PR DESCRIPTION
## Summary

Replaces two `.expect()` panics with proper error propagation in RPC conversion impls that handle protobuf data.

## Problem

`value.note_type` and `proto_header.note_type` are protobuf `i32` fields. The conversion `u64::try_from(i32)` fails for any negative value, returning `TryFromIntError`. Instead of propagating this as `RpcConversionError`, both call sites used `.expect("invalid note type")` which panics on unexpected wire data from the network.

## Fix

Replaced both `.expect("invalid note type")` calls with `?`. Since `RpcConversionError` already has `InvalidInt(#[from] TryFromIntError)`, the `?` operator converts and propagates the error automatically — no new imports needed.

## Changes
- 1 file changed, 2 insertions(+), 4 deletions(-)
- `crates/rust-client/src/rpc/domain/note.rs` (lines 51 and 328)