### PR TITLE
Extract shared execution result printing helper

### DIFF
--- a/bin/miden-cli/src/commands/call.rs
+++ b/bin/miden-cli/src/commands/call.rs
@@ -6,9 +6,8 @@ use clap::Parser;
 use miden_client::assembly::CodeBuilder;
 use miden_client::keystore::Keystore;
 use miden_client::transaction::{AdviceInputs, TransactionRequestBuilder, TransactionScript};
-use miden_client::vm::Package;
+use miden_client::vm::{Package, PackageExport};
 use miden_client::{Client, Deserializable, Felt, Word};
-use miden_client::vm::PackageExport;
 
 use crate::errors::CliError;
 use crate::utils::{parse_account_id, print_executed_program_stack, print_executed_transaction};

--- a/bin/miden-cli/src/commands/call.rs
+++ b/bin/miden-cli/src/commands/call.rs
@@ -8,9 +8,10 @@ use miden_client::keystore::Keystore;
 use miden_client::transaction::{AdviceInputs, TransactionRequestBuilder, TransactionScript};
 use miden_client::vm::Package;
 use miden_client::{Client, Deserializable, Felt, Word};
+use miden_client::vm::PackageExport;
 
 use crate::errors::CliError;
-use crate::utils::{parse_account_id, print_executed_transaction};
+use crate::utils::{parse_account_id, print_executed_program_stack, print_executed_transaction};
 
 // CALL COMMAND
 // ================================================================================================
@@ -94,7 +95,7 @@ impl CallCmd {
             .execute_program(account_id, read_tx_script, AdviceInputs::default(), BTreeMap::new())
             .await?;
 
-        print_output_stack(&output_stack, result_count);
+        print_executed_program_stack(&output_stack, result_count);
 
         // 2) Transaction execution to get state delta.
         let delta_tx_script = generate_tx_script(linked_builder, &digest, &args, Some(0))?;
@@ -111,7 +112,7 @@ impl CallCmd {
                 print_executed_transaction(tx_result.executed_transaction())?;
             },
             Err(e) => {
-                println!("\n(Could not compute state delta: {e:?})");
+                println!("\n(Could not compute state delta: {e})");
             },
         }
 
@@ -181,8 +182,6 @@ fn print_manifest_signature(package: &Package, procedure_name: &str) -> Procedur
     const UNKNOWN: ProcedureSignature =
         ProcedureSignature { param_count: None, result_count: None };
 
-    use miden_client::vm::PackageExport;
-
     let kebab_name = procedure_name.replace('_', "-");
     let quoted_kebab = format!("\"{kebab_name}\"");
     let quoted_name = format!("\"{procedure_name}\"");
@@ -232,24 +231,6 @@ fn print_manifest_signature(package: &Package, procedure_name: &str) -> Procedur
     }
     println!();
     UNKNOWN
-}
-
-fn print_output_stack(stack: &[Felt; 16], expected_results: Option<usize>) {
-    let count = match expected_results {
-        Some(n) => n,
-        None => stack.iter().rposition(|v| v.as_canonical_u64() != 0).map_or(0, |pos| pos + 1),
-    };
-
-    if count == 0 {
-        println!("\nResult: 0");
-    } else if count == 1 {
-        println!("\nResult: {}", stack[0]);
-    } else {
-        println!("\nResult ({count} values):");
-        for (i, val) in stack.iter().enumerate().take(count) {
-            println!("  [{i}]: {val}");
-        }
-    }
 }
 
 /// Builds a transaction script that pushes `args`, calls the procedure at `digest`, and optionally

--- a/bin/miden-cli/src/commands/exec.rs
+++ b/bin/miden-cli/src/commands/exec.rs
@@ -8,7 +8,11 @@ use miden_client::{Client, Felt, Word};
 use serde::{Deserialize, Deserializer, Serialize, de};
 
 use crate::errors::CliError;
-use crate::utils::get_input_acc_id_by_prefix_or_default;
+use crate::utils::{
+    get_input_acc_id_by_prefix_or_default,
+    print_executed_program_stack,
+    print_executed_program_stack_hex_words,
+};
 
 // EXEC COMMAND
 // ================================================================================================
@@ -94,40 +98,14 @@ impl ExecCmd {
         match result {
             Ok(output_stack) => {
                 println!("Program executed successfully");
-                println!("Output stack:");
-                self.print_stack(output_stack);
+                if self.hex_words {
+                    print_executed_program_stack_hex_words(&output_stack);
+                } else {
+                    print_executed_program_stack(&output_stack, None);
+                }
                 Ok(())
             },
             Err(err) => Err(CliError::Exec(err.into(), "error executing the program".to_string())),
-        }
-    }
-
-    /// Print the output stack in a human-readable format
-    fn print_stack(&self, stack: [Felt; 16]) {
-        if self.hex_words {
-            for i in 0..4 {
-                let word_idx = i * 4;
-                let word_idx_end = word_idx + 3;
-
-                if word_idx == 12 {
-                    print!("└── {word_idx:2} - {word_idx_end:2}: ");
-                } else {
-                    print!("├── {word_idx:2} - {word_idx_end:2}: ");
-                }
-
-                let word: [Felt; 4] =
-                    stack[word_idx..=word_idx_end].try_into().expect("Length should be 4");
-
-                println!("{:?} ({})", word, Word::from(word).to_hex());
-            }
-        } else {
-            for (i, value) in stack.iter().enumerate() {
-                if i == 15 {
-                    println!("└── {i:2}: {value}");
-                } else {
-                    println!("├── {i:2}: {value}");
-                }
-            }
         }
     }
 }

