### PR TITLE
feat(client): expose `concurrent` feature for no-std builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2916,7 +2916,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client"
-version = "0.14.7"
+version = "0.14.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2954,7 +2954,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-bench"
-version = "0.14.7"
+version = "0.14.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2971,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-cli"
-version = "0.14.7"
+version = "0.14.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2998,7 +2998,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-integration-tests"
-version = "0.14.7"
+version = "0.14.8"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3019,7 +3019,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-sqlite-store"
-version = "0.14.7"
+version = "0.14.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3037,7 +3037,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-unit-tests"
-version = "0.14.7"
+version = "0.14.8"
 dependencies = [
  "miden-client",
  "miden-client-sqlite-store",
@@ -3999,7 +3999,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "node-builder"
-version = "0.14.7"
+version = "0.14.8"
 dependencies = [
  "anyhow",
  "miden-node-block-producer",
@@ -6056,7 +6056,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "testing-remote-prover"
-version = "0.14.7"
+version = "0.14.8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ edition      = "2024"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/miden-client"
 rust-version = "1.93"
-version      = "0.14.7"
+version      = "0.14.8"
 
 [profile.dev]
 codegen-units = 16

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -25,12 +25,23 @@ crate-type = ["lib"]
 
 [features]
 # Rayon-parallel proving in miden-tx + miden-prover. Surfaced independently
-# of `std` so wasm32 consumers (the web-sdk's MT WASM bundle, the
-# miden-mobile-prover crate that ships in iOS/Android Capacitor plugins)
-# can opt in to parallel proving without also pulling in tokio/tempfile.
-# Native `std`-using consumers get this transitively through `std`; the
-# duplication is intentional so each consumer can pick the smallest
-# feature set they need.
+# of `miden-client`'s own `std` feature so wasm32 consumers (the web-sdk's
+# MT WASM bundle, the miden-mobile-prover crate that ships in iOS/Android
+# Capacitor plugins) can opt in to parallel proving without dragging in
+# the heavy `miden-client/std` deps — `dep:tokio`, `dep:tempfile`, and
+# `tonic`'s `transport`/`tls-*` features.
+#
+# Note: `miden-tx`'s own `concurrent` feature is defined upstream as
+# `["miden-prover/concurrent", "std"]`, so enabling `concurrent` here
+# does activate `std` on the protocol crates (miden-tx, miden-prover,
+# miden-protocol). That `std` is unavoidable for parallel proving and
+# is cheap on wasm32 — it doesn't reach the tokio/tempfile/transport
+# pieces gated above. The win this feature delivers is dropping those
+# `miden-client`-side deps; full no_std is not a goal of this feature.
+#
+# Native `std`-using consumers get `concurrent` transitively through
+# `std`; the duplication in the `std` feature list is intentional so
+# each consumer can pick the smallest feature set they need.
 concurrent = ["miden-tx/concurrent"]
 dap = ["dep:miden-debug"]
 default = ["dap", "std"]

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -24,15 +24,23 @@ ignored = ["getrandom", "prost-types", "tonic-prost"]
 crate-type = ["lib"]
 
 [features]
+# Rayon-parallel proving in miden-tx + miden-prover. Surfaced independently
+# of `std` so wasm32 consumers (the web-sdk's MT WASM bundle, the
+# miden-mobile-prover crate that ships in iOS/Android Capacitor plugins)
+# can opt in to parallel proving without also pulling in tokio/tempfile.
+# Native `std`-using consumers get this transitively through `std`; the
+# duplication is intentional so each consumer can pick the smallest
+# feature set they need.
+concurrent = ["miden-tx/concurrent"]
 dap = ["dep:miden-debug"]
 default = ["dap", "std"]
 std = [
+  "concurrent",
   "dep:tempfile",
   "dep:tokio",
   "miden-protocol/std",
   "miden-remote-prover-client/std",
   "miden-remote-prover-client/tx-prover",
-  "miden-tx/concurrent",
   "tonic/tls-native-roots",
   "tonic/tls-ring",
   "tonic/transport",


### PR DESCRIPTION
## Summary

Surface the rayon-parallel proving path (already enabled by `miden-tx`'s `concurrent` feature) as a top-level `miden-client` feature, independent of `std`.

## Motivation

Today the `std` feature on `miden-client` includes `miden-tx/concurrent`, so native consumers (`cargo build` defaults) get parallel proving transitively. But wasm32 consumers using `default-features = false` — notably the `@miden-sdk/miden-sdk` MT WASM bundle from [`0xMiden/web-sdk#134`](https://github.com/0xMiden/web-sdk/pull/134) and the new `miden-mobile-prover` native plugin for iOS/Android wallets — have no way to opt into `miden-tx/concurrent` without also pulling in `tokio` + `tempfile`.

Net effect today: the published MT WASM bundle ships with rayon parallelism only in `miden-crypto` (Merkle/hash). The prover-side parallelism in `miden-tx`/`miden-prover` is silently single-threaded. Anyone using `@miden-sdk/miden-sdk/mt/lazy` thinks they're getting MT and only gets a fraction of the win.

(See review thread on web-sdk PR #134: https://github.com/0xMiden/web-sdk/pull/134/files#r3196048839 — same issue, different angle.)

## Change

Add `concurrent = ["miden-tx/concurrent"]` as a separate feature, and remove the duplicated `miden-tx/concurrent` from `std`'s list (it now flows in via `std → concurrent → miden-tx/concurrent`). The duplication-removal is purely cosmetic; the std build is bit-for-bit identical before/after.

## Verification

```bash
cargo tree -p miden-client --no-default-features --features concurrent --target wasm32-unknown-unknown -f "{p} {f}"
```

Before: only `miden-crypto` shows `concurrent` (via web-sdk's direct dep).
After: `miden-tx v0.14.5 concurrent,std`, `miden-prover v0.22.1 concurrent,std`, and `miden-crypto v0.23.0 concurrent,serde,std` all show `concurrent`.

## Followup

A coordinated commit on web-sdk PR #134 will switch `mt-threads` from `miden-crypto/concurrent` to `miden-client/concurrent`, picking up everything in one go.

## Test plan
- [ ] `cargo check -p miden-client --no-default-features --features concurrent` passes (verified locally; takes ~45s clean)
- [ ] `cargo check -p miden-client` (default features) still passes (verified locally)
- [ ] CI green