### PR TITLE
fix: migrate note scripts to @note_script library form for miden-standards 0.14.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.14.5 (2026-04-27)
 
+### Breaking Changes
+
+* [BREAKING][behavior][rust,web] `CodeBuilder::compile_note_script` now expects a library module with a single procedure annotated `@note_script` (e.g. `@note_script\npub proc main\n    ...\nend`) instead of a `begin..end` program. Inherited from `miden-standards` 0.14.5, which switched the underlying call from `assemble_program` to `assemble_library` ([#2128](https://github.com/0xMiden/miden-client/pull/2128)).
+
 ### Enhancements
 
 * Added `ClientBuilder::source_manager()` to override the `SourceManager` used by the client. When not set, the client defaults to `DefaultSourceManager`. Set this when compiling scripts outside the client with an external `Assembler`, so source spans resolve against the same manager ([#2047](https://github.com/0xMiden/miden-client/pull/2047)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1641,7 +1641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2306,7 +2306,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2838,9 +2838,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "miden-agglayer"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73a12734b3bf5e8c88580c4c173368865d1efd6f51f48365df76b59f12d8dc53"
+checksum = "44929802246cf00c5ff76ae9f9648e079f64245e5fa8344a2aefc33bab9cd346"
 dependencies = [
  "alloy-sol-types",
  "fs-err",
@@ -2853,6 +2853,8 @@ dependencies = [
  "miden-utils-sync",
  "primitive-types",
  "regex",
+ "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "walkdir",
 ]
@@ -2914,9 +2916,9 @@ dependencies = [
 
 [[package]]
 name = "miden-block-prover"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "334340b0b2e6993f6b71af359a77cf8730c4a19ac366f77aee734a5faa993897"
+checksum = "fec217cf565a2c7272a4cc409939bd8a5a43bfd02b7f7a16bd6abd3cfcb2b514"
 dependencies = [
  "miden-protocol",
  "thiserror 2.0.18",
@@ -3691,9 +3693,9 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595b3d43ceb562d05e248a6c52bdc2992dc270b60d6d0e8c0a6480aa30672b8e"
+checksum = "140b1b3d6b2a3a2bfaeca8b0d2ca15a8ee6a7e0abebbc4f1a2a3a1f1b7f7f58d"
 dependencies = [
  "bech32",
  "fs-err",
@@ -3721,9 +3723,9 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol-macros"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c287782953c94452c2f7431feff137e4fe8b8d1eb5aa9112eab83a6f11c8f2"
+checksum = "3cbd8195ba7804fab6ab22f042715fab55c842ac29e99534490243c6a12a3cb8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3782,9 +3784,9 @@ dependencies = [
 
 [[package]]
 name = "miden-standards"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f63cd9264dc1f9f124fe644ee631828cc9bfd71022a75cd5bc1678f3ba7b56"
+checksum = "a08e4e4edb289460b1b676a9cdb1727131c2749218dd85a333571d09e1cfa621"
 dependencies = [
  "fs-err",
  "miden-assembly",
@@ -3800,9 +3802,9 @@ dependencies = [
 
 [[package]]
 name = "miden-testing"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2761dd1f8baa744c91d1ff143d954c623d5fb1d2dfec8c8ab1dac2254343d7cd"
+checksum = "44aa821e2e285e6a8a262f964794313c35abea3716eda7af2e0588cae4ff7751"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -3843,9 +3845,9 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e894e952e2819545e9351f7427779f82538e51553dfaca3294301ff308086497"
+checksum = "3b5264ce262d3a0a9983785d9f944cbda35dc51550715be674309e7d6112fc80"
 dependencies = [
  "miden-processor",
  "miden-protocol",
@@ -3857,9 +3859,9 @@ dependencies = [
 
 [[package]]
 name = "miden-tx-batch-prover"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e7aac0d511aa412138ea7dfa4a6d8c76340c6028fa91313727b7ad3614711b"
+checksum = "62cc436bd810b9712a52183a0dd52a65006238ea7177470056e7edab50ab9deb"
 dependencies = [
  "miden-protocol",
  "miden-tx",
@@ -4979,7 +4981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -5000,7 +5002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5426,7 +5428,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6076,7 +6078,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7156,7 +7158,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/bin/integration-tests/src/asm/PASS_THROUGH.masm
+++ b/bin/integration-tests/src/asm/PASS_THROUGH.masm
@@ -18,7 +18,8 @@ const ERR_PASS_THROUGH_WRONG_NUMBER_OF_STORAGE_ITEMS="wrong number of storage it
 #! - ASSET_VALUE
 #! - RECIPIENT
 #! - [note_type, tag]
-begin
+@note_script
+pub proc main
     # drop note arguments
     dropw
 

--- a/bin/integration-tests/src/asm/custom_p2id.masm
+++ b/bin/integration-tests/src/asm/custom_p2id.masm
@@ -13,7 +13,8 @@ use miden::protocol::active_note
 use miden::standards::wallets::basic->basic_wallet
 use miden::core::mem
 
-begin
+@note_script
+pub proc main
     # push data from the advice map into the advice stack
     adv.push_mapval
     # => [NOTE_ARG]

--- a/bin/integration-tests/src/tests/custom_transaction.rs
+++ b/bin/integration-tests/src/tests/custom_transaction.rs
@@ -281,7 +281,8 @@ pub async fn test_onchain_notes_sync_with_tag(client_config: ClientConfig) -> Re
 
     // Create the custom note
     let note_script = "
-            begin
+            @note_script
+            pub proc main
                 push.1 push.1
                 assert_eq
             end

--- a/bin/integration-tests/src/tests/network_fpi.rs
+++ b/bin/integration-tests/src/tests/network_fpi.rs
@@ -96,7 +96,8 @@ pub async fn test_network_fpi(client_config: ClientConfig) -> Result<()> {
         use external_contract::counter_contract
         use miden::core::sys
 
-        begin
+        @note_script
+        pub proc main
             # push the hash of the `get_fpi_map_item` account procedure
             push.{proc_root}
 

--- a/bin/integration-tests/src/tests/network_transaction.rs
+++ b/bin/integration-tests/src/tests/network_transaction.rs
@@ -89,6 +89,14 @@ const INCR_SCRIPT_CODE: &str = "
     end
 ";
 
+const INCR_NOTE_SCRIPT_CODE: &str = "
+    use external_contract::counter_contract
+    @note_script
+    pub proc main
+        call.counter_contract::increment_count
+    end
+";
+
 /// Deploys a counter contract as a network account
 pub(crate) async fn deploy_counter_contract(
     client: &mut TestClient,
@@ -309,7 +317,13 @@ fn get_network_note<T: Rng>(
     source_manager: Arc<dyn SourceManagerSync>,
     rng: &mut T,
 ) -> Result<Note> {
-    get_network_note_with_script(sender, network_account, INCR_SCRIPT_CODE, source_manager, rng)
+    get_network_note_with_script(
+        sender,
+        network_account,
+        INCR_NOTE_SCRIPT_CODE,
+        source_manager,
+        rng,
+    )
 }
 
 pub(crate) fn get_network_note_with_script<T: Rng>(

--- a/bin/miden-cli/tests/cli.rs
+++ b/bin/miden-cli/tests/cli.rs
@@ -711,7 +711,8 @@ async fn debug_mode_outputs_logs() -> Result<()> {
 
     // Create the custom note with a script that will print the stack state
     let note_script = "
-            begin
+            @note_script
+            pub proc main
                 debug.stack
                 assert_eq
             end

--- a/crates/rust-client/src/note/mod.rs
+++ b/crates/rust-client/src/note/mod.rs
@@ -46,7 +46,7 @@
 //! }
 //!
 //! // Compile the note script
-//! let script_src = "begin push.9 push.12 add end";
+//! let script_src = "@note_script\npub proc main\n    push.9 push.12 add\nend";
 //! let note_script = client.code_builder().compile_note_script(script_src)?;
 //! println!("Compiled note script successfully.");
 //!

--- a/crates/rust-client/src/sync/state_sync.rs
+++ b/crates/rust-client/src/sync/state_sync.rs
@@ -1795,7 +1795,9 @@ mod tests {
         // Create a public output note. It won't be in the mock chain (simulating erasure).
         let sender_id: AccountId = ACCOUNT_ID_SENDER.try_into().unwrap();
         let metadata = NoteMetadata::new(sender_id, NoteType::Public);
-        let script = CodeBuilder::new().compile_note_script("begin nop end").unwrap();
+        let script = CodeBuilder::new()
+            .compile_note_script("@note_script\npub proc main\n    nop\nend")
+            .unwrap();
         let recipient = NoteRecipient::new(
             Word::from([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]),
             script,

--- a/crates/testing/miden-client-tests/src/tests.rs
+++ b/crates/testing/miden-client-tests/src/tests.rs
@@ -2783,7 +2783,8 @@ async fn consume_note_with_custom_script() {
     client.sync_state().await.unwrap();
 
     let custom_note_script = "
-        begin
+        @note_script
+        pub proc main
             nop
         end
     ";

--- a/crates/web-client/test/compile_and_contract.test.ts
+++ b/crates/web-client/test/compile_and_contract.test.ts
@@ -252,7 +252,8 @@ test.describe("compile.txScript()", () => {
 // on runtime note-script semantics.
 const RECEIVE_NOTE_SCRIPT = `
   use miden::core::sys
-  begin
+  @note_script
+  pub proc main
     exec.sys::truncate_stack
   end
 `;
@@ -283,7 +284,8 @@ test.describe("compile.noteScript()", () => {
           code: `
             use external_contract::counter_contract
             use miden::core::sys
-            begin
+            @note_script
+            pub proc main
               call.counter_contract::increment_count
               exec.sys::truncate_stack
             end
@@ -313,7 +315,8 @@ test.describe("compile.noteScript()", () => {
           code: `
             use external_contract::counter_contract
             use miden::core::sys
-            begin
+            @note_script
+            pub proc main
               call.counter_contract::increment_count
               exec.sys::truncate_stack
             end
@@ -331,7 +334,8 @@ test.describe("compile.noteScript()", () => {
           code: `
             use external_contract::counter_contract
             use miden::core::sys
-            begin
+            @note_script
+            pub proc main
               call.counter_contract::increment_count
               exec.sys::truncate_stack
             end
@@ -369,7 +373,8 @@ test.describe("compile.noteScript()", () => {
           code: `
             use external_contract::counter_contract
             use miden::core::sys
-            begin
+            @note_script
+            pub proc main
               call.counter_contract::increment_count
               exec.sys::truncate_stack
             end

--- a/crates/web-client/test/new_transactions.test.ts
+++ b/crates/web-client/test/new_transactions.test.ts
@@ -367,7 +367,8 @@ export const customTransaction = async (
             use miden::protocol::active_note
             use miden::standards::wallets::basic->basic_wallet
             use miden::core::mem
-            begin
+            @note_script
+            pub proc main
                 # push data from the advice map into the advice stack
                 adv.push_mapval
                 # => [NOTE_ARG]
@@ -1177,6 +1178,13 @@ export const counterAccountComponent = async (
             call.counter_contract::increment_count
         end
       `;
+    const noteScriptCode = `
+        use external_contract::counter_contract
+        @note_script
+        pub proc main
+            call.counter_contract::increment_count
+        end
+      `;
     const client = window.client;
 
     // Create counter account
@@ -1230,7 +1238,7 @@ export const counterAccountComponent = async (
     );
 
     // Create transaction with network note
-    let compiledNoteScript = await builder.compileNoteScript(scriptCode);
+    let compiledNoteScript = await builder.compileNoteScript(noteScriptCode);
 
     let noteStorage = new window.NoteStorage(
       new window.MidenArrays.FeltArray([])

--- a/crates/web-client/test/transactions.test.ts
+++ b/crates/web-client/test/transactions.test.ts
@@ -341,7 +341,7 @@ export const compileTxScript = async (
     );
 
     let builder = client.createCodeBuilder();
-    const compiledScript = builder.compileNoteScript(_script);
+    const compiledScript = builder.compileTxScript(_script);
 
     return {
       scriptRoot: compiledScript.root().toHex(),
@@ -369,7 +369,7 @@ test.describe("compile_tx_script tests", () => {
     const script = "fakeScript";
 
     await expect(compileTxScript(page, script)).rejects.toThrow(
-      /failed to compile note script:/
+      /failed to compile transaction script:/
     );
   });
 });

--- a/packages/react-sdk/src/__tests__/hooks/useCompile.test.tsx
+++ b/packages/react-sdk/src/__tests__/hooks/useCompile.test.tsx
@@ -114,7 +114,7 @@ describe("useCompile", () => {
       const { result } = renderHook(() => useCompile());
 
       await expect(
-        result.current.noteScript({ code: "begin end" })
+        result.current.noteScript({ code: "@note_script\npub proc main\nend" })
       ).rejects.toThrow("Miden client is not ready");
     });
   });
@@ -190,7 +190,9 @@ describe("useCompile", () => {
       const { result } = renderHook(() => useCompile());
 
       await act(async () => {
-        await result.current.noteScript({ code: "begin end" });
+        await result.current.noteScript({
+          code: "@note_script\npub proc main\nend",
+        });
         await result.current.txScript({ code: "begin end" });
       });
 


### PR DESCRIPTION
- Bumps miden-protocol and friends to 0.14.5
`0.14.5` changed `CodeBuilder::compile_note_script` to call `assemble_library` instead of `assemble_program`, so note scripts now must be library modules with a single procedure annotated `@note_script`.  `begin..end` programs are rejected with library modules cannot contain begin..end blocks.