### PR TITLE
fix: remove panicking `debug_assert` in `BlockUpdates::insert`

### DIFF
--- a/crates/rust-client/src/sync/state_sync_update.rs
+++ b/crates/rust-client/src/sync/state_sync_update.rs
@@ -120,12 +120,6 @@ impl BlockUpdates {
         peaks: MmrPeaks,
         new_authentication_nodes: Vec<(InOrderIndex, Word)>,
     ) {
-        debug_assert_eq!(
-            peaks.forest().num_leaves(),
-            block_header.block_num().as_usize(),
-            "MMR peaks stored for a block header must use that block number as the forest",
-        );
-
         self.block_headers
             .entry(block_header.block_num())
             .and_modify(|(_, existing_has_notes, _)| {


### PR DESCRIPTION
A `debug_assert_eq!` in `BlockUpdates::insert` panics during state sync whenever the client encounters historical note-bearing blocks: the caller pairs the older header with the partial MMR's current peaks, so `peaks.forest().num_leaves() != block_header.block_num()`. This was reported externally in #2126.

The structural fix already landed on `next` via #2100, which removes the per-block `partial_blockchain_peaks` column entirely (and with it the `peaks` parameter of this insert). On `main` the minimal change is just dropping the assert: the stored peaks aren't actually used in a way that affects behavior, which is why release builds (with `debug_assert` compiled out) have been working fine all along.