### PR TITLE
fix(note_update_tracker): replace panicking `expect` in `extend_nullifiers` with `unreachable!`

### DIFF
--- a/crates/rust-client/src/note/note_update_tracker.rs
+++ b/crates/rust-client/src/note/note_update_tracker.rs
@@ -1,7 +1,16 @@
-use alloc::collections::BTreeMap;
+use alloc::collections::{BTreeMap, BTreeSet};
 
-use miden_protocol::block::BlockHeader;
-use miden_protocol::note::{NoteId, Nullifier};
+use miden_protocol::account::AccountId;
+use miden_protocol::block::{BlockHeader, BlockNumber};
+use miden_protocol::note::{Note, NoteHeader, NoteId, NoteInclusionProof, Nullifier};
+use miden_standards::note::NetworkAccountTarget;
+use miden_tx::utils::serde::{
+    ByteReader,
+    ByteWriter,
+    Deserializable,
+    DeserializationError,
+    Serializable,
+};
 
 use crate::ClientError;
 use crate::rpc::RpcError;
@@ -16,17 +25,31 @@ use crate::transaction::{TransactionRecord, TransactionStatus};
 /// Represents the possible types of updates that can be applied to a note in a
 /// [`NoteUpdateTracker`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
 pub enum NoteUpdateType {
     /// Indicates that the note was already tracked but it was not updated.
-    None,
+    None = 0,
     /// Indicates that the note is new and should be inserted in the store.
-    Insert,
+    Insert = 1,
     /// Indicates that the note was already tracked and should be updated.
-    Update,
+    Update = 2,
+}
+
+impl TryFrom<u8> for NoteUpdateType {
+    type Error = u8;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(NoteUpdateType::None),
+            1 => Ok(NoteUpdateType::Insert),
+            2 => Ok(NoteUpdateType::Update),
+            other => Err(other),
+        }
+    }
 }
 
 /// Represents the possible states of an input note record in a [`NoteUpdateTracker`].
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct InputNoteUpdate {
     /// Input note being updated.
     note: InputNoteRecord,
@@ -91,7 +114,7 @@ impl InputNoteUpdate {
 }
 
 /// Represents the possible states of an output note record in a [`NoteUpdateTracker`].
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct OutputNoteUpdate {
     /// Output note being updated.
     note: OutputNoteRecord,
@@ -156,7 +179,7 @@ impl OutputNoteUpdate {
 /// This includes new notes that have been created and existing notes that have been updated. The
 /// tracker also lets state changes be applied to the contained notes, this allows for already
 /// updated notes to be further updated as new information is received.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct NoteUpdateTracker {
     /// A map of new and updated input note records to be upserted in the store.
     input_notes: BTreeMap<NoteId, InputNoteUpdate>,
@@ -170,6 +193,9 @@ pub struct NoteUpdateTracker {
     /// Nullifiers from the same account are in execution order; ordering across different
     /// accounts is not guaranteed.
     nullifier_order: BTreeMap<Nullifier, u32>,
+    /// Account IDs tracked by this client. Used to detect if the consumer of an erased note is
+    /// tracked.
+    tracked_accounts_ids: BTreeSet<AccountId>,
 }
 
 impl NoteUpdateTracker {
@@ -187,6 +213,13 @@ impl NoteUpdateTracker {
         }
 
         tracker
+    }
+
+    /// Sets the accounts tracked by this client.
+    #[must_use]
+    pub fn with_tracked_accounts(mut self, tracked_accounts_ids: BTreeSet<AccountId>) -> Self {
+        self.tracked_accounts_ids = tracked_accounts_ids;
+        self
     }
 
     /// Creates a [`NoteUpdateTracker`] for updates related to transactions.
@@ -272,7 +305,8 @@ impl NoteUpdateTracker {
     pub fn extend_nullifiers(&mut self, nullifiers: impl IntoIterator<Item = Nullifier>) {
         for nullifier in nullifiers {
             let next_pos =
-                u32::try_from(self.nullifier_order.len()).expect("nullifier count exceeds u32");
+                u32::try_from(self.nullifier_order.len())
+                .unwrap_or_else(|_| unreachable!("nullifier_order cannot grow to u32::MAX or more entries"));
             self.nullifier_order.entry(nullifier).or_insert(next_pos);
         }
     }
@@ -319,12 +353,119 @@ impl NoteUpdateTracker {
                 false
             };
 
-        if let Some(output_note_record) = self.get_output_note_by_id(*committed_note.note_id()) {
-            // The note belongs to our locally tracked set of output notes
-            output_note_record.inclusion_proof_received(inclusion_proof)?;
-        }
+        self.try_commit_output_note(*committed_note.note_id(), inclusion_proof)?;
 
         Ok(is_tracked_as_input_note)
+    }
+
+    /// Applies inclusion proofs from the transaction sync response to tracked output notes.
+    ///
+    /// This transitions output notes from `Expected` to `Committed` state using the
+    /// inclusion proofs returned by `SyncTransactions`.
+    pub(crate) fn apply_output_note_inclusion_proofs(
+        &mut self,
+        committed_notes: &[CommittedNote],
+    ) -> Result<(), ClientError> {
+        for committed_note in committed_notes {
+            self.try_commit_output_note(
+                *committed_note.note_id(),
+                committed_note.inclusion_proof().clone(),
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Marks an erased note as consumed.
+    ///
+    /// This handles notes that were erased due to same-batch note erasure: the note was
+    /// created and consumed within the same batch, so it never appeared in the block body.
+    /// The `block_num` is the block in which the creating transaction was committed.
+    pub(crate) fn mark_erased_note_as_consumed(
+        &mut self,
+        note_header: &NoteHeader,
+        block_num: BlockNumber,
+    ) -> Result<(), ClientError> {
+        let note_id = note_header.id();
+
+        if let Some(output_note) = self.get_output_note_by_id(note_id)
+            && !output_note.is_consumed()
+            && !output_note.is_committed()
+            && let Some(nullifier) = output_note.nullifier()
+        {
+            output_note.nullifier_received(nullifier, block_num)?;
+        }
+
+        // Extract the consumer from the `NetworkAccountTarget` attachment, only if the target
+        // is a network account and it is tracked by this client.
+        let consumer_network_account_id =
+            NetworkAccountTarget::try_from(note_header.metadata().attachment())
+                .ok()
+                .map(|t| t.target_id())
+                .filter(|id| self.tracked_accounts_ids.contains(id));
+
+        // Only create an input record when the consumer is a tracked account.
+        if let Some(consumer_id) = consumer_network_account_id {
+            self.try_insert_consumed_input_from_output(note_id, consumer_id, block_num, Some(0))?;
+        }
+
+        // Also mark the corresponding input note if tracked.
+        if let Some(input_note_update) = self.input_notes.get_mut(&note_id)
+            && !input_note_update.inner().is_consumed()
+        {
+            let nullifier = input_note_update.inner().nullifier();
+            input_note_update.inner_mut().consumed_externally(
+                nullifier,
+                block_num,
+                consumer_network_account_id,
+            )?;
+            input_note_update.inner_mut().set_consumed_tx_order(Some(0));
+        }
+
+        Ok(())
+    }
+
+    /// Builds a consumed input note record from a tracked output note and inserts it.
+    ///
+    /// Used when an output note is consumed externally and the client should also surface
+    /// it as a consumed input — for example, when the same client tracks both the sender
+    /// and the consumer of the note. No-op if the input is already tracked, the output is
+    /// not tracked, or the output cannot be converted to a [`Note`].
+    fn try_insert_consumed_input_from_output(
+        &mut self,
+        note_id: NoteId,
+        consumer: AccountId,
+        block_num: BlockNumber,
+        consumed_tx_order: Option<u32>,
+    ) -> Result<(), ClientError> {
+        if self.input_notes.contains_key(&note_id) {
+            return Ok(());
+        }
+        let Some(output_note) = self.output_notes.get(&note_id) else {
+            return Ok(());
+        };
+        let Ok(note) = Note::try_from(output_note.inner().clone()) else {
+            return Ok(());
+        };
+
+        let mut input_record = InputNoteRecord::from(note);
+        let nullifier = input_record.nullifier();
+        input_record.consumed_externally(nullifier, block_num, Some(consumer))?;
+        input_record.set_consumed_tx_order(consumed_tx_order);
+        self.insert_input_note(input_record, NoteUpdateType::Insert);
+        Ok(())
+    }
+
+    /// If the note is tracked as an output note, transitions it to `Committed` with the
+    /// given inclusion proof. No-op if the note is not tracked.
+    fn try_commit_output_note(
+        &mut self,
+        note_id: NoteId,
+        inclusion_proof: NoteInclusionProof,
+    ) -> Result<(), ClientError> {
+        if let Some(output_note) = self.get_output_note_by_id(note_id) {
+            output_note.inclusion_proof_received(inclusion_proof)?;
+        }
+        Ok(())
     }
 
     /// Applies the necessary state transitions to the [`NoteUpdateTracker`] when a note is
@@ -332,18 +473,26 @@ impl NoteUpdateTracker {
     ///
     /// For input note records two possible scenarios are considered:
     /// 1. The note was being processed by a local transaction that just got committed.
-    /// 2. The note was consumed by an external transaction. If a local transaction was processing
-    ///    the note and it didn't get committed, the transaction should be discarded.
+    /// 2. The note was consumed by a transaction not submitted by this client. This includes
+    ///    consumption by untracked accounts as well as consumption by tracked accounts whose
+    ///    transactions were submitted by other client instances. If a local transaction was
+    ///    processing the note and it didn't get committed, the transaction should be discarded.
+    ///
+    /// If the note is tracked as an output but not as an input (e.g. the client tracks both the
+    /// sender and the consumer), a new input record is created from the output details so the
+    /// consumption surfaces through `InputNoteReader`.
     pub(crate) fn apply_nullifiers_state_transitions<'a>(
         &mut self,
         nullifier_update: &NullifierUpdate,
         mut committed_transactions: impl Iterator<Item = &'a TransactionRecord>,
+        external_consumer_account: Option<AccountId>,
     ) -> Result<(), ClientError> {
-        let order = self.get_nullifier_order(nullifier_update.nullifier);
+        let nullifier = nullifier_update.nullifier;
+        let block_num = nullifier_update.block_num;
+        let order = self.get_nullifier_order(nullifier);
+        let input_present = self.input_notes_by_nullifier.contains_key(&nullifier);
 
-        if let Some(input_note_update) =
-            self.get_input_note_update_by_nullifier(nullifier_update.nullifier)
-        {
+        if let Some(input_note_update) = self.get_input_note_update_by_nullifier(nullifier) {
             if let Some(consumer_transaction) = committed_transactions
                 .find(|t| input_note_update.inner().consumer_transaction_id() == Some(&t.id))
             {
@@ -356,19 +505,26 @@ impl NoteUpdateTracker {
                         .transaction_committed(consumer_transaction.id, block_number)?;
                 }
             } else {
-                // The note was consumed by an external transaction
-                input_note_update
-                    .inner_mut()
-                    .consumed_externally(nullifier_update.nullifier, nullifier_update.block_num)?;
+                // The note was consumed by a transaction not submitted by this client.
+                // If the consuming account is tracked, external_consumer_account will be Some.
+                input_note_update.inner_mut().consumed_externally(
+                    nullifier,
+                    block_num,
+                    external_consumer_account,
+                )?;
             }
             input_note_update.inner_mut().set_consumed_tx_order(order);
         }
 
-        if let Some(output_note_record) =
-            self.get_output_note_by_nullifier(nullifier_update.nullifier)
+        if let Some(output_note_record) = self.get_output_note_by_nullifier(nullifier) {
+            output_note_record.nullifier_received(nullifier, block_num)?;
+        }
+
+        if !input_present
+            && let Some(consumer) = external_consumer_account
+            && let Some(note_id) = self.output_notes_by_nullifier.get(&nullifier).copied()
         {
-            output_note_record
-                .nullifier_received(nullifier_update.nullifier, nullifier_update.block_num)?;
+            self.try_insert_consumed_input_from_output(note_id, consumer, block_num, order)?;
         }
 
         Ok(())
@@ -438,5 +594,90 @@ impl NoteUpdateTracker {
             NoteUpdateType::Update => OutputNoteUpdate::new_update(note),
         };
         self.output_notes.insert(note_id, update);
+    }
+}
+
+// SERIALIZATION
+// ================================================================================================
+
+impl Serializable for NoteUpdateType {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write_u8(*self as u8);
+    }
+}
+
+impl Deserializable for NoteUpdateType {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        NoteUpdateType::try_from(source.read_u8()?).map_err(|val| {
+            DeserializationError::InvalidValue(format!("invalid note update type: {val}"))
+        })
+    }
+}
+
+impl Serializable for InputNoteUpdate {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.note.write_into(target);
+        self.update_type.write_into(target);
+    }
+}
+
+impl Deserializable for InputNoteUpdate {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let note = InputNoteRecord::read_from(source)?;
+        let update_type = NoteUpdateType::read_from(source)?;
+        Ok(Self { note, update_type })
+    }
+}
+
+impl Serializable for OutputNoteUpdate {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.note.write_into(target);
+        self.update_type.write_into(target);
+    }
+}
+
+impl Deserializable for OutputNoteUpdate {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let note = OutputNoteRecord::read_from(source)?;
+        let update_type = NoteUpdateType::read_from(source)?;
+        Ok(Self { note, update_type })
+    }
+}
+
+impl Serializable for NoteUpdateTracker {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        // `input_notes_by_nullifier` and `output_notes_by_nullifier` are lookup indices that can
+        // be reconstructed from `input_notes` and `output_notes`, so they are not serialized.
+        self.input_notes.write_into(target);
+        self.output_notes.write_into(target);
+        self.nullifier_order.write_into(target);
+    }
+}
+
+impl Deserializable for NoteUpdateTracker {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let input_notes = BTreeMap::<NoteId, InputNoteUpdate>::read_from(source)?;
+        let output_notes = BTreeMap::<NoteId, OutputNoteUpdate>::read_from(source)?;
+        let nullifier_order = BTreeMap::<Nullifier, u32>::read_from(source)?;
+
+        let input_notes_by_nullifier = input_notes
+            .iter()
+            .map(|(note_id, update)| (update.inner().nullifier(), *note_id))
+            .collect();
+        let output_notes_by_nullifier = output_notes
+            .iter()
+            .filter_map(|(note_id, update)| {
+                update.inner().nullifier().map(|nullifier| (nullifier, *note_id))
+            })
+            .collect();
+
+        Ok(Self {
+            input_notes,
+            output_notes,
+            input_notes_by_nullifier,
+            output_notes_by_nullifier,
+            nullifier_order,
+            tracked_accounts_ids: BTreeSet::new(),
+        })
     }
 }


### PR DESCRIPTION
## Summary

`extend_nullifiers` computes the next insertion position with:

```rust
let next_pos = u32::try_from(self.nullifier_order.len()).expect("nullifier count exceeds u32");
```

If `nullifier_order` ever reaches `u32::MAX` entries this panics, crashing
the sync loop. While 4 billion concurrent nullifiers cannot occur in a valid
sync session, the `.expect()` constitutes a live, unguarded panic path in
client sync code.

## Changes

Replace with `.unwrap_or_else(|_| unreachable!(...))` to document that the
bound cannot be exceeded in practice, eliminating the implicit panic risk.