### PR TITLE
refactor(keystore): use hex encoding for key filenames

### DIFF
--- a/crates/rust-client/src/keystore/fs_keystore.rs
+++ b/crates/rust-client/src/keystore/fs_keystore.rs
@@ -2,7 +2,6 @@ use alloc::boxed::Box;
 use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::string::String;
 use std::fs;
-use std::hash::{DefaultHasher, Hash, Hasher};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::string::ToString;
@@ -335,7 +334,7 @@ impl Keystore for FilesystemKeyStore {
 
 /// Returns the file path that belongs to the public key commitment
 fn key_file_path(keys_directory: &Path, pub_key: PublicKeyCommitment) -> PathBuf {
-    let filename = hash_pub_key(pub_key.into());
+    let filename = Word::from(pub_key).to_hex();
     keys_directory.join(filename)
 }
 
@@ -364,12 +363,4 @@ fn write_secret_key_file(file_path: &Path, key: &AuthSecretKey) -> Result<(), Ke
 
 fn keystore_error(context: &str) -> impl FnOnce(std::io::Error) -> KeyStoreError {
     move |err| KeyStoreError::StorageError(format!("{context}: {err:?}"))
-}
-
-/// Hashes a public key to a string representation.
-fn hash_pub_key(pub_key: Word) -> String {
-    let pub_key = pub_key.to_hex();
-    let mut hasher = DefaultHasher::new();
-    pub_key.hash(&mut hasher);
-    hasher.finish().to_string()
 }

--- a/crates/rust-client/src/keystore/fs_keystore.rs
+++ b/crates/rust-client/src/keystore/fs_keystore.rs
@@ -4,7 +4,6 @@ use alloc::string::String;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::string::ToString;
 use std::sync::Arc;
 
 use miden_protocol::Word;
@@ -333,8 +332,8 @@ impl Keystore for FilesystemKeyStore {
 // ================================================================================================
 
 /// Returns the file path that belongs to the public key commitment
-fn key_file_path(keys_directory: &Path, pub_key: PublicKeyCommitment) -> PathBuf {
-    let filename = Word::from(pub_key).to_hex();
+fn key_file_path(keys_directory: &Path, pub_key_commitment: PublicKeyCommitment) -> PathBuf {
+    let filename = Word::from(pub_key_commitment).to_hex();
     keys_directory.join(filename)
 }
 


### PR DESCRIPTION
Key files were named using DefaultHasher, which is not guaranteed to be stable across Rust versions. Replaced with hex encoding, consistent with how the key index already stores the same data

Closes https://github.com/0xMiden/miden-client/issues/2188