### PR TITLE
feat: add `get_account_details` default implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Removed limit on accounts and note tags that can be tracked by the client ([#2170](https://github.com/0xMiden/miden-client/pull/2170)).
 * [BREAKING] Updated the `sync_notes` and `sync_transactions` to return directly the fetched updates. Removed `TransactionsInfo` and `NoteSyncInfo` structs ([#2170](https://github.com/0xMiden/miden-client/pull/2170)).
 * [BREAKING][rust] `NodeRpcClient::get_note_script_by_root` now returns `Option<NoteScript>` (`None` when the node has no script for the requested root) instead of erroring when the script is absent ([#1840](https://github.com/0xMiden/miden-client/pull/1840)).
+* Added a blanket implementation for `NodeRpcClient::get_account_details` ([#2196](https://github.com/0xMiden/miden-client/pull/2196)).
 
 ### Enhancements
 

--- a/crates/rust-client/src/rpc/domain/account.rs
+++ b/crates/rust-client/src/rpc/domain/account.rs
@@ -28,7 +28,7 @@ use crate::rpc::generated::{self as proto};
 // FETCHED ACCOUNT
 // ================================================================================================
 
-/// Describes the possible responses from the `GetAccountDetails` endpoint for an account.
+/// Describes the possible responses from the `GetAccoun` endpoint for an account.
 #[derive(Debug)]
 pub enum FetchedAccount {
     /// Private accounts are stored off-chain. Only a commitment to the state of the account is
@@ -724,7 +724,7 @@ impl TryFrom<proto::rpc::AccountResponse> for AccountProof {
     fn try_from(account_proof: proto::rpc::AccountResponse) -> Result<Self, Self::Error> {
         let Some(witness) = account_proof.witness else {
             return Err(RpcError::ExpectedDataMissing(
-                "GetAccountProof returned an account without witness".to_string(),
+                "GetAccount returned an account without witness".to_string(),
             ));
         };
 

--- a/crates/rust-client/src/rpc/domain/account.rs
+++ b/crates/rust-client/src/rpc/domain/account.rs
@@ -28,7 +28,7 @@ use crate::rpc::generated::{self as proto};
 // FETCHED ACCOUNT
 // ================================================================================================
 
-/// Describes the possible responses from the `GetAccoun` endpoint for an account.
+/// Describes the possible responses from the `GetAccount` endpoint for an account.
 #[derive(Debug)]
 pub enum FetchedAccount {
     /// Private accounts are stored off-chain. Only a commitment to the state of the account is

--- a/crates/rust-client/src/rpc/domain/account.rs
+++ b/crates/rust-client/src/rpc/domain/account.rs
@@ -801,6 +801,13 @@ impl AccountStorageRequirements {
         AccountStorageRequirements(map)
     }
 
+    /// Returns a new `AccountStorageRequirements` that requests all entries for all given slots.
+    pub fn all_entries(slot_names: &[StorageSlotName]) -> Self {
+        AccountStorageRequirements(
+            slot_names.iter().map(|name| (name.clone(), Vec::new())).collect(),
+        )
+    }
+
     pub fn inner(&self) -> &BTreeMap<StorageSlotName, Vec<StorageMapKey>> {
         &self.0
     }

--- a/crates/rust-client/src/rpc/mod.rs
+++ b/crates/rust-client/src/rpc/mod.rs
@@ -48,7 +48,11 @@ use alloc::vec::Vec;
 use core::fmt;
 
 use domain::account::{
-    AccountProof, AccountUpdateSummary, FetchedAccount, StorageMapEntries, StorageMapEntry,
+    AccountProof,
+    AccountUpdateSummary,
+    FetchedAccount,
+    StorageMapEntries,
+    StorageMapEntry,
 };
 use domain::note::{FetchedNote, NoteSyncBlock, SyncNotesResult};
 use domain::nullifier::NullifierUpdate;
@@ -239,7 +243,6 @@ pub trait NodeRpcClient: Send + Sync {
 
         // Second call: request entries for every map slot at the same block, so the view is
         // consistent. If there are no maps, the first proof already has what we need.
-        // TODO: can this still return too_many_entries?
         let final_proof = if map_slot_names.is_empty() {
             initial_proof
         } else {

--- a/crates/rust-client/src/rpc/mod.rs
+++ b/crates/rust-client/src/rpc/mod.rs
@@ -200,8 +200,13 @@ pub trait NodeRpcClient: Send + Sync {
     /// [`NodeRpcClient::get_account_proof`] (which already falls back to
     /// [`NodeRpcClient::sync_account_vault`] when the response is truncated by `too_many_assets`)
     /// plus [`NodeRpcClient::sync_storage_maps`] for any storage map flagged with
-    /// `too_many_entries`. Two `/GetAccount` requests are made for public accounts: one to
-    /// discover the storage layout, and a second to request entries for all map slots.
+    /// `too_many_entries`. Up to two `/GetAccount` requests are made for public accounts: one to
+    /// discover the storage layout, and a second to request entries for all map slots (skipped
+    /// when the account has no storage maps).
+    // TODO: `get_account_proof` always fetches the full vault, and this implementation also
+    // requests every storage map. Not all callers of `get_account_details` need that much data,
+    // so the API should be refactored to let callers express which parts of the account they
+    // actually need and avoid the redundant requests during sync.
     async fn get_account_details(&self, account_id: AccountId) -> Result<FetchedAccount, RpcError> {
         // For accounts without public state, only the witness commitment is needed.
         if !account_id.has_public_state() {
@@ -243,6 +248,8 @@ pub trait NodeRpcClient: Send + Sync {
 
         // Second call: request entries for every map slot at the same block, so the view is
         // consistent. If there are no maps, the first proof already has what we need.
+        // This refetches the full vault as a side effect of `get_account_proof`; kept for
+        // simplicity until the trait grows a way to request storage maps without the vault.
         let final_proof = if map_slot_names.is_empty() {
             initial_proof
         } else {
@@ -273,7 +280,7 @@ pub trait NodeRpcClient: Send + Sync {
             details.storage_details.map_details.iter().any(|m| m.too_many_entries);
         if has_oversized_maps {
             let info = self
-                .sync_storage_maps(BlockNumber::from(0), Some(block_number), account_id)
+                .sync_storage_maps(BlockNumber::GENESIS, Some(block_number), account_id)
                 .await?;
             for map_details in &mut details.storage_details.map_details {
                 if !map_details.too_many_entries {

--- a/crates/rust-client/src/rpc/mod.rs
+++ b/crates/rust-client/src/rpc/mod.rs
@@ -271,20 +271,21 @@ pub trait NodeRpcClient: Send + Sync {
         let has_oversized_maps =
             details.storage_details.map_details.iter().any(|m| m.too_many_entries);
         if has_oversized_maps {
-            let info = self
+            let mut updates = self
                 .sync_storage_maps(BlockNumber::GENESIS, Some(block_number), account_id)
-                .await?;
+                .await?
+                .updates;
+            // The sync endpoint may return multiple updates for the same key across different
+            // blocks. Sorting by block once (a stable sort preserves this order within each slot's
+            // subset) lets the per-slot BTreeMap below retain each key's latest value.
+            updates.sort_by_key(|u| u.block_num);
             for map_details in &mut details.storage_details.map_details {
                 if !map_details.too_many_entries {
                     continue;
                 }
-                // The sync endpoint may return multiple updates for the same key across
-                // different blocks. Sort by block so the BTreeMap retains the latest value.
-                let mut sorted: Vec<_> =
-                    info.updates.iter().filter(|u| u.slot_name == map_details.slot_name).collect();
-                sorted.sort_by_key(|u| u.block_num);
-                let entries: Vec<StorageMapEntry> = sorted
-                    .into_iter()
+                let entries: Vec<StorageMapEntry> = updates
+                    .iter()
+                    .filter(|u| u.slot_name == map_details.slot_name)
                     .map(|u| (u.key, u.value))
                     .collect::<BTreeMap<_, _>>()
                     .into_iter()

--- a/crates/rust-client/src/rpc/mod.rs
+++ b/crates/rust-client/src/rpc/mod.rs
@@ -57,7 +57,7 @@ use domain::account::{
 use domain::note::{FetchedNote, NoteSyncBlock, SyncNotesResult};
 use domain::nullifier::NullifierUpdate;
 use domain::sync::{ChainMmrInfo, SyncTarget};
-use miden_protocol::account::{Account, AccountCode, AccountId, StorageMapKey, StorageSlotName};
+use miden_protocol::account::{Account, AccountCode, AccountId, StorageSlotName};
 use miden_protocol::address::NetworkId;
 use miden_protocol::batch::{ProposedBatch, ProvenBatch};
 use miden_protocol::block::{BlockHeader, BlockNumber, ProvenBlock};
@@ -203,10 +203,6 @@ pub trait NodeRpcClient: Send + Sync {
     /// `too_many_entries`. Up to two `/GetAccount` requests are made for public accounts: one to
     /// discover the storage layout, and a second to request entries for all map slots (skipped
     /// when the account has no storage maps).
-    // TODO: `get_account_proof` always fetches the full vault, and this implementation also
-    // requests every storage map. Not all callers of `get_account_details` need that much data,
-    // so the API should be refactored to let callers express which parts of the account they
-    // actually need and avoid the redundant requests during sync.
     async fn get_account_details(&self, account_id: AccountId) -> Result<FetchedAccount, RpcError> {
         // For accounts without public state, only the witness commitment is needed.
         if !account_id.has_public_state() {
@@ -248,15 +244,11 @@ pub trait NodeRpcClient: Send + Sync {
 
         // Second call: request entries for every map slot at the same block, so the view is
         // consistent. If there are no maps, the first proof already has what we need.
-        // This refetches the full vault as a side effect of `get_account_proof`; kept for
-        // simplicity until the trait grows a way to request storage maps without the vault.
+        // TODO: this refetches the full vault and could be avoided
         let final_proof = if map_slot_names.is_empty() {
             initial_proof
         } else {
-            let empty_keys: Vec<StorageMapKey> = Vec::new();
-            let requirements = AccountStorageRequirements::new(
-                map_slot_names.iter().map(|name| (name.clone(), empty_keys.iter())),
-            );
+            let requirements = AccountStorageRequirements::all_entries(&map_slot_names);
             let (_, proof) = self
                 .get_account_proof(
                     account_id,

--- a/crates/rust-client/src/rpc/mod.rs
+++ b/crates/rust-client/src/rpc/mod.rs
@@ -47,18 +47,20 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
 
-use domain::account::{AccountProof, FetchedAccount};
+use domain::account::{
+    AccountProof, AccountUpdateSummary, FetchedAccount, StorageMapEntries, StorageMapEntry,
+};
 use domain::note::{FetchedNote, NoteSyncBlock, SyncNotesResult};
 use domain::nullifier::NullifierUpdate;
 use domain::sync::{ChainMmrInfo, SyncTarget};
-use miden_protocol::Word;
-use miden_protocol::account::{AccountCode, AccountId};
+use miden_protocol::account::{Account, AccountCode, AccountId, StorageMapKey, StorageSlotName};
 use miden_protocol::address::NetworkId;
 use miden_protocol::batch::{ProposedBatch, ProvenBatch};
 use miden_protocol::block::{BlockHeader, BlockNumber, ProvenBlock};
 use miden_protocol::crypto::merkle::mmr::MmrProof;
 use miden_protocol::note::{NoteId, NoteScript, NoteTag, NoteType, Nullifier};
 use miden_protocol::transaction::{ProvenTransaction, TransactionInputs};
+use miden_protocol::{EMPTY_WORD, Word};
 
 use crate::rpc::domain::storage_map::StorageMapInfo;
 
@@ -186,11 +188,114 @@ pub trait NodeRpcClient: Send + Sync {
         upper_bound: SyncTarget,
     ) -> Result<ChainMmrInfo, RpcError>;
 
-    /// Fetches the current state of an account from the node using the `/GetAccountDetails` RPC
-    /// endpoint.
+    /// Fetches the current state of an account from the node.
     ///
     /// - `account_id` is the ID of the wanted account.
-    async fn get_account_details(&self, account_id: AccountId) -> Result<FetchedAccount, RpcError>;
+    ///
+    /// The default implementation builds the full account on top of
+    /// [`NodeRpcClient::get_account_proof`] (which already falls back to
+    /// [`NodeRpcClient::sync_account_vault`] when the response is truncated by `too_many_assets`)
+    /// plus [`NodeRpcClient::sync_storage_maps`] for any storage map flagged with
+    /// `too_many_entries`. Two `/GetAccount` requests are made for public accounts: one to
+    /// discover the storage layout, and a second to request entries for all map slots.
+    async fn get_account_details(&self, account_id: AccountId) -> Result<FetchedAccount, RpcError> {
+        // For accounts without public state, only the witness commitment is needed.
+        if !account_id.has_public_state() {
+            let (block_number, proof) = self
+                .get_account_proof(
+                    account_id,
+                    AccountStorageRequirements::default(),
+                    AccountStateAt::ChainTip,
+                    None,
+                    None,
+                )
+                .await?;
+            return Ok(FetchedAccount::new_private(
+                account_id,
+                AccountUpdateSummary::new(proof.account_commitment(), block_number),
+            ));
+        }
+
+        // First call discovers the storage layout (which slots are maps).
+        let (block_number, initial_proof) = self
+            .get_account_proof(
+                account_id,
+                AccountStorageRequirements::default(),
+                AccountStateAt::ChainTip,
+                None,
+                Some(EMPTY_WORD),
+            )
+            .await?;
+
+        let map_slot_names: Vec<StorageSlotName> = initial_proof
+            .storage_header()
+            .ok_or(RpcError::ExpectedDataMissing(
+                "storage_header missing for public account".into(),
+            ))?
+            .slots()
+            .filter(|slot| slot.slot_type().is_map())
+            .map(|slot| slot.name().clone())
+            .collect();
+
+        // Second call: request entries for every map slot at the same block, so the view is
+        // consistent. If there are no maps, the first proof already has what we need.
+        // TODO: can this still return too_many_entries?
+        let final_proof = if map_slot_names.is_empty() {
+            initial_proof
+        } else {
+            let empty_keys: Vec<StorageMapKey> = Vec::new();
+            let requirements = AccountStorageRequirements::new(
+                map_slot_names.iter().map(|name| (name.clone(), empty_keys.iter())),
+            );
+            let (_, proof) = self
+                .get_account_proof(
+                    account_id,
+                    requirements,
+                    AccountStateAt::Block(block_number),
+                    None,
+                    Some(EMPTY_WORD),
+                )
+                .await?;
+            proof
+        };
+
+        let summary = AccountUpdateSummary::new(final_proof.account_commitment(), block_number);
+        let mut details = final_proof.into_parts().1.ok_or(RpcError::ExpectedDataMissing(
+            "public account returned without details".into(),
+        ))?;
+
+        // Resolve any storage maps flagged as too_many_entries via SyncStorageMaps. Vault
+        // truncation is already handled by get_account_proof.
+        let has_oversized_maps =
+            details.storage_details.map_details.iter().any(|m| m.too_many_entries);
+        if has_oversized_maps {
+            let info = self
+                .sync_storage_maps(BlockNumber::from(0), Some(block_number), account_id)
+                .await?;
+            for map_details in &mut details.storage_details.map_details {
+                if !map_details.too_many_entries {
+                    continue;
+                }
+                // The sync endpoint may return multiple updates for the same key across
+                // different blocks. Sort by block so the BTreeMap retains the latest value.
+                let mut sorted: Vec<_> =
+                    info.updates.iter().filter(|u| u.slot_name == map_details.slot_name).collect();
+                sorted.sort_by_key(|u| u.block_num);
+                let entries: Vec<StorageMapEntry> = sorted
+                    .into_iter()
+                    .map(|u| (u.key, u.value))
+                    .collect::<BTreeMap<_, _>>()
+                    .into_iter()
+                    .map(|(key, value)| StorageMapEntry { key, value })
+                    .collect();
+                map_details.too_many_entries = false;
+                map_details.entries = StorageMapEntries::AllEntries(entries);
+            }
+        }
+
+        let account = Account::try_from(&details)?;
+        Ok(FetchedAccount::new_public(account, summary))
+    }
 
     /// Fetches the notes related to the specified tags using the `/SyncNotes` RPC endpoint.
     ///
@@ -267,7 +372,7 @@ pub trait NodeRpcClient: Send + Sync {
     ) -> Result<Vec<NullifierUpdate>, RpcError>;
 
     /// Fetches the account proof and optionally its details from the node, using the
-    /// `GetAccountProof` endpoint.
+    /// `/GetAccount` endpoint.
     ///
     /// The `account_state` parameter specifies the block number from which to retrieve
     /// the account proof from (the state of the account at that block).
@@ -519,7 +624,7 @@ impl fmt::Display for RpcEndpoint {
             RpcEndpoint::SyncNullifiers => {
                 write!(f, "sync_nullifiers")
             },
-            RpcEndpoint::GetAccount => write!(f, "get_account_proof"),
+            RpcEndpoint::GetAccount => write!(f, "get_account"),
             RpcEndpoint::GetBlockByNumber => write!(f, "get_block_by_number"),
             RpcEndpoint::GetBlockHeaderByNumber => {
                 write!(f, "get_block_header_by_number")

--- a/crates/rust-client/src/rpc/mod.rs
+++ b/crates/rust-client/src/rpc/mod.rs
@@ -374,7 +374,7 @@ pub trait NodeRpcClient: Send + Sync {
     ) -> Result<Vec<NullifierUpdate>, RpcError>;
 
     /// Fetches the account proof and optionally its details from the node, using the
-    /// `/GetAccount` endpoint.
+    /// `GetAccount` endpoint.
     ///
     /// The `account_state` parameter specifies the block number from which to retrieve
     /// the account proof from (the state of the account at that block).

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -6,14 +6,12 @@ use alloc::vec::Vec;
 use core::error::Error;
 use core::pin::Pin;
 
-use miden_protocol::asset::{Asset, AssetVault};
+use miden_protocol::asset::Asset;
 use miden_protocol::vm::FutureMaybeSend;
 
 type RpcFuture<T> = Pin<Box<dyn FutureMaybeSend<T>>>;
 
-use miden_protocol::account::{
-    Account, AccountCode, AccountId, AccountStorage, StorageMap, StorageSlot, StorageSlotType,
-};
+use miden_protocol::account::{AccountCode, AccountId};
 use miden_protocol::address::NetworkId;
 use miden_protocol::batch::{ProposedBatch, ProvenBatch};
 use miden_protocol::block::account_tree::AccountWitness;
@@ -29,24 +27,22 @@ use miden_tx::utils::sync::RwLock;
 use tonic::Status;
 use tracing::info;
 
-use super::domain::account::{
-    AccountProof, AccountStorageDetails, AccountStorageRequirements, AccountUpdateSummary,
-};
-use super::domain::{note::{FetchedNote, NoteSyncBlock}, nullifier::NullifierUpdate};
-use super::generated::rpc::account_request::AccountDetailRequest;
+use super::domain::account::{AccountProof, AccountStorageRequirements};
+use super::domain::note::{FetchedNote, NoteSyncBlock};
+use super::domain::nullifier::NullifierUpdate;
 use super::generated::rpc::AccountRequest;
-use super::{Endpoint, FetchedAccount, NodeRpcClient, RpcEndpoint, RpcError, RpcStatusInfo};
-use crate::rpc::domain::status::NetworkNoteStatusInfo;
-use crate::rpc::domain::sync::{ChainMmrInfo, SyncTarget};
+use super::generated::rpc::account_request::AccountDetailRequest;
+use super::{Endpoint, NodeRpcClient, RpcEndpoint, RpcError, RpcStatusInfo};
 use crate::rpc::domain::account_vault::{AccountVaultInfo, AccountVaultUpdate};
+use crate::rpc::domain::limits::RpcLimits;
+use crate::rpc::domain::status::NetworkNoteStatusInfo;
 use crate::rpc::domain::storage_map::{StorageMapInfo, StorageMapUpdate};
+use crate::rpc::domain::sync::{ChainMmrInfo, SyncTarget};
 use crate::rpc::domain::transaction::TransactionRecord;
 use crate::rpc::errors::node::parse_node_error;
 use crate::rpc::errors::{AcceptHeaderContext, AcceptHeaderError, GrpcError, RpcConversionError};
-use crate::rpc::generated::rpc::account_request::account_detail_request::storage_map_detail_request::SlotData;
-use crate::rpc::generated::rpc::account_request::account_detail_request::StorageMapDetailRequest;
 use crate::rpc::generated::rpc::BlockRange;
-use crate::rpc::domain::limits::RpcLimits;
+use crate::rpc::generated::rpc::account_request::account_detail_request::StorageMapDetailRequest;
 use crate::rpc::{AccountStateAt, generated as proto};
 
 mod api_client;
@@ -310,171 +306,6 @@ impl GrpcClient {
     // GET ACCOUNT HELPERS
     // ============================================================================================
 
-    /// Given an [`AccountId`], return the proof for the account.
-    ///
-    /// If the account also has public state, its details will also be retrieved
-    pub async fn fetch_full_account_proof(
-        &self,
-        account_id: AccountId,
-    ) -> Result<(BlockNumber, AccountProof), RpcError> {
-        let has_public_state = account_id.has_public_state();
-        let account_request = {
-            AccountRequest {
-                account_id: Some(account_id.into()),
-                block_num: None,
-                details: {
-                    if has_public_state {
-                        // Since we have to request the storage maps for an account
-                        // we *dont know* anything about, we'll have to do first this
-                        // request, which will tell us about the account's storage slots,
-                        // and then, request the slots in another request.
-                        Some(AccountDetailRequest {
-                            code_commitment: Some(EMPTY_WORD.into()),
-                            asset_vault_commitment: Some(EMPTY_WORD.into()),
-                            storage_maps: vec![],
-                        })
-                    } else {
-                        None
-                    }
-                },
-            }
-        };
-        let account_response = self
-            .call_with_retry(RpcEndpoint::GetAccount, |mut rpc_api| {
-                let request = account_request.clone();
-                Box::pin(async move { rpc_api.get_account(request).await })
-            })
-            .await?
-            .into_inner();
-        let block_number = account_response.block_num.ok_or(RpcError::ExpectedDataMissing(
-            "GetAccountDetails returned an account without a matching block number for the witness"
-                .to_owned(),
-        ))?;
-        let account_proof = {
-            if has_public_state {
-                let account_details = account_response
-                    .details
-                    .ok_or(RpcError::ExpectedDataMissing("details in public account".to_owned()))?
-                    .into_domain(&BTreeMap::new(), &AccountStorageRequirements::default())?;
-                let storage_header = account_details.storage_details.header;
-                // This variable will hold the storage slots that are maps, below we will use it to
-                // actually fetch the storage maps details, since we now know the names of each
-                // storage slot.
-                let maps_to_request = storage_header
-                    .slots()
-                    .filter(|header| header.slot_type().is_map())
-                    .map(|map| map.name().to_string());
-                let account_request = AccountRequest {
-                    account_id: Some(account_id.into()),
-                    block_num: Some(block_number),
-                    details: Some(AccountDetailRequest {
-                        code_commitment: Some(EMPTY_WORD.into()),
-                        asset_vault_commitment: Some(EMPTY_WORD.into()),
-                        storage_maps: maps_to_request
-                            .map(|slot_name| StorageMapDetailRequest {
-                                slot_name,
-                                slot_data: Some(SlotData::AllEntries(true)),
-                            })
-                            .collect(),
-                    }),
-                };
-                let response = self
-                    .call_with_retry(RpcEndpoint::GetAccount, |mut rpc_api| {
-                        let request = account_request.clone();
-                        Box::pin(async move { rpc_api.get_account(request).await })
-                    })
-                    .await?;
-                response.into_inner().try_into()
-            } else {
-                account_response.try_into()
-            }
-        };
-        Ok((block_number.block_num.into(), account_proof?))
-    }
-
-    /// Given the storage details for an account and its id, returns a vector with all of its
-    /// storage slots. Keep in mind that if an account triggers the `too_many_entries` flag, there
-    /// will potentially be multiple requests.
-    async fn build_storage_slots(
-        &self,
-        account_id: AccountId,
-        storage_details: &AccountStorageDetails,
-        block_to: Option<BlockNumber>,
-    ) -> Result<Vec<StorageSlot>, RpcError> {
-        let mut slots = vec![];
-        // `SyncStorageMaps` will return information for *every* map for a given account, so this
-        // map_cache value should be fetched only once, hence the None placeholder
-        let mut map_cache: Option<StorageMapInfo> = None;
-        for slot_header in storage_details.header.slots() {
-            // We have two cases for each slot:
-            // - Slot is a value => We simply instance a StorageSlot
-            // - Slot is a map => If the map is 'small', we can simply
-            // build the map from the given entries. Otherwise we will have to
-            // call the SyncStorageMaps RPC method to obtain the data for the map.
-            // With the current setup, one RPC call should be enough.
-            match slot_header.slot_type() {
-                StorageSlotType::Value => {
-                    slots.push(miden_protocol::account::StorageSlot::with_value(
-                        slot_header.name().clone(),
-                        slot_header.value(),
-                    ));
-                },
-                StorageSlotType::Map => {
-                    let map_details = storage_details.find_map_details(slot_header.name()).ok_or(
-                        RpcError::ExpectedDataMissing(format!(
-                            "slot named '{}' was reported as a map, but it does not have a matching map_detail entry",
-                            slot_header.name(),
-                        )),
-                    )?;
-
-                    let storage_map = if map_details.too_many_entries {
-                        let map_info = if let Some(ref info) = map_cache {
-                            info
-                        } else {
-                            let fetched_data =
-                                self.sync_storage_maps(0_u32.into(), block_to, account_id).await?;
-                            map_cache.insert(fetched_data)
-                        };
-                        // The sync endpoint may return multiple updates for the same key
-                        // across different blocks. We sort by block number so that
-                        // inserting into the map keeps only the latest value per key.
-                        let mut sorted_updates: Vec<_> = map_info
-                            .updates
-                            .iter()
-                            .filter(|slot_info| slot_info.slot_name == *slot_header.name())
-                            .collect();
-                        sorted_updates.sort_by_key(|u| u.block_num);
-                        let map_entries: Vec<_> = sorted_updates
-                            .into_iter()
-                            .map(|u| (u.key, u.value))
-                            .collect::<BTreeMap<_, _>>()
-                            .into_iter()
-                            .collect();
-                        StorageMap::with_entries(map_entries)
-                    } else {
-                        map_details.entries.clone().into_storage_map().ok_or_else(|| {
-                            RpcError::ExpectedDataMissing(
-                                "expected AllEntries for full account fetch, got EntriesWithProofs"
-                                    .into(),
-                            )
-                        })?
-                    }
-                    .map_err(|err| {
-                        RpcError::InvalidResponse(format!(
-                            "the rpc api returned a non-valid map entry: {err}"
-                        ))
-                    })?;
-
-                    slots.push(miden_protocol::account::StorageSlot::with_map(
-                        slot_header.name().clone(),
-                        storage_map,
-                    ));
-                },
-            }
-        }
-        Ok(slots)
-    }
-
     /// Fetches the full vault assets via `SyncAccountVault`.
     ///
     /// Used when `too_many_assets` is set in the response. Deduplicates updates by
@@ -668,68 +499,7 @@ impl NodeRpcClient for GrpcClient {
         response.into_inner().try_into()
     }
 
-    /// Sends a `GetAccountDetailsRequest` to the Miden node, and extracts an [`FetchedAccount`]
-    /// from the `GetAccountDetailsResponse` response.
-    ///
-    /// # Errors
-    ///
-    /// This function will return an error if:
-    ///
-    /// - There was an error sending the request to the node.
-    /// - The answer had a `None` for one of the expected fields (`account`, `summary`,
-    ///   `account_commitment`, `details`).
-    /// - There is an error during [Account] deserialization.
-    async fn get_account_details(&self, account_id: AccountId) -> Result<FetchedAccount, RpcError> {
-        let (block_number, full_account_proof) = self.fetch_full_account_proof(account_id).await?;
-        let update_summary =
-            AccountUpdateSummary::new(full_account_proof.account_commitment(), block_number);
-
-        // The case for a private account is simple,
-        // we simple use the commitment and its id.
-        if account_id.is_private() {
-            Ok(FetchedAccount::new_private(account_id, update_summary))
-        } else {
-            let details =
-                full_account_proof.into_parts().1.ok_or(RpcError::ExpectedDataMissing(
-                    "GetAccountDetails returned a public account without details".to_owned(),
-                ))?;
-
-            let account_id = details.header.id();
-            let nonce = details.header.nonce();
-
-            // If the vault exceeds the node's size threshold, download the full vault
-            // via the sync endpoint; otherwise use the assets from the response directly.
-            let assets = if details.vault_details.too_many_assets {
-                self.fetch_full_vault(account_id, block_number).await?
-            } else {
-                details.vault_details.assets
-            };
-
-            // build_storage_slots handles too_many_entries maps internally via
-            // sync_storage_maps.
-            let slots = self
-                .build_storage_slots(account_id, &details.storage_details, Some(block_number))
-                .await?;
-            let asset_vault = AssetVault::new(&assets).map_err(|err| {
-                RpcError::InvalidResponse(format!("api rpc returned non-valid assets: {err}"))
-            })?;
-            let account_storage = AccountStorage::new(slots).map_err(|err| {
-                RpcError::InvalidResponse(format!(
-                    "api rpc returned non-valid storage slots: {err}"
-                ))
-            })?;
-            let account =
-                Account::new(account_id, asset_vault, account_storage, details.code, nonce, None)
-                    .map_err(|err| {
-                    RpcError::InvalidResponse(format!(
-                        "failed to instance an account from the rpc api response: {err}"
-                    ))
-                })?;
-            Ok(FetchedAccount::new_public(account, update_summary))
-        }
-    }
-
-    /// Sends a `GetAccountProof` request to the Miden node, and extracts the [AccountProof]
+    /// Sends a `/GetAccount` request to the Miden node, and extracts the [`AccountProof`]
     /// from the response, as well as the block number that it was retrieved for.
     ///
     /// # Errors

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -576,6 +576,7 @@ impl NodeRpcClient for GrpcClient {
 
             if details.vault_details.too_many_assets {
                 details.vault_details.assets = self.fetch_full_vault(account_id, block_num).await?;
+                details.vault_details.too_many_assets = false;
             }
 
             Some(details)

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -499,7 +499,7 @@ impl NodeRpcClient for GrpcClient {
         response.into_inner().try_into()
     }
 
-    /// Sends a `/GetAccount` request to the Miden node, and extracts the [`AccountProof`]
+    /// Sends a `GetAccount` request to the Miden node, and extracts the [`AccountProof`]
     /// from the response, as well as the block number that it was retrieved for.
     ///
     /// # Errors

--- a/crates/rust-client/src/sync/state_sync.rs
+++ b/crates/rust-client/src/sync/state_sync.rs
@@ -9,7 +9,6 @@ use miden_protocol::account::{
     AccountHeader,
     AccountId,
     AccountStorageHeader,
-    StorageMapKey,
     StorageSlotName,
     StorageSlotType,
 };
@@ -644,11 +643,7 @@ impl StateSync {
 
         // Request all map data we know about up-front so the response is self-sufficient
         // when the on-chain layout hasn't grown since the hint was produced.
-        let initial_requirements = AccountStorageRequirements::new(
-            hinted_map_slots
-                .iter()
-                .map(|n| (n.clone(), core::iter::empty::<&StorageMapKey>())),
-        );
+        let initial_requirements = AccountStorageRequirements::all_entries(&hinted_map_slots);
 
         let (proof_block_num, proof) = self
             .rpc_api
@@ -721,11 +716,7 @@ impl StateSync {
         block_from: BlockNumber,
         block_to: BlockNumber,
     ) -> Result<PublicAccountUpdate, ClientError> {
-        let storage_requirements = AccountStorageRequirements::new(
-            missing_map_slots
-                .iter()
-                .map(|n| (n.clone(), core::iter::empty::<&StorageMapKey>())),
-        );
+        let storage_requirements = AccountStorageRequirements::all_entries(missing_map_slots);
 
         let (_, follow_up_proof) = self
             .rpc_api

--- a/crates/rust-client/src/test_utils/mock.rs
+++ b/crates/rust-client/src/test_utils/mock.rs
@@ -22,9 +22,7 @@ use crate::rpc::domain::account::{
     AccountStorageDetails,
     AccountStorageMapDetails,
     AccountStorageRequirements,
-    AccountUpdateSummary,
     AccountVaultDetails,
-    FetchedAccount,
     StorageMapEntries,
     StorageMapEntry,
 };
@@ -460,36 +458,6 @@ impl NodeRpcClient for MockRpcApi {
         let block_num = self.get_chain_tip_block_num();
 
         Ok(block_num)
-    }
-
-    /// Returns the node's tracked account details for the specified account ID.
-    /// Always returns the full account for public accounts.
-    async fn get_account_details(&self, account_id: AccountId) -> Result<FetchedAccount, RpcError> {
-        let summary =
-            self.account_commitment_updates
-                .read()
-                .iter()
-                .rev()
-                .find_map(|(block_num, updates)| {
-                    updates.get(&account_id).map(|commitment| AccountUpdateSummary {
-                        commitment: *commitment,
-                        last_block_num: *block_num,
-                    })
-                });
-
-        if let Ok(account) = self.mock_chain.read().committed_account(account_id) {
-            let summary = summary.unwrap_or_else(|| AccountUpdateSummary {
-                commitment: account.to_commitment(),
-                last_block_num: BlockNumber::GENESIS,
-            });
-            Ok(FetchedAccount::new_public(account.clone(), summary))
-        } else if let Some(summary) = summary {
-            Ok(FetchedAccount::new_private(account_id, summary))
-        } else {
-            Err(RpcError::ExpectedDataMissing(format!(
-                "account {account_id} not found in mock commitment updates or mock chain"
-            )))
-        }
     }
 
     /// Returns the account proof for the specified account. The `known_account_code` parameter


### PR DESCRIPTION
Part of https://github.com/0xMiden/miden-client/issues/2191

This PR moves the `get_account_details` implementation from the tonic client to the `NodeRpcClient` trait. This endpoint already uses the same `GetAccount` endpoint as the `get_account_proof` method. Now the implementation reuses the `get_account_proof` so the duplicated code was removed.

TODO:

Further refactor the API. Currently the get_account_proof does the account fetch and also the account vault sync. The get_account_details makes the storage sync. This is not needed since not all callers of get_account_proof need the full vault. This is causing extra requests on the sync.