### PR TITLE
backport: feat(rust-client): inject caller-supplied gRPC request headers (#2101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.14.7 (2026-06-05)
+
+### Enhancements
+
+* [FEATURE][rust] Added `GrpcClient::with_bearer_auth(token)` to attach an `authorization: Bearer <token>` header to every outbound gRPC call, for use behind authenticating gateways. Tokens are validated at connection time and preserved across `set_genesis_commitment` updates ([#2101](https://github.com/0xMiden/miden-client/pull/2101)).
+
 ## 0.14.6 (2026-05-05)
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2916,7 +2916,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2954,7 +2954,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-bench"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2971,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-cli"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2998,7 +2998,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-integration-tests"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3019,7 +3019,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-sqlite-store"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3037,7 +3037,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-unit-tests"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "miden-client",
  "miden-client-sqlite-store",
@@ -3999,7 +3999,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "node-builder"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "anyhow",
  "miden-node-block-producer",
@@ -6056,7 +6056,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "testing-remote-prover"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ edition      = "2024"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/miden-client"
 rust-version = "1.93"
-version      = "0.14.6"
+version      = "0.14.7"
 
 [profile.dev]
 codegen-units = 16

--- a/crates/rust-client/src/rpc/tonic_client/api_client.rs
+++ b/crates/rust-client/src/rpc/tonic_client/api_client.rs
@@ -28,42 +28,55 @@ pub(crate) mod api_client_wrapper {
     pub struct ApiClient {
         pub(crate) client: InnerClient,
         wasm_client: WasmClient,
+        bearer_token: Option<String>,
     }
 
     impl ApiClient {
         /// Connects to the Miden node API using the provided URL and genesis commitment.
         ///
-        /// The client is configured with an interceptor that sets all requisite request metadata.
+        /// When `bearer_token` is `Some`, an `authorization: Bearer <token>` header is
+        /// injected into every outbound request alongside the standard `accept` header.
         // Kept async for API parity with the native client; in WASM this is synchronous.
         #[allow(clippy::unused_async)]
         pub async fn new_client(
             endpoint: String,
             _timeout_ms: u64,
             genesis_commitment: Option<Word>,
+            bearer_token: Option<String>,
         ) -> Result<ApiClient, RpcError> {
             let wasm_client = WasmClient::new(endpoint);
-            let interceptor = accept_header_interceptor(genesis_commitment);
+            let interceptor =
+                accept_header_interceptor(genesis_commitment, bearer_token.as_deref())?;
             let client = ProtoClient::with_interceptor(wasm_client.clone(), interceptor);
-            Ok(ApiClient { client, wasm_client })
+            Ok(ApiClient { client, wasm_client, bearer_token })
         }
 
         /// Connects to the Miden node API without injecting an Accept header.
+        ///
+        /// `bearer_token`, if set, is still forwarded as `authorization: Bearer <token>`.
         // Kept async for API parity with the native client; in WASM this is synchronous.
         #[allow(clippy::unused_async)]
         pub async fn new_client_without_accept_header(
             endpoint: String,
             _timeout_ms: u64,
+            bearer_token: Option<String>,
         ) -> Result<ApiClient, RpcError> {
             let wasm_client = WasmClient::new(endpoint);
-            let interceptor = MetadataInterceptor::default();
+            let interceptor =
+                MetadataInterceptor::default().with_bearer_token(bearer_token.as_deref())?;
             let client = ProtoClient::with_interceptor(wasm_client.clone(), interceptor);
-            Ok(ApiClient { client, wasm_client })
+            Ok(ApiClient { client, wasm_client, bearer_token })
         }
 
         /// Returns a new `ApiClient` with an updated genesis commitment.
-        /// This creates a new client that shares the same underlying channel.
+        /// This creates a new client that shares the same underlying channel. Any
+        /// `bearer_token` passed to the constructor is preserved.
         pub fn set_genesis_commitment(&mut self, genesis_commitment: Word) -> &mut Self {
-            let interceptor = accept_header_interceptor(Some(genesis_commitment));
+            // The bearer token was validated at construction time; re-applying the same
+            // value here cannot fail.
+            let interceptor =
+                accept_header_interceptor(Some(genesis_commitment), self.bearer_token.as_deref())
+                    .expect("bearer token already validated at construction time");
             self.client = ProtoClient::with_interceptor(self.wasm_client.clone(), interceptor);
             self
         }
@@ -92,17 +105,25 @@ pub(crate) mod api_client_wrapper {
     pub struct ApiClient {
         pub(crate) client: InnerClient,
         channel: Channel,
+        bearer_token: Option<String>,
     }
 
     impl ApiClient {
         /// Connects to the Miden node API using the provided URL, timeout and genesis commitment.
         ///
-        /// The client is configured with an interceptor that sets all requisite request metadata.
+        /// When `bearer_token` is `Some`, an `authorization: Bearer <token>` header is
+        /// injected into every outbound request alongside the standard `accept` header.
         pub async fn new_client(
             endpoint: String,
             timeout_ms: u64,
             genesis_commitment: Option<Word>,
+            bearer_token: Option<String>,
         ) -> Result<ApiClient, RpcError> {
+            // Build the interceptor first so an invalid bearer token fails fast,
+            // before we attempt the network connection.
+            let interceptor =
+                accept_header_interceptor(genesis_commitment, bearer_token.as_deref())?;
+
             // Setup connection channel.
             let endpoint = tonic::transport::Endpoint::try_from(endpoint)
                 .map_err(|err| RpcError::ConnectionError(Box::new(err)))?
@@ -113,20 +134,24 @@ pub(crate) mod api_client_wrapper {
                 .connect()
                 .await
                 .map_err(|err| RpcError::ConnectionError(Box::new(err)))?;
-
-            // Set up the accept metadata interceptor.
-            let interceptor = accept_header_interceptor(genesis_commitment);
 
             // Return the connected client.
             let client = ProtoClient::with_interceptor(channel.clone(), interceptor);
-            Ok(ApiClient { client, channel })
+            Ok(ApiClient { client, channel, bearer_token })
         }
 
         /// Connects to the Miden node API without injecting an Accept header.
+        ///
+        /// `bearer_token`, if set, is still forwarded as `authorization: Bearer <token>`.
         pub async fn new_client_without_accept_header(
             endpoint: String,
             timeout_ms: u64,
+            bearer_token: Option<String>,
         ) -> Result<ApiClient, RpcError> {
+            // Fail fast on an invalid bearer token, before opening the channel.
+            let interceptor =
+                MetadataInterceptor::default().with_bearer_token(bearer_token.as_deref())?;
+
             // Setup connection channel.
             let endpoint = tonic::transport::Endpoint::try_from(endpoint)
                 .map_err(|err| RpcError::ConnectionError(Box::new(err)))?
@@ -138,15 +163,19 @@ pub(crate) mod api_client_wrapper {
                 .await
                 .map_err(|err| RpcError::ConnectionError(Box::new(err)))?;
 
-            let interceptor = MetadataInterceptor::default();
             let client = ProtoClient::with_interceptor(channel.clone(), interceptor);
-            Ok(ApiClient { client, channel })
+            Ok(ApiClient { client, channel, bearer_token })
         }
 
         /// Returns a new `ApiClient` with an updated genesis commitment.
-        /// This creates a new client that shares the same underlying channel.
+        /// This creates a new client that shares the same underlying channel. Any
+        /// `bearer_token` passed to the constructor is preserved.
         pub fn set_genesis_commitment(&mut self, genesis_commitment: Word) -> &mut Self {
-            let interceptor = accept_header_interceptor(Some(genesis_commitment));
+            // The bearer token was validated at construction time; re-applying the same
+            // value here cannot fail.
+            let interceptor =
+                accept_header_interceptor(Some(genesis_commitment), self.bearer_token.as_deref())
+                    .expect("bearer token already validated at construction time");
             self.client = ProtoClient::with_interceptor(self.channel.clone(), interceptor);
             self
         }
@@ -176,7 +205,7 @@ pub struct MetadataInterceptor {
 }
 
 impl MetadataInterceptor {
-    /// Adds or overwrites metadata to the interceptor.
+    /// Adds or overwrites metadata on the interceptor.
     pub fn with_metadata(
         mut self,
         key: &'static str,
@@ -184,6 +213,22 @@ impl MetadataInterceptor {
     ) -> Result<Self, InvalidMetadataValue> {
         self.metadata.insert(key, AsciiMetadataValue::try_from(value)?);
         Ok(self)
+    }
+
+    /// Adds or overwrites the `authorization: Bearer <token>` header on the interceptor.
+    /// A `None` token is a no-op.
+    ///
+    /// Returns [`RpcError::ConnectionError`] if the token is not a valid ASCII metadata
+    /// value, mirroring the behaviour of other transport-setup failures on the client.
+    pub(super) fn with_bearer_token(
+        self,
+        bearer_token: Option<&str>,
+    ) -> Result<Self, crate::rpc::RpcError> {
+        let Some(token) = bearer_token else {
+            return Ok(self);
+        };
+        self.with_metadata("authorization", alloc::format!("Bearer {token}"))
+            .map_err(|err| crate::rpc::RpcError::ConnectionError(alloc::boxed::Box::new(err)))
     }
 }
 
@@ -198,9 +243,14 @@ impl Interceptor for MetadataInterceptor {
 }
 
 /// Returns the HTTP header [`MetadataInterceptor`] that is expected by Miden RPC.
+///
 /// The interceptor sets the `accept` header to the Miden API version and optionally includes the
-/// genesis commitment.
-fn accept_header_interceptor(genesis_digest: Option<Word>) -> MetadataInterceptor {
+/// genesis commitment. When `bearer_token` is `Some`, an `authorization: Bearer <token>` header
+/// is also attached.
+fn accept_header_interceptor(
+    genesis_digest: Option<Word>,
+    bearer_token: Option<&str>,
+) -> Result<MetadataInterceptor, crate::rpc::RpcError> {
     let version = env!("CARGO_PKG_VERSION");
     let mut accept_value = format!("application/vnd.miden; version={version}");
     if let Some(commitment) = genesis_digest {
@@ -211,4 +261,58 @@ fn accept_header_interceptor(genesis_digest: Option<Word>) -> MetadataIntercepto
     MetadataInterceptor::default()
         .with_metadata("accept", accept_value)
         .expect("valid key/value metadata for interceptor")
+        .with_bearer_token(bearer_token)
+}
+
+#[cfg(test)]
+mod tests {
+    use tonic::Request;
+    use tonic::service::Interceptor;
+
+    use super::{MetadataInterceptor, accept_header_interceptor};
+
+    #[test]
+    fn interceptor_injects_bearer_token_onto_request() {
+        // Build the same interceptor that the native/WASM clients would use, with a caller
+        // bearer token in addition to the standard `accept`.
+        let mut interceptor =
+            accept_header_interceptor(None, Some("test-token")).expect("build interceptor");
+
+        // Run it against a bare request to inspect what actually ends up on the wire.
+        let request = interceptor.call(Request::new(())).expect("interceptor call succeeds");
+        let metadata = request.metadata();
+
+        let auth = metadata
+            .get("authorization")
+            .expect("authorization header must be present on outbound request");
+        assert_eq!(auth.to_str().unwrap(), "Bearer test-token");
+
+        // The standard accept header is still set alongside the caller's header.
+        assert!(metadata.get("accept").is_some(), "accept header must still be present");
+    }
+
+    #[test]
+    fn interceptor_omits_authorization_when_no_token_configured() {
+        let mut interceptor = accept_header_interceptor(None, None).expect("build interceptor");
+
+        let request = interceptor.call(Request::new(())).expect("interceptor call succeeds");
+        let metadata = request.metadata();
+
+        assert!(
+            metadata.get("authorization").is_none(),
+            "authorization must not leak when no token is configured",
+        );
+        assert!(metadata.get("accept").is_some(), "accept header must still be present");
+    }
+
+    #[test]
+    fn with_bearer_token_rejects_invalid_ascii_values() {
+        // Control characters are not valid ASCII metadata values; the builder must reject
+        // them rather than silently dropping the header.
+        match MetadataInterceptor::default().with_bearer_token(Some("bad\nvalue")) {
+            Err(crate::rpc::RpcError::ConnectionError(_)) => {},
+            Err(other) => panic!("expected ConnectionError, got {other:?}"),
+            Ok(_) => panic!("expected invalid metadata value to error"),
+        }
+    }
 }

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -152,6 +152,10 @@ pub struct GrpcClient {
     max_retries: u32,
     /// Fallback retry interval in milliseconds when no `retry-after` header is present.
     retry_interval_ms: u64,
+    /// Optional bearer token injected as `authorization: Bearer <token>` on every outbound
+    /// gRPC call, alongside the standard `accept` header. Used when talking to an
+    /// authenticating gateway in front of the node.
+    bearer_token: Option<String>,
 }
 
 impl GrpcClient {
@@ -166,6 +170,7 @@ impl GrpcClient {
             limits: RwLock::new(None),
             max_retries: retry::DEFAULT_MAX_RETRIES,
             retry_interval_ms: retry::DEFAULT_RETRY_INTERVAL_MS,
+            bearer_token: None,
         }
     }
 
@@ -185,6 +190,36 @@ impl GrpcClient {
         self
     }
 
+    /// Attaches a `authorization: Bearer <token>` header to every outbound gRPC call made
+    /// by this client, alongside the standard `accept` header.
+    ///
+    /// Intended for connecting to a Miden node through an authenticating gateway
+    /// (e.g. `miden-testnet.eu-central-8.gateway.fm`) that rate-limits unauthenticated
+    /// traffic. Without an auth mechanism on the client side, callers would have no way
+    /// to supply the token the gateway requires.
+    ///
+    /// Calling this method twice overwrites the earlier token.
+    ///
+    /// Validation of the token against
+    /// [`AsciiMetadataValue`](tonic::metadata::AsciiMetadataValue) is deferred to
+    /// connection time (printable ASCII plus tab only — `HeaderValue::from_str` semantics):
+    /// invalid tokens surface as
+    /// [`RpcError::ConnectionError`](crate::rpc::RpcError::ConnectionError) on the first
+    /// request, so CR/LF header-injection attempts are rejected.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use miden_client::rpc::{Endpoint, GrpcClient};
+    /// let endpoint = Endpoint::new("https".into(), "node.example".into(), Some(443));
+    /// let client = GrpcClient::new(&endpoint, 10_000).with_bearer_auth("<api-key>".into());
+    /// ```
+    #[must_use]
+    pub fn with_bearer_auth(mut self, token: String) -> Self {
+        self.bearer_token = Some(token);
+        self
+    }
+
     /// Takes care of establishing the RPC connection if not connected yet. It ensures that the
     /// `rpc_api` field is initialized and returns a write guard to it.
     async fn ensure_connected(&self) -> Result<ApiClient, RpcError> {
@@ -199,9 +234,13 @@ impl GrpcClient {
     /// genesis commitment.
     async fn connect(&self) -> Result<(), RpcError> {
         let genesis_commitment = *self.genesis_commitment.read();
-        let new_client =
-            ApiClient::new_client(self.endpoint.clone(), self.timeout_ms, genesis_commitment)
-                .await?;
+        let new_client = ApiClient::new_client(
+            self.endpoint.clone(),
+            self.timeout_ms,
+            genesis_commitment,
+            self.bearer_token.clone(),
+        )
+        .await?;
         let mut client = self.client.write();
         client.replace(new_client);
 
@@ -252,11 +291,16 @@ impl GrpcClient {
     /// Fetches RPC status without injecting an Accept header.
     ///
     /// This instantiates a separate API client without the Accept interceptor, so it does not
-    /// reuse the primary gRPC client.
+    /// reuse the primary gRPC client. Any caller-supplied
+    /// [`with_bearer_auth`](Self::with_bearer_auth) token is still forwarded so gateway
+    /// authentication keeps working.
     pub async fn get_status_unversioned(&self) -> Result<RpcStatusInfo, RpcError> {
-        let mut rpc_api =
-            ApiClient::new_client_without_accept_header(self.endpoint.clone(), self.timeout_ms)
-                .await?;
+        let mut rpc_api = ApiClient::new_client_without_accept_header(
+            self.endpoint.clone(),
+            self.timeout_ms,
+            self.bearer_token.clone(),
+        )
+        .await?;
         rpc_api
             .status(())
             .await
@@ -1124,6 +1168,7 @@ mod tests {
     use miden_protocol::block::BlockNumber;
 
     use super::{BlockPagination, GrpcClient, PaginationResult};
+    use crate::alloc::string::ToString;
     use crate::rpc::{Endpoint, NodeRpcClient, RpcError};
 
     fn assert_send_sync<T: Send + Sync>() {}
@@ -1245,5 +1290,76 @@ mod tests {
 
         assert_eq!(client.genesis_commitment.read().unwrap(), commitment);
         assert!(client.client.read().as_ref().is_some());
+    }
+
+    #[test]
+    fn with_bearer_auth_stores_token() {
+        let endpoint = &Endpoint::devnet();
+        let client = GrpcClient::new(endpoint, 10000).with_bearer_auth("token-one".to_string());
+
+        assert_eq!(client.bearer_token.as_deref(), Some("token-one"));
+    }
+
+    #[test]
+    fn with_bearer_auth_overwrites_on_repeat_call() {
+        let endpoint = &Endpoint::devnet();
+        let client = GrpcClient::new(endpoint, 10000)
+            .with_bearer_auth("token-one".to_string())
+            .with_bearer_auth("token-two".to_string());
+
+        // Second call replaces the first.
+        assert_eq!(client.bearer_token.as_deref(), Some("token-two"));
+    }
+
+    #[tokio::test]
+    async fn with_bearer_auth_surfaces_invalid_ascii_value_at_connect_time() {
+        // Tokens containing control characters are rejected by `AsciiMetadataValue`. The
+        // fluent builder defers the check to connection time, so the error must surface as
+        // a `ConnectionError` on the first request — preventing CR/LF header-injection.
+        let endpoint = &Endpoint::devnet();
+        let client = GrpcClient::new(endpoint, 10000).with_bearer_auth("bad\nvalue".to_string());
+
+        let err = client.connect().await.expect_err("expected invalid token to fail connect");
+        assert!(
+            matches!(err, RpcError::ConnectionError(_)),
+            "expected ConnectionError, got {err:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn with_bearer_auth_is_preserved_across_set_genesis_commitment() {
+        let endpoint = &Endpoint::devnet();
+        let client = GrpcClient::new(endpoint, 10000).with_bearer_auth("token".to_string());
+        client.connect().await.unwrap();
+
+        client.set_genesis_commitment(Word::default()).await.unwrap();
+
+        // Rebuilding the interceptor after a genesis update must not drop the caller token.
+        assert_eq!(client.bearer_token.as_deref(), Some("token"));
+        assert!(client.client.read().as_ref().is_some());
+    }
+
+    /// Real-network smoke test: hitting the public testnet with a caller-supplied bearer
+    /// token must return a real [`RpcStatusInfo`], proving the header is a valid
+    /// [`AsciiMetadataValue`](tonic::metadata::AsciiMetadataValue) on the wire and that an
+    /// unauthenticated node ignores it cleanly.
+    ///
+    /// `#[ignore]`d by default so offline CI doesn't fail; run with
+    /// `cargo test -- --ignored with_bearer_auth_does_not_break_real_rpc_against_testnet`
+    /// when validating against the real network. The interceptor-level test
+    /// (`api_client::tests::interceptor_injects_bearer_token_onto_request`)
+    /// already proves the header reaches outbound request metadata without needing the
+    /// network.
+    #[tokio::test]
+    #[ignore = "requires network access to public testnet"]
+    async fn with_bearer_auth_does_not_break_real_rpc_against_testnet() {
+        let endpoint = &Endpoint::testnet();
+        let client = GrpcClient::new(endpoint, 10_000).with_bearer_auth("smoke-test".to_string());
+
+        let status = client
+            .get_status_unversioned()
+            .await
+            .expect("testnet status with caller auth header must succeed");
+        assert!(!status.version.is_empty(), "status must include a server version");
     }
 }


### PR DESCRIPTION
Ports the changes from #2101 :

* feat(rust-client): add GrpcClient::with_bearer_auth for gateway auth

Enables miden-client callers to authenticate to a gateway sitting in front of the Miden node (e.g. miden-testnet.eu-central-8.gateway.fm) that rate-limits unauthenticated traffic. Without this, consumers like miden-agglayer have no way to attach the api-key the gateway requires and get throttled aggressively on legitimate traffic.

```rust
let client = GrpcClient::new(&endpoint, timeout_ms)
    .with_bearer_auth(api_key.to_string());
```

The token is formatted as `Bearer <token>` and sent as the `authorization` metadata entry on every outbound gRPC call, alongside the standard `accept` header. Calling twice overwrites the earlier token.

- New `ExtraHeader` type threaded through `ApiClient::new_client` / `new_client_without_accept_header`, stored on `ApiClient`, and re-applied when `set_genesis_commitment` rebuilds the interceptor (so a commitment update doesn't drop the auth token).
- Token validation (AsciiMetadataValue / HeaderValue::from_str — printable ASCII plus tab only) is done up-front when building the interceptor, so invalid tokens fail fast with `RpcError::ConnectionError` before opening the channel. CR/LF header-injection attempts are rejected.
- The `accept` metadata key cannot be clobbered: only `authorization` is exposed via the public API, and the interceptor always seeds `accept` before extras. The internal `MetadataInterceptor::with_metadata` stays crate-private.

Both the native (`tonic::transport::Channel`) and wasm32 (`tonic_web_wasm_client`) `ApiClient` wrappers get the same `extra_headers` field and same constructor signature.

- `with_bearer_auth` storage + overwrite-on-repeat.
- Invalid-ASCII token surfaces as `ConnectionError` at connect time.
- Token preserved across `set_genesis_commitment`.
- Wire-level: `MetadataInterceptor::call()` on a `Request<()>` — asserts `authorization` lands in outbound request metadata and the standard `accept` header is still present alongside it.
- Live-network smoke (`#[ignore]`d by default): hits `rpc.testnet.miden.io:443` with `with_bearer_auth("smoke-test")` and asserts a real `RpcStatusInfo` comes back — proves the header is a valid AsciiMetadataValue on the wire. Run with `cargo test -- --ignored with_bearer_auth_does_not_break_real`.

CHANGELOG entry added under 0.15.0 Enhancements.

Scope intentionally narrow — only `authorization: Bearer` is exposed. No generic `with_header(key, value)` / X-API-Key path (could be added later if a gateway requires it, but YAGNI today — `Bearer` covers the one concrete use case in front of us).

Addresses upstream review feedback on #2101 from @SantiagoPittella.

* chore(rust-client): apply nightly rustfmt to api_client.rs

The CI Format check rejected a >100-col `let interceptor = ...?;` line in the WASM `new_client_without_accept_header` block. Run nightly `cargo fmt --all` to wrap it the same way the native counterpart is already wrapped.

Also add the PR backlink to the bearer-auth CHANGELOG entry to match the format used by neighbouring 0.15.0 enhancements.