### PR TITLE
fix: bump crate versions for `v0.14.5` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2924,7 +2924,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-bench"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2979,7 +2979,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-cli"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3006,7 +3006,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-integration-tests"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3027,7 +3027,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-sqlite-store"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3045,7 +3045,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-unit-tests"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "miden-client",
  "miden-client-sqlite-store",
@@ -3058,7 +3058,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-web"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "async-trait",
  "console_error_panic_hook",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "miden-idxdb-store"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "async-trait",
  "base64",
@@ -4047,7 +4047,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "node-builder"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "anyhow",
  "miden-node-block-producer",
@@ -6115,7 +6115,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "testing-remote-prover"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ edition      = "2024"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/miden-client"
 rust-version = "1.93"
-version      = "0.14.4"
+version      = "0.14.5"
 
 [profile.dev]
 codegen-units = 16

--- a/crates/web-client/package.json
+++ b/crates/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-sdk",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "description": "Miden Wasm SDK",
   "collaborators": [
     "Miden"

--- a/packages/react-sdk/examples/wallet/package.json
+++ b/packages/react-sdk/examples/wallet/package.json
@@ -9,13 +9,13 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@miden-sdk/miden-sdk": "^0.14.4",
-    "@miden-sdk/react": "^0.14.4",
+    "@miden-sdk/miden-sdk": "^0.14.5",
+    "@miden-sdk/react": "^0.14.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@miden-sdk/vite-plugin": "^0.14.4",
+    "@miden-sdk/vite-plugin": "^0.14.5",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^4.2.0",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/react",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "description": "React hooks library for Miden Web Client",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -33,7 +33,7 @@
     "test:all": "VITE_CJS_IGNORE_WARNING=1 vitest run && playwright test"
   },
   "peerDependencies": {
-    "@miden-sdk/miden-sdk": "^0.14.4",
+    "@miden-sdk/miden-sdk": "^0.14.5",
     "react": ">=18.0.0"
   },
   "dependencies": {

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/vite-plugin",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "description": "Vite plugin for Miden dApps — WASM dedup, COOP/COEP headers, and gRPC-web proxy",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
https://github.com/0xMiden/miden-client/pull/2117 forgot to bump crate/package version, thus failing to run the release jobs. This PR fixes that.