### PR TITLE
fix: use inclusive range start for `sync_account_vault` and `sync_storage_maps`

### DIFF
--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -896,23 +896,22 @@ impl NodeRpcClient for GrpcClient {
         block_from: BlockNumber,
         block_to: Option<BlockNumber>,
     ) -> Result<Vec<NullifierUpdate>, RpcError> {
-        const MAX_ITERATIONS: u32 = 1000; // Safety limit to prevent infinite loops
-
         let limits = self.get_rpc_limits().await?;
         let mut all_nullifiers = BTreeSet::new();
 
         // If the prefixes are too many, we need to chunk them into smaller groups to avoid
         // violating the RPC limit.
-        'chunk_nullifiers: for chunk in prefixes.chunks(limits.nullifiers_limit as usize) {
-            let mut current_block_from = block_from.as_u32();
+        for chunk in prefixes.chunks(limits.nullifiers_limit as usize) {
+            let proto_prefixes: Vec<u32> = chunk.iter().map(|&x| u32::from(x)).collect();
+            let mut pagination = BlockPagination::new(block_from, block_to);
 
-            for _ in 0..MAX_ITERATIONS {
+            loop {
                 let request = proto::rpc::SyncNullifiersRequest {
-                    nullifiers: chunk.iter().map(|&x| u32::from(x)).collect(),
+                    nullifiers: proto_prefixes.clone(),
                     prefix_len: 16,
                     block_range: Some(BlockRange {
-                        block_from: current_block_from,
-                        block_to: block_to.map(|b| b.as_u32()),
+                        block_from: pagination.current_block_from().as_u32(),
+                        block_to: pagination.block_to().map(|b| b.as_u32()),
                     }),
                 };
 
@@ -921,10 +920,9 @@ impl NodeRpcClient for GrpcClient {
                         let request = request.clone();
                         Box::pin(async move { rpc_api.sync_nullifiers(request).await })
                     })
-                    .await?;
-                let response = response.into_inner();
+                    .await?
+                    .into_inner();
 
-                // Convert nullifiers for this batch
                 let batch_nullifiers = response
                     .nullifiers
                     .iter()
@@ -934,30 +932,15 @@ impl NodeRpcClient for GrpcClient {
 
                 all_nullifiers.extend(batch_nullifiers);
 
-                // Check if we need to fetch more pages
-                if let Some(page) = response.pagination_info {
-                    // Ensure we're making progress to avoid infinite loops
-                    if page.block_num < current_block_from {
-                        return Err(RpcError::PaginationError(
-                            "invalid pagination: block_num went backwards".to_string(),
-                        ));
-                    }
+                let page = response.pagination_info.ok_or(RpcError::ExpectedDataMissing(
+                    "SyncNullifiersResponse.pagination_info".to_owned(),
+                ))?;
 
-                    // Calculate target block as minimum between block_to and chain_tip
-                    let target_block =
-                        block_to.map_or(page.chain_tip, |b| b.as_u32().min(page.chain_tip));
-
-                    if page.block_num >= target_block {
-                        // No pagination info or we've reached/passed the target so we're done
-                        continue 'chunk_nullifiers;
-                    }
-                    current_block_from = page.block_num + 1;
+                match pagination.advance(page.block_num.into(), page.chain_tip.into())? {
+                    PaginationResult::Continue => {},
+                    PaginationResult::Done { .. } => break,
                 }
             }
-            // If we exit the loop, we've hit the iteration limit
-            return Err(RpcError::PaginationError(
-                "too many pagination iterations, possible infinite loop".to_string(),
-            ));
         }
         Ok(all_nullifiers.into_iter().collect::<Vec<_>>())
     }

--- a/crates/rust-client/src/sync/state_sync.rs
+++ b/crates/rust-client/src/sync/state_sync.rs
@@ -545,7 +545,7 @@ impl StateSync {
         account_updates: &mut AccountUpdates,
         accounts: &[AccountHeader],
         account_commitment_updates: &[(AccountId, Word)],
-        block_num: BlockNumber,
+        block_from: BlockNumber,
     ) -> Result<(), ClientError> {
         // "Public" here includes both Public and Network accounts, since both have
         // their state stored on-chain and follow the same sync path.
@@ -556,7 +556,7 @@ impl StateSync {
             account_updates,
             account_commitment_updates,
             &public_accounts,
-            block_num,
+            block_from,
         )
         .await?;
 
@@ -585,7 +585,7 @@ impl StateSync {
         account_updates: &mut AccountUpdates,
         commitment_updates: &[(AccountId, Word)],
         current_public_accounts: &[&AccountHeader],
-        block_num: BlockNumber,
+        block_from: BlockNumber,
     ) -> Result<(), ClientError> {
         for (id, commitment) in commitment_updates {
             let Some(local_header) = current_public_accounts
@@ -633,7 +633,7 @@ impl StateSync {
                     // Delta path: build an AccountDelta from incremental updates,
                     // fetching storage slots and vault from the store on demand.
                     let delta = self
-                        .build_account_delta(&details, local_header, block_num, proof_block_num)
+                        .build_account_delta(&details, local_header, block_from, proof_block_num)
                         .await?;
                     account_updates.extend(AccountUpdates::new(
                         vec![PublicAccountUpdate::Delta {

--- a/crates/rust-client/src/sync/state_sync.rs
+++ b/crates/rust-client/src/sync/state_sync.rs
@@ -803,11 +803,13 @@ impl StateSync {
                 })?;
 
             if map_details.too_many_entries {
-                // Oversized map: fetch delta entries from the sync endpoint.
+                // Oversized map: fetch delta entries from the sync endpoint. The lower bound
+                // is inclusive at the node, so request from `block_from + 1` to skip the
+                // block whose state we already have.
                 if map_delta_cache.is_none() {
                     let map_info = self
                         .rpc_api
-                        .sync_storage_maps(block_from, Some(block_to), account_id)
+                        .sync_storage_maps(block_from + 1, Some(block_to), account_id)
                         .await
                         .map_err(ClientError::RpcError)?;
                     map_delta_cache = Some(map_info.updates);
@@ -948,10 +950,12 @@ impl StateSync {
             store.get_account_vault(account_id).await.map_err(ClientError::StoreError)?;
 
         if details.vault_details.too_many_assets {
-            // Oversized vault: fetch delta from sync endpoint.
+            // Oversized vault: fetch delta from sync endpoint. The lower bound is inclusive
+            // at the node, so request from `block_from + 1` to skip the block whose state
+            // we already have.
             let vault_info = self
                 .rpc_api
-                .sync_account_vault(block_from, Some(block_to), account_id)
+                .sync_account_vault(block_from + 1, Some(block_to), account_id)
                 .await
                 .map_err(ClientError::RpcError)?;
 

--- a/crates/rust-client/src/test_utils/mock.rs
+++ b/crates/rust-client/src/test_utils/mock.rs
@@ -144,8 +144,8 @@ impl MockRpcApi {
         let mut updates = vec![];
         for block in self.mock_chain.read().proven_blocks() {
             let block_number = block.header().block_num();
-            // Only include blocks in range (block_from, page_end_block]
-            if block_number <= block_from || block_number > page_end_block {
+            // Only include blocks in range [block_from, page_end_block]
+            if block_number < block_from || block_number > page_end_block {
                 continue;
             }
 
@@ -231,7 +231,8 @@ impl MockRpcApi {
         let mut updates = vec![];
         for block in self.mock_chain.read().proven_blocks() {
             let block_number = block.header().block_num();
-            if block_number <= block_from || block_number > page_end_block {
+            // Only include blocks in range [block_from, page_end_block]
+            if block_number < block_from || block_number > page_end_block {
                 continue;
             }
 


### PR DESCRIPTION
This PR changes the starting block number used on `sync_account_vault` and `sync_storage_maps` endpoints, that was causing duplicate results being fetched. Also updated the mockchain behavior.

Separately, refactored the `sync_nullifiers` implementation to use the `PaginationResult` struct as in the rest of the endpoints.