--- a/bin/miden-cli/src/utils.rs
+++ b/bin/miden-cli/src/utils.rs
@@ -2,7 +2,7 @@ use miden_client::account::AccountId;
 use miden_client::address::{Address, AddressId};
 use miden_client::asset::{FungibleAsset, NonFungibleDeltaAction};
 use miden_client::transaction::{ExecutedTransaction, InputNote};
-use miden_client::{Client, Word};
+use miden_client::{Client, Felt, Word};
 
 use super::{CLIENT_CONFIG_FILE_NAME, create_dynamic_table, get_account_with_id_prefix};
 use crate::commands::account::DEFAULT_ACCOUNT_ID_KEY;
@@ -196,4 +196,40 @@ pub fn print_executed_transaction(executed_tx: &ExecutedTransaction) -> Result<(
     println!("Nonce incremented by: {}.", delta.nonce_delta());
 
     Ok(())
+}
+
+/// Prints the output stack from `execute_program`.
+///
+/// If `expected_results` is `Some(n)`, prints the top `n` values. If `None`, prints up to the
+/// last non-zero value so trailing zero-padding is hidden.
+pub fn print_executed_program_stack(stack: &[Felt; 16], expected_results: Option<usize>) {
+    let count = match expected_results {
+        Some(n) => n,
+        None => stack.iter().rposition(|v| v.as_canonical_u64() != 0).map_or(0, |pos| pos + 1),
+    };
+
+    if count == 0 {
+        println!("\nResult: 0");
+    } else if count == 1 {
+        println!("\nResult: {}", stack[0]);
+    } else {
+        println!("\nResult ({count} values):");
+        for (i, val) in stack.iter().enumerate().take(count) {
+            println!("  [{i}]: {val}");
+        }
+    }
+}
+
+/// Prints the output stack as four 4-felt words with their hex encoding.
+pub fn print_executed_program_stack_hex_words(stack: &[Felt; 16]) {
+    println!("Output stack:");
+    for word_idx in (0..16).step_by(4) {
+        let word_idx_end = word_idx + 3;
+        let prefix = if word_idx == 12 { "└──" } else { "├──" };
+        let word = [stack[word_idx], stack[word_idx + 1], stack[word_idx + 2], stack[word_idx + 3]];
+        println!(
+            "{prefix} {word_idx:2} - {word_idx_end:2}: {word:?} ({})",
+            Word::from(word).to_hex()
+        );
+    }
 }

--- a/bin/miden-cli/src/utils.rs
+++ b/bin/miden-cli/src/utils.rs
@@ -2,7 +2,7 @@ use miden_client::account::AccountId;
 use miden_client::address::{Address, AddressId};
 use miden_client::asset::{FungibleAsset, NonFungibleDeltaAction};
 use miden_client::transaction::{ExecutedTransaction, InputNote};
-use miden_client::{Client, Felt, Word};
+use miden_client::{Client, Felt, WORD_SIZE, Word};
 
 use super::{CLIENT_CONFIG_FILE_NAME, create_dynamic_table, get_account_with_id_prefix};
 use crate::commands::account::DEFAULT_ACCOUNT_ID_KEY;
@@ -208,24 +208,30 @@ pub fn print_executed_program_stack(stack: &[Felt; 16], expected_results: Option
         None => stack.iter().rposition(|v| v.as_canonical_u64() != 0).map_or(0, |pos| pos + 1),
     };
 
-    if count == 0 {
-        println!("\nResult: 0");
-    } else if count == 1 {
-        println!("\nResult: {}", stack[0]);
-    } else {
-        println!("\nResult ({count} values):");
-        for (i, val) in stack.iter().enumerate().take(count) {
-            println!("  [{i}]: {val}");
-        }
+    match count {
+        0 => println!("\nResult: 0"),
+        1 => println!("\nResult: {}", stack[0]),
+        _ => {
+            println!("\nResult ({count} values):");
+            for (i, val) in stack.iter().enumerate().take(count) {
+                println!("  [{i}]: {val}");
+            }
+        },
     }
 }
 
 /// Prints the output stack as four 4-felt words with their hex encoding.
 pub fn print_executed_program_stack_hex_words(stack: &[Felt; 16]) {
+    let stack_depth = stack.len();
+    let last_word_start = stack_depth - WORD_SIZE;
     println!("Output stack:");
-    for word_idx in (0..16).step_by(4) {
-        let word_idx_end = word_idx + 3;
-        let prefix = if word_idx == 12 { "└──" } else { "├──" };
+    for word_idx in (0..stack_depth).step_by(WORD_SIZE) {
+        let word_idx_end = word_idx + WORD_SIZE - 1;
+        let prefix = if word_idx == last_word_start {
+            "└──"
+        } else {
+            "├──"
+        };
         let word = [stack[word_idx], stack[word_idx + 1], stack[word_idx + 2], stack[word_idx + 3]];
         println!(
             "{prefix} {word_idx:2} - {word_idx_end:2}: {word:?} ({})",

--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -303,6 +303,7 @@ pub use miden_protocol::{
     MIN_TX_EXECUTION_CYCLES,
     ONE,
     PrettyPrint,
+    WORD_SIZE,
     Word,
     ZERO,
 };


### PR DESCRIPTION
Extract shared `print_executed_program_stack` into `utils.rs` so `call` and `exec` now reuse them instead of duplicating output formatting cc @igamigo 

Closes [#2096](https://github.com/0xMiden/miden-client/issues/2096)