### PR TITLE
fix(cli): show external account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 * [FEATURE][rust] Added `GrpcClient::with_bearer_auth(token)` to attach an `authorization: Bearer <token>` header to every outbound gRPC call, for use behind authenticating gateways. Tokens are validated at connection time and preserved across `set_genesis_commitment` updates ([#2101](https://github.com/0xMiden/miden-client/pull/2101)).
 * Made new-account construction use merged storage schema commitment (`build_with_schema_commitment`), re-exported `AccountBuilderSchemaCommitmentExt`, added WASM `buildWithoutSchemaCommitment()`, and fixed contract `accounts.create()` to require explicit `components` ([#1996](https://github.com/0xMiden/miden-client/pull/1996)).
-* Fixed the faucet token symbol display when showing account details ([#1985](https://github.com/0xMiden/miden-client/pull/1985)).
+* Fixed the faucet token symbol display when showing account details ([#1985](https://github.com/0xMiden/miden-client/pull/1985) ([#2158](https://github.com/0xMiden/miden-client/pull/2158))).
 * [FEATURE][rust,cli,web] Added `get_network_note_status` to `NodeRpcClient` trait for querying the processing status of notes submitted to the network (pending, nullifier-inflight, discarded, nullifier-committed), along with attempt count and error details. Exposed as `miden-client network-note-status <note_id>` CLI command and `RpcClient.getNetworkNoteStatus()` in the web client. ([#1981](https://github.com/0xMiden/miden-client/pull/1981))
 * Remove MMR peaks from the blocks table and store them alongside the sync height in a new `blockchain_checkpoint` table ([#2100](https://github.com/0xMiden/miden-client/pull/2100)).
 * Added `miden-cli call` command for invoking account procedures directly from the CLI ([#1943](https://github.com/0xMiden/miden-client/pull/1943)).

--- a/bin/miden-cli/src/commands/account.rs
+++ b/bin/miden-cli/src/commands/account.rs
@@ -136,7 +136,7 @@ async fn list_accounts<AUTH>(client: Client<AUTH>) -> Result<(), CliError> {
 // SHOW ACCOUNT
 // ================================================================================================
 
-pub async fn show_account<AUTH>(
+async fn show_account<AUTH>(
     client: Client<AUTH>,
     account_id: AccountId,
     rpc_config: &RpcConfig,

--- a/bin/miden-cli/src/commands/account.rs
+++ b/bin/miden-cli/src/commands/account.rs
@@ -151,9 +151,7 @@ pub async fn show_account<AUTH>(
             GrpcClient::new(&rpc_config.endpoint.clone().into(), rpc_config.timeout_ms);
 
         let fetched_account = rpc_client.get_account_details(account_id).await.map_err(|err| {
-            CliError::Input(
-                format!("Unable to fetch account {account_id} from the network: {err}",),
-            )
+            CliError::Input(format!("Unable to fetch account {account_id} from the network: {err}"))
         })?;
 
         let account: Option<Account> = fetched_account.into();

--- a/bin/miden-cli/src/commands/account.rs
+++ b/bin/miden-cli/src/commands/account.rs
@@ -289,7 +289,12 @@ fn print_summary_table(account: &Account, network_id: NetworkId, token_symbol: O
     println!("{table}\n");
 }
 
-/// Reads the token metadata from a fungible faucet account's storage via its [`AccountReader`].
+/// Reads the token metadata via the [`AccountReader`]. Accesses the client's store to fetch the
+/// storage item.
+///
+/// # Errors
+/// Returns an error if the account is not tracked by the client, thus the storage item is not
+/// found.
 async fn get_token_metadata(
     reader: &AccountReader,
     account_id: AccountId,
@@ -309,6 +314,9 @@ async fn get_token_metadata(
 
 /// Reads the token metadata directly from an [`Account`]'s storage, without going through the
 /// client's store.
+///
+/// # Errors
+/// Returns an error if the storage item is not present in the Account's storage.
 fn get_token_metadata_from_account(account: &Account) -> Result<TokenMetadata, CliError> {
     let account_id = account.id();
     let word = account.storage().get_item(TokenMetadata::metadata_slot()).map_err(|err| {

--- a/bin/miden-cli/src/commands/account.rs
+++ b/bin/miden-cli/src/commands/account.rs
@@ -5,17 +5,18 @@ use miden_client::account::{
     Account,
     AccountId,
     AccountInterfaceExt,
+    AccountReader,
     AccountType,
     StorageSlotContent,
 };
-use miden_client::address::{Address, AddressInterface, RoutingParameters};
+use miden_client::address::{Address, AddressInterface, NetworkId, RoutingParameters};
 use miden_client::asset::Asset;
 use miden_client::rpc::{GrpcClient, NodeRpcClient};
 use miden_client::transaction::{AccountComponentInterface, AccountInterface};
 use miden_client::utils::base_units_to_tokens;
-use miden_client::{Client, PrettyPrint, ZERO};
+use miden_client::{Client, PrettyPrint, Word, ZERO};
 
-use crate::config::CliConfig;
+use crate::config::{CliConfig, RpcConfig};
 use crate::errors::CliError;
 use crate::utils::parse_account_id;
 use crate::{client_binary_name, create_dynamic_table};
@@ -58,7 +59,7 @@ impl AccountCmd {
                 ..
             } => {
                 let account_id = parse_account_id(&client, id).await?;
-                show_account(client, account_id, &cli_config, self.with_code).await?;
+                show_account(client, account_id, &cli_config.rpc, self.with_code).await?;
             },
             AccountCmd {
                 list: false,
@@ -111,11 +112,17 @@ async fn list_accounts<AUTH>(client: Client<AUTH>) -> Result<(), CliError> {
     let mut table =
         create_dynamic_table(&["Account ID", "Type", "Storage Mode", "Nonce", "Status"]);
     for (acc, _acc_seed) in &accounts {
-        let status = client.account_reader(acc.id()).status().await?.to_string();
+        let reader = client.account_reader(acc.id());
+        let status = reader.status().await?.to_string();
+        let token_symbol = if acc.id().account_type() == AccountType::FungibleFaucet {
+            Some(get_token_metadata(&reader, acc.id()).await?.symbol().to_string())
+        } else {
+            None
+        };
 
         table.add_row(vec![
             acc.id().to_hex(),
-            account_type_display_name(&client, acc.id()).await?,
+            account_type_display_name(acc.id(), token_symbol.as_deref()),
             acc.id().storage_mode().to_string(),
             acc.nonce().as_canonical_u64().to_string(),
             status,
@@ -132,7 +139,7 @@ async fn list_accounts<AUTH>(client: Client<AUTH>) -> Result<(), CliError> {
 pub async fn show_account<AUTH>(
     client: Client<AUTH>,
     account_id: AccountId,
-    cli_config: &CliConfig,
+    rpc_config: &RpcConfig,
     with_code: bool,
 ) -> Result<(), CliError> {
     let account = if let Some(account) = client.get_account(account_id).await? {
@@ -141,12 +148,12 @@ pub async fn show_account<AUTH>(
         println!("Account {account_id} is not tracked by the client. Fetching from the network...");
 
         let rpc_client =
-            GrpcClient::new(&cli_config.rpc.endpoint.clone().into(), cli_config.rpc.timeout_ms);
+            GrpcClient::new(&rpc_config.endpoint.clone().into(), rpc_config.timeout_ms);
 
-        let fetched_account = rpc_client.get_account_details(account_id).await.map_err(|_| {
-            CliError::Input(format!(
-                "Unable to fetch account {account_id} from the network. It may not exist.",
-            ))
+        let fetched_account = rpc_client.get_account_details(account_id).await.map_err(|err| {
+            CliError::Input(
+                format!("Unable to fetch account {account_id} from the network: {err}",),
+            )
         })?;
 
         let account: Option<Account> = fetched_account.into();
@@ -156,7 +163,13 @@ pub async fn show_account<AUTH>(
         )))?
     };
 
-    print_summary_table(&account, &client, cli_config).await?;
+    let network_id = rpc_config.endpoint.0.to_network_id();
+    let token_symbol = if account.id().account_type() == AccountType::FungibleFaucet {
+        Some(get_token_metadata_from_account(&account)?.symbol().to_string())
+    } else {
+        None
+    };
+    print_summary_table(&account, network_id, token_symbol.as_deref());
 
     // Vault Table
     {
@@ -167,9 +180,18 @@ pub async fn show_account<AUTH>(
         for asset in assets {
             let (asset_type, faucet, amount) = match asset {
                 Asset::Fungible(fungible_asset) => {
-                    let metadata = get_token_metadata(&client, fungible_asset.faucet_id()).await?;
-                    let faucet = metadata.symbol().to_string();
-                    let amount = base_units_to_tokens(fungible_asset.amount(), metadata.decimals());
+                    let faucet_id = fungible_asset.faucet_id();
+                    let reader = client.account_reader(faucet_id);
+                    let (faucet, amount) = match get_token_metadata(&reader, faucet_id).await {
+                        Ok(metadata) => (
+                            metadata.symbol().to_string(),
+                            base_units_to_tokens(fungible_asset.amount(), metadata.decimals()),
+                        ),
+                        Err(_) => (
+                            faucet_id.prefix().to_hex(),
+                            format!("{} (raw)", fungible_asset.amount()),
+                        ),
+                    };
                     ("Fungible Asset", faucet, amount)
                 },
                 Asset::NonFungible(non_fungible_asset) => {
@@ -232,20 +254,13 @@ pub async fn show_account<AUTH>(
 // ================================================================================================
 
 /// Prints a summary table with account information.
-async fn print_summary_table<AUTH>(
-    account: &Account,
-    client: &Client<AUTH>,
-    cli_config: &CliConfig,
-) -> Result<(), CliError> {
+fn print_summary_table(account: &Account, network_id: NetworkId, token_symbol: Option<&str>) {
     let mut table = create_dynamic_table(&["Account Information"]);
     table
         .load_preset(presets::UTF8_HORIZONTAL_ONLY)
         .set_content_arrangement(ContentArrangement::DynamicFullWidth);
 
-    table.add_row(vec![
-        Cell::new("Address"),
-        Cell::new(account_bech_32(account.id(), client, cli_config).await?),
-    ]);
+    table.add_row(vec![Cell::new("Address"), Cell::new(account_bech_32(account, network_id))]);
     table.add_row(vec![Cell::new("Account ID (hex)"), Cell::new(account.id().to_string())]);
     table.add_row(vec![
         Cell::new("Account Commitment"),
@@ -253,7 +268,7 @@ async fn print_summary_table<AUTH>(
     ]);
     table.add_row(vec![
         Cell::new("Type"),
-        Cell::new(account_type_display_name(client, account.id()).await?),
+        Cell::new(account_type_display_name(account.id(), token_symbol)),
     ]);
     table.add_row(vec![
         Cell::new("Storage mode"),
@@ -274,24 +289,41 @@ async fn print_summary_table<AUTH>(
     ]);
 
     println!("{table}\n");
-    Ok(())
 }
 
-/// Reads the token metadata from a fungible faucet account's storage metadata slot.
-async fn get_token_metadata<AUTH>(
-    client: &Client<AUTH>,
+/// Reads the token metadata from a fungible faucet account's storage via its [`AccountReader`].
+async fn get_token_metadata(
+    reader: &AccountReader,
     account_id: AccountId,
 ) -> Result<TokenMetadata, CliError> {
-    let word = client
-        .account_reader(account_id)
-        .get_storage_item(TokenMetadata::metadata_slot().clone())
-        .await
-        .map_err(|err| {
-            CliError::Faucet(
-                err.into(),
-                format!("Failed to read token metadata for faucet {account_id}"),
-            )
-        })?;
+    let word =
+        reader
+            .get_storage_item(TokenMetadata::metadata_slot().clone())
+            .await
+            .map_err(|err| {
+                CliError::Faucet(
+                    err.into(),
+                    format!("Failed to read token metadata for faucet {account_id}"),
+                )
+            })?;
+    parse_token_metadata(word, account_id)
+}
+
+/// Reads the token metadata directly from an [`Account`]'s storage, without going through the
+/// client's store.
+fn get_token_metadata_from_account(account: &Account) -> Result<TokenMetadata, CliError> {
+    let account_id = account.id();
+    let word = account.storage().get_item(TokenMetadata::metadata_slot()).map_err(|err| {
+        CliError::Faucet(
+            err.into(),
+            format!("Failed to read token metadata for faucet {account_id}"),
+        )
+    })?;
+    parse_token_metadata(word, account_id)
+}
+
+/// Parses a raw storage [`Word`] into [`TokenMetadata`], wrapping errors with faucet context.
+fn parse_token_metadata(word: Word, account_id: AccountId) -> Result<TokenMetadata, CliError> {
     TokenMetadata::try_from(word).map_err(|err| {
         CliError::Faucet(
             err.into(),
@@ -300,20 +332,18 @@ async fn get_token_metadata<AUTH>(
     })
 }
 
-/// Returns a display name for the account type.
-async fn account_type_display_name<AUTH>(
-    client: &Client<AUTH>,
-    account_id: AccountId,
-) -> Result<String, CliError> {
-    Ok(match account_id.account_type() {
+/// Returns a display name for the account type. For fungible faucets, the token symbol is
+/// appended when available.
+fn account_type_display_name(account_id: AccountId, token_symbol: Option<&str>) -> String {
+    match account_id.account_type() {
         AccountType::FungibleFaucet => {
-            let token_symbol = get_token_metadata(client, account_id).await?.symbol().to_string();
-            format!("Fungible faucet (token symbol: {token_symbol})")
+            let symbol = token_symbol.unwrap_or("Unknown");
+            format!("Fungible faucet (token symbol: {symbol})")
         },
         AccountType::NonFungibleFaucet => "Non-fungible faucet".to_string(),
         AccountType::RegularAccountImmutableCode => "Regular".to_string(),
         AccountType::RegularAccountUpdatableCode => "Regular (updatable)".to_string(),
-    })
+    }
 }
 
 /// Sets the provided account ID as the default account in the client's store, if not set already.
@@ -340,13 +370,9 @@ pub(crate) async fn set_default_account_if_unset<AUTH>(
     Ok(())
 }
 
-async fn account_bech_32<AUTH>(
-    account_id: AccountId,
-    client: &Client<AUTH>,
-    cli_config: &CliConfig,
-) -> Result<String, CliError> {
-    let account = client.try_get_account(account_id).await?;
-    let account_interface = AccountInterface::from_account(&account);
+fn account_bech_32(account: &Account, network_id: NetworkId) -> String {
+    let account_id = account.id();
+    let account_interface = AccountInterface::from_account(account);
 
     let mut address = Address::new(account_id);
     if account_interface
@@ -358,6 +384,5 @@ async fn account_bech_32<AUTH>(
             address.with_routing_parameters(RoutingParameters::new(AddressInterface::BasicWallet));
     }
 
-    let encoded = address.encode(cli_config.rpc.endpoint.0.to_network_id());
-    Ok(encoded)
+    address.encode(network_id)
 }

--- a/bin/miden-cli/src/commands/account.rs
+++ b/bin/miden-cli/src/commands/account.rs
@@ -185,10 +185,9 @@ async fn show_account<AUTH>(
                             metadata.symbol().to_string(),
                             base_units_to_tokens(fungible_asset.amount(), metadata.decimals()),
                         ),
-                        Err(_) => (
-                            faucet_id.prefix().to_hex(),
-                            format!("{} (raw)", fungible_asset.amount()),
-                        ),
+                        Err(_) => {
+                            (faucet_id.prefix().to_hex(), fungible_asset.amount().to_string())
+                        },
                     };
                     ("Fungible Asset", faucet, amount)
                 },

--- a/bin/miden-cli/tests/cli.rs
+++ b/bin/miden-cli/tests/cli.rs
@@ -357,6 +357,41 @@ async fn token_symbol_mapping() -> Result<()> {
     Ok(())
 }
 
+// ACCOUNT SHOW TESTS
+// ================================================================================================
+
+/// Runs `account show` against a public account that is NOT tracked by the local client. The
+/// account must be fetched from the node, its token metadata read from the fetched `Account`
+/// storage, and its bech32 address rendered without hitting the client's store.
+#[tokio::test]
+async fn show_untracked_public_account() -> Result<()> {
+    // First client: creates a public fungible faucet and commits it to the node via a mint.
+    let (_store_path_a, temp_dir_a, endpoint) = init_cli();
+    let fungible_faucet_account_id = new_faucet_cli(&temp_dir_a, AccountStorageMode::Public);
+
+    mint_cli(
+        &temp_dir_a,
+        &AccountId::try_from(ACCOUNT_ID_REGULAR).unwrap().to_hex(),
+        &fungible_faucet_account_id,
+    );
+    sync_until_committed_transaction(&temp_dir_a);
+
+    // Second client: fresh CLI on the same network, not tracking the faucet.
+    let store_path_b = create_test_store_path();
+    let temp_dir_b = init_cli_with_store_path(&store_path_b, &endpoint);
+
+    let mut show_cmd = cargo_bin_cmd!("miden-client");
+    show_cmd.args(["account", "--show", &fungible_faucet_account_id]);
+    show_cmd
+        .current_dir(&temp_dir_b)
+        .assert()
+        .success()
+        .stdout(contains("Fetching from the network"))
+        .stdout(contains("Fungible faucet (token symbol: BTC)"));
+
+    Ok(())
+}
+
 // IMPORT TESTS
 // ================================================================================================
 

--- a/bin/miden-cli/tests/cli.rs
+++ b/bin/miden-cli/tests/cli.rs
@@ -368,6 +368,7 @@ async fn show_untracked_public_account() -> Result<()> {
     // First client: creates a public fungible faucet and commits it to the node via a mint.
     let (_store_path_a, temp_dir_a, endpoint) = init_cli();
     let fungible_faucet_account_id = new_faucet_cli(&temp_dir_a, AccountStorageMode::Public);
+    sync_cli(&temp_dir_a);
 
     mint_cli(
         &temp_dir_a,


### PR DESCRIPTION
https://github.com/0xMiden/miden-client/pull/1985 introduced an error on the CLI `show` command when the account is not locally tracked.

This PR changes the CLI so when that the account details are accessed from the fetched account details storage, instead of accessing the client's store. This was causing the `show` command to error when the account is not stored on the client.

Example output for a non-tracked faucet account:
```bash
➜  miden-client account --show 0x001ecc653c5a5a203274024ac0b3ba
Account 0x001ecc653c5a5a203274024ac0b3ba is not tracked by the client. Fetching from the network...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Account Information
═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 Address                                                     mlcl1aqqpanr983d95gpjwspy4s9nhgg9l5ll
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Account ID (hex)                                            0x001ecc653c5a5a203274024ac0b3ba
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Account Commitment                                          0x7f2df1d4ba0d69ea5d5c7c1ef0f6e6d81932ad8571963f098eee0d427f4af9a6
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Type                                                        Fungible faucet (token symbol: TKN)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Storage mode                                                public
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Code Commitment                                             0x1ab545d2fdcc8caa18bcaea2674011b275ddf74657fcd646aadf297437cf7c53
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Vault Root                                                  0x06c51ffe24ba8da0b1f39a69ea0cbf630fb773a74e158d73c19d752ac1fb151f
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Storage Root                                                0x4a90c0e81d43088eb3a7c6369ec70d0075fd8d974521a87090316f4f04cb5a17
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Nonce                                                       1
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

And for a non-tracked account that holds assets:
```bash
➜  ~/Lambda/miden-client git:(tomasarrachea-fix-show-account) miden-client account --show 0x0a0a0a0a0a0a0a100a0a0a0a0a0a0a
Account 0x0a0a0a0a0a0a0a100a0a0a0a0a0a0a is not tracked by the client. Fetching from the network...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Account Information
═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 Address                                                     mlcl1aq9q5zs2pg9q5yq2pg9q5zs2pg0ythze_qr7qqq9wr6w
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Account ID (hex)                                            0x0a0a0a0a0a0a0a100a0a0a0a0a0a0a
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Account Commitment                                          0x9add9db1afc0abf5a5f2459b146bdf8200441b1649c6bc7a78581f62e075c62b
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Type                                                        Regular (updatable)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Storage mode                                                public
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Code Commitment                                             0x0bad1f4a00c7989a3b54f4fcbca767b9f724c7f251ed13a4c1785e2b1a0220bf
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Vault Root                                                  0x217c6a215d2f01a255ffdda0a07b9108d31cfa43163578d38ba48eec1225c294
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Storage Root                                                0x16bd1960b5dce3351d07bafc7152c4120e33fa6b25f5ce54fd08fa2360eda40e
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Nonce                                                       1
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Assets:
┌───────────────────────────────────────────────────────┬───────────────────────────────────────────────────────────┬───────────────────────────────────────────────┐
│ Asset Type                                            ┆ Faucet                                                    ┆ Amount                                        │
╞═══════════════════════════════════════════════════════╪═══════════════════════════════════════════════════════════╪═══════════════════════════════════════════════╡
│ Fungible Asset                                        ┆ 0xde7ac3cdd6bb0820                                        ┆ 75                                            │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
...
```