### PR TITLE
fix(rpc): don't terminate sync_notes pagination on empty pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@
 * [FEATURE][web] Added `StorageView` JS wrapper over WASM `AccountStorage`. `account.storage()` now returns a `StorageView` that makes `getItem()` work intuitively for both Value and StorageMap slots. WASM primitives are unchanged; the raw `AccountStorage` is accessible via `.raw` ([#1955](https://github.com/0xMiden/miden-client/pull/1955)).
 * [FEATURE][web] Added `wordToBigInt()` utility export for losslessly converting a `Word`'s first felt to a `BigInt`. `StorageResult.toString()` is BigInt-backed, and `valueOf()` returns a JS number for values fitting in `Number.MAX_SAFE_INTEGER` and throws `RangeError` for larger u64 values — use `.toBigInt()` for exact access ([#1955](https://github.com/0xMiden/miden-client/pull/1955)).
 
+### Fixes
+
+* [FIX][rust] Fixed `sync_notes_with_details` pagination terminating early when a page contains no matching notes, causing intermittent note discovery failures. Notes committed in later blocks were permanently skipped because the sync height was updated to the chain tip. ([#2180](https://github.com/0xMiden/miden-client/pull/2180))
+
 ## 0.14.7 (2026-06-05)
 
 ### Enhancements

--- a/crates/rust-client/src/rpc/mod.rs
+++ b/crates/rust-client/src/rpc/mod.rs
@@ -230,7 +230,12 @@ pub trait NodeRpcClient: Send + Sync {
             let range_end = block_to.unwrap_or(chain_tip);
             // `range_end` is inclusive, so after advancing the cursor, equality means
             // the final block is still the next page to fetch.
-            let done = note_sync.blocks.is_empty() || cursor > range_end;
+            //
+            // Do NOT check `blocks.is_empty()` here: an empty page just means no
+            // matching notes in that page's block range. The note may exist in a
+            // later page. Early-terminating on empty pages causes intermittent note
+            // discovery failures (see #2175).
+            let done = cursor > range_end;
             all_blocks.extend(note_sync.blocks);
 
             if done {


### PR DESCRIPTION
## Summary

- Fix early termination in `sync_notes_with_details` pagination that caused intermittent note discovery failures
- When a page returned no matching notes, the loop stopped even if the cursor hadn't covered the full block range
- Notes committed in later blocks were permanently skipped, breaking dApps that rely on wallet adapter + local client sync

## Root Cause

In `crates/rust-client/src/rpc/mod.rs`, line 233:

```rust
// BEFORE (buggy):
let done = note_sync.blocks.is_empty() || cursor > range_end;

// AFTER (fixed):
let done = cursor > range_end;
```

The `blocks.is_empty()` check was an incorrect optimization. An empty page means no matching notes in that page's block range, but the note may exist in a later page. The cursor always advances via `note_sync.block_to + 1`, so removing the check doesn't risk infinite loops.

## Impact

This particularly affects dApps using the wallet adapter (MidenFi extension), where the wallet extension submits transactions and the local `WebClient` discovers the resulting notes via `syncState()`. The timing correlation between wallet submission and local sync makes it likely for notes to land just past a page boundary.

Observed behavior: ~50% of handshake flows in a battleship dApp failed because the setup note was never discovered by the local client, despite 10+ sync retries over 100+ seconds.

## Test plan

- [ ] Existing sync tests pass
- [ ] Manual test with battleship dApp: wallet adapter submits note, local client discovers it via sync on first attempt

Fixes #2175