### PR TITLE
fix: ensure binary correction

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install Rust toolchain
         run: rustup update --no-self-update
       - name: Add Rust Cache
-        uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: rust-release
           prefix-key: ${{ env.RUST_CACHE_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,3 +44,27 @@ jobs:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: make - build
         run: make build
+
+  install:
+    name: Install binaries
+    runs-on: warp-ubuntu-latest-x64-8x
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Cleanup large tools for build space
+        uses: ./.github/actions/cleanup-runner
+      - name: Install Rust toolchain
+        run: rustup update --no-self-update
+      - name: Add Rust Cache
+        uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
+        with:
+          shared-key: rust-release
+          prefix-key: ${{ env.RUST_CACHE_KEY }}
+          save-if: false
+      - name: make - install
+        run: make install
+      - name: make - install-bench
+        run: make install-bench
+      - name: make - install-tests
+        run: make install-tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,12 @@ jobs:
         run: make build
 
   install:
-    name: Install binaries
-    runs-on: warp-ubuntu-latest-x64-8x
+    name: Install ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [install, install-bench, install-tests]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -62,9 +66,5 @@ jobs:
           shared-key: rust-release
           prefix-key: ${{ env.RUST_CACHE_KEY }}
           save-if: false
-      - name: make - install
-        run: make install
-      - name: make - install-bench
-        run: make install-bench
-      - name: make - install-tests
-        run: make install-tests
+      - name: make - ${{ matrix.target }}
+        run: make ${{ matrix.target }}

--- a/bin/miden-cli/Cargo.toml
+++ b/bin/miden-cli/Cargo.toml
@@ -33,7 +33,7 @@ thiserror          = { workspace = true }
 tokio              = { workspace = true }
 toml               = { version = "0.9" }
 tracing            = { workspace = true }
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { default-features = true, workspace = true }
 
 [build-dependencies]
 miden-client = { features = ["std"], workspace = true }


### PR DESCRIPTION
[A dependency was badly imported on a past PR](https://github.com/0xMiden/miden-client/pull/2114/changes#diff-a69efd28a8988c548db00bea369044febd573203cf2a7b69bd275d4c77403e03R36), making `make install` fail.

This PR adds a CI check for all binary targets (and fixes the import issue).