### PR TITLE
chore: fix lint with new nightly version

### DIFF
--- a/bin/miden-cli/tests/cli.rs
+++ b/bin/miden-cli/tests/cli.rs
@@ -566,11 +566,11 @@ async fn cli_export_import_account() -> Result<()> {
     for stored_pk_commitment in faucet_pks {
         let matching_secret_key = cli_keystore.get_key_sync(stored_pk_commitment).unwrap();
         assert!(matching_secret_key.is_some());
-        assert!(matching_secret_key.unwrap().public_key().to_commitment() == stored_pk_commitment);
+        assert_eq!(matching_secret_key.unwrap().public_key().to_commitment(), stored_pk_commitment);
 
         let public_key = cli_keystore.get_public_key(stored_pk_commitment).await;
         assert!(public_key.is_some());
-        assert!(public_key.unwrap().to_commitment() == stored_pk_commitment);
+        assert_eq!(public_key.unwrap().to_commitment(), stored_pk_commitment);
     }
 
     let wallet_pks = cli_keystore
@@ -580,11 +580,11 @@ async fn cli_export_import_account() -> Result<()> {
     for stored_pk_commitment in wallet_pks {
         let matching_secret_key = cli_keystore.get_key_sync(stored_pk_commitment).unwrap();
         assert!(matching_secret_key.is_some());
-        assert!(matching_secret_key.unwrap().public_key().to_commitment() == stored_pk_commitment);
+        assert_eq!(matching_secret_key.unwrap().public_key().to_commitment(), stored_pk_commitment);
 
         let public_key = cli_keystore.get_public_key(stored_pk_commitment).await;
         assert!(public_key.is_some());
-        assert!(public_key.unwrap().to_commitment() == stored_pk_commitment);
+        assert_eq!(public_key.unwrap().to_commitment(), stored_pk_commitment);
     }
 
     Ok(())

--- a/crates/testing/miden-client-tests/src/tests.rs
+++ b/crates/testing/miden-client-tests/src/tests.rs
@@ -2316,7 +2316,7 @@ async fn missing_recipient_digest() {
         .unwrap_err();
 
     if let ClientError::MissingOutputRecipients(digests) = error {
-        assert!(digests == vec![dummy_recipient_digest]);
+        assert_eq!(digests, vec![dummy_recipient_digest]);
     }
 }
 

--- a/crates/testing/miden-client-tests/src/tests/transaction.rs
+++ b/crates/testing/miden-client-tests/src/tests/transaction.rs
@@ -88,7 +88,7 @@ async fn transaction_creates_two_notes() {
     // Validate that the request is expected to create two assets in the first note
     let expected_notes = tx_request.expected_output_own_notes();
     assert!(!expected_notes.is_empty());
-    assert!(expected_notes[0].assets().num_assets() == 2);
+    assert_eq!(expected_notes[0].assets().num_assets(), 2);
 
     // Let the client process state changes (mock chain)
     client.sync_state().await.unwrap();


### PR DESCRIPTION
The new nightly release just broke our lint job of the CI. This PR moves all `assert!`s that were matching equality to use `assert_eq!`.