### PR TITLE
fix(sqlite-store): roll back AccountSmtForest when its SQL transaction fails

### DIFF
--- a/crates/sqlite-store/src/account/accounts.rs
+++ b/crates/sqlite-store/src/account/accounts.rs
@@ -265,8 +265,7 @@ impl SqliteStore {
         account_id: AccountId,
         vault_key: AssetVaultKey,
     ) -> Result<Option<(Asset, AssetWitness)>, StoreError> {
-        // Acquire forest lock before getting header in order to avoid unwanted concurrent writes to
-        // it.
+        // Acquire forest lock before getting header in order to avoid concurrent writes to it.
         let smt_forest = smt_forest
             .read()
             .map_err(|_| StoreError::DatabaseError("smt_forest read lock poisoned".to_string()))?;
@@ -290,8 +289,7 @@ impl SqliteStore {
         slot_name: StorageSlotName,
         key: StorageMapKey,
     ) -> Result<(Word, StorageMapWitness), StoreError> {
-        // Acquire forest lock before getting header in order to avoid unwanted concurrent writes to
-        // it.
+        // Acquire forest lock before getting header in order to avoid concurrent writes to it.
         let smt_forest = smt_forest
             .read()
             .map_err(|_| StoreError::DatabaseError("smt_forest read lock poisoned".to_string()))?;

--- a/crates/sqlite-store/src/account/accounts.rs
+++ b/crates/sqlite-store/src/account/accounts.rs
@@ -50,6 +50,7 @@ use crate::account::helpers::{
     query_vault_assets,
 };
 use crate::sql_error::SqlResultExt;
+use crate::transaction::with_forest_snapshot;
 use crate::{SqliteStore, column_value_as_u64, insert_sql, subst, u64_to_value};
 
 impl SqliteStore {
@@ -258,17 +259,23 @@ impl SqliteStore {
 
     /// Fetches a specific asset from the account's vault without the need of loading the entire
     /// vault. The witness is retrieved from the [`AccountSmtForest`].
+    ///
+    /// The forest read lock is acquired before the DB read so the DB header and the forest
+    /// observation come from the same `apply_*` epoch: no writer can pop the read root between
+    /// the header fetch and the witness lookup.
     pub(crate) fn get_account_asset(
         conn: &mut Connection,
         smt_forest: &Arc<RwLock<AccountSmtForest>>,
         account_id: AccountId,
         vault_key: AssetVaultKey,
     ) -> Result<Option<(Asset, AssetWitness)>, StoreError> {
+        let smt_forest = smt_forest
+            .read()
+            .map_err(|_| StoreError::DatabaseError("smt_forest read lock poisoned".to_string()))?;
         let header = Self::get_account_header(conn, account_id)?
             .ok_or(StoreError::AccountDataNotFound(account_id))?
             .0;
 
-        let smt_forest = smt_forest.read().expect("smt_forest read lock not poisoned");
         match smt_forest.get_asset_and_witness(header.vault_root(), vault_key) {
             Ok((asset, witness)) => Ok(Some((asset, witness))),
             Err(StoreError::MerkleStoreError(MerkleError::UntrackedKey(_))) => Ok(None),
@@ -278,6 +285,10 @@ impl SqliteStore {
 
     /// Retrieves a specific item from the account's storage map without loading the entire storage.
     /// The witness is retrieved from the [`AccountSmtForest`].
+    ///
+    /// The forest read lock is acquired before the DB read so the DB state and the forest
+    /// observation come from the same `apply_*` epoch: no writer can pop the read root between
+    /// the storage-row fetch and the witness lookup.
     pub(crate) fn get_account_map_item(
         conn: &mut Connection,
         smt_forest: &Arc<RwLock<AccountSmtForest>>,
@@ -285,6 +296,9 @@ impl SqliteStore {
         slot_name: StorageSlotName,
         key: StorageMapKey,
     ) -> Result<(Word, StorageMapWitness), StoreError> {
+        let smt_forest = smt_forest
+            .read()
+            .map_err(|_| StoreError::DatabaseError("smt_forest read lock poisoned".to_string()))?;
         let header = Self::get_account_header(conn, account_id)?
             .ok_or(StoreError::AccountDataNotFound(account_id))?
             .0;
@@ -297,7 +311,6 @@ impl SqliteStore {
             return Err(StoreError::AccountError(AccountError::StorageSlotNotMap(slot_name)));
         }
 
-        let smt_forest = smt_forest.read().expect("smt_forest read lock not poisoned");
         let witness = smt_forest.get_storage_map_item_witness(map_root, key)?;
         let item = witness.get(key).unwrap_or(miden_client::EMPTY_WORD);
 
@@ -337,30 +350,23 @@ impl SqliteStore {
         initial_address: &Address,
         client_account_type: ClientAccountType,
     ) -> Result<(), StoreError> {
-        let tx = conn.transaction().into_store_error()?;
+        with_forest_snapshot(conn, smt_forest, |tx, smt_forest| {
+            Self::insert_account_code(tx, account.code())?;
 
-        Self::insert_account_code(&tx, account.code())?;
+            let account_id = account.id();
+            Self::insert_storage_slots(tx, account_id, account.storage().slots().iter())?;
+            Self::insert_assets(tx, account_id, account.vault().assets())?;
+            let watched = matches!(client_account_type, ClientAccountType::Watched);
+            Self::insert_new_account_header(tx, &account.into(), account.seed(), watched)?;
+            Self::insert_address(tx, initial_address, account.id())?;
 
-        let account_id = account.id();
-
-        Self::insert_storage_slots(&tx, account_id, account.storage().slots().iter())?;
-
-        Self::insert_assets(&tx, account_id, account.vault().assets())?;
-        let watched = matches!(client_account_type, ClientAccountType::Watched);
-        Self::insert_new_account_header(&tx, &account.into(), account.seed(), watched)?;
-
-        Self::insert_address(&tx, initial_address, account.id())?;
-
-        tx.commit().into_store_error()?;
-
-        let mut smt_forest = smt_forest.write().expect("smt_forest write lock not poisoned");
-        smt_forest.insert_and_register_account_state(
-            account.id(),
-            account.vault(),
-            account.storage(),
-        )?;
-
-        Ok(())
+            smt_forest.insert_and_register_account_state(
+                account.id(),
+                account.vault(),
+                account.storage(),
+            )?;
+            Ok(())
+        })
     }
 
     pub(crate) fn update_account(
@@ -391,10 +397,9 @@ impl SqliteStore {
             return Err(StoreError::AccountDataNotFound(new_account_state.id()));
         }
 
-        let mut smt_forest = smt_forest.write().expect("smt_forest write lock not poisoned");
-        let tx = conn.transaction().into_store_error()?;
-        Self::update_account_state(&tx, &mut smt_forest, new_account_state)?;
-        tx.commit().into_store_error()
+        with_forest_snapshot(conn, smt_forest, |tx, smt_forest| {
+            Self::update_account_state(tx, smt_forest, new_account_state)
+        })
     }
 
     pub fn upsert_foreign_account_code(

--- a/crates/sqlite-store/src/account/accounts.rs
+++ b/crates/sqlite-store/src/account/accounts.rs
@@ -259,16 +259,14 @@ impl SqliteStore {
 
     /// Fetches a specific asset from the account's vault without the need of loading the entire
     /// vault. The witness is retrieved from the [`AccountSmtForest`].
-    ///
-    /// The forest read lock is acquired before the DB read so the DB header and the forest
-    /// observation come from the same `apply_*` epoch: no writer can pop the read root between
-    /// the header fetch and the witness lookup.
     pub(crate) fn get_account_asset(
         conn: &mut Connection,
         smt_forest: &Arc<RwLock<AccountSmtForest>>,
         account_id: AccountId,
         vault_key: AssetVaultKey,
     ) -> Result<Option<(Asset, AssetWitness)>, StoreError> {
+        // Acquire forest lock before getting header in order to avoid unwanted concurrent writes to
+        // it.
         let smt_forest = smt_forest
             .read()
             .map_err(|_| StoreError::DatabaseError("smt_forest read lock poisoned".to_string()))?;
@@ -285,10 +283,6 @@ impl SqliteStore {
 
     /// Retrieves a specific item from the account's storage map without loading the entire storage.
     /// The witness is retrieved from the [`AccountSmtForest`].
-    ///
-    /// The forest read lock is acquired before the DB read so the DB state and the forest
-    /// observation come from the same `apply_*` epoch: no writer can pop the read root between
-    /// the storage-row fetch and the witness lookup.
     pub(crate) fn get_account_map_item(
         conn: &mut Connection,
         smt_forest: &Arc<RwLock<AccountSmtForest>>,
@@ -296,6 +290,8 @@ impl SqliteStore {
         slot_name: StorageSlotName,
         key: StorageMapKey,
     ) -> Result<(Word, StorageMapWitness), StoreError> {
+        // Acquire forest lock before getting header in order to avoid unwanted concurrent writes to
+        // it.
         let smt_forest = smt_forest
             .read()
             .map_err(|_| StoreError::DatabaseError("smt_forest read lock poisoned".to_string()))?;

--- a/crates/sqlite-store/src/account/tests.rs
+++ b/crates/sqlite-store/src/account/tests.rs
@@ -1981,10 +1981,7 @@ async fn with_forest_snapshot_leaves_forest_unchanged_on_error() -> anyhow::Resu
     assert!(matches!(outcome, Err(StoreError::DatabaseError(_))));
 
     let forest_after = forest_arc.read().expect("read lock").clone();
-    assert_eq!(
-        forest_after, forest_before,
-        "forest must be unchanged after a failed closure"
-    );
+    assert_eq!(forest_after, forest_before, "forest must be unchanged after a failed closure");
 
     // The DB transaction was rolled back too — account state is still at nonce 0.
     let (header, _) = store

--- a/crates/sqlite-store/src/account/tests.rs
+++ b/crates/sqlite-store/src/account/tests.rs
@@ -29,7 +29,7 @@ use miden_client::asset::{
     NonFungibleAssetDetails,
 };
 use miden_client::auth::{AuthSchemeId, AuthSingleSig, PublicKeyCommitment};
-use miden_client::store::{ClientAccountType, Store};
+use miden_client::store::{ClientAccountType, Store, StoreError};
 use miden_client::testing::common::ACCOUNT_ID_REGULAR;
 use miden_client::{EMPTY_WORD, Felt, ONE, ZERO};
 use miden_protocol::account::AccountComponentMetadata;
@@ -43,6 +43,7 @@ use rusqlite::params;
 use crate::SqliteStore;
 use crate::sql_error::SqlResultExt;
 use crate::tests::create_test_store;
+use crate::transaction::with_forest_snapshot;
 
 #[tokio::test]
 async fn account_code_insertion_no_duplicates() -> anyhow::Result<()> {
@@ -1870,6 +1871,175 @@ async fn undo_after_update_removes_genuinely_new_entries() -> anyhow::Result<()>
         .await?
         .expect("account should exist after undo");
     assert_eq!(header.nonce().as_canonical_u64(), 0);
+
+    Ok(())
+}
+
+// SMT FOREST SNAPSHOT ROLLBACK
+// ================================================================================================
+
+/// Builds a non-trivial delta over a freshly inserted account: a value-slot write, a map-slot
+/// write, and a vault addition. Sufficient to drive `stage_roots` + multiple SMT mutations in
+/// `apply_account_delta`.
+fn build_delta_for_snapshot_test(
+    account: &Account,
+    value_slot_name: StorageSlotName,
+    map_slot_name: StorageSlotName,
+) -> anyhow::Result<(AccountDelta, Account)> {
+    let mut storage_delta = AccountStorageDelta::new();
+    storage_delta.set_item(value_slot_name, [ZERO, ZERO, ZERO, ONE].into())?;
+    storage_delta.set_map_item(
+        map_slot_name,
+        StorageMapKey::new([ONE, ZERO, ZERO, ZERO].into()),
+        [ONE, ONE, ONE, ONE].into(),
+    )?;
+
+    let vault_delta = AccountVaultDelta::from_iters(
+        vec![
+            FungibleAsset::new(AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET)?, 100)?
+                .into(),
+        ],
+        [],
+    );
+
+    let delta = AccountDelta::new(account.id(), storage_delta, vault_delta, ONE)?;
+
+    let mut account_after_delta = account.clone();
+    account_after_delta.apply_delta(&delta)?;
+    Ok((delta, account_after_delta))
+}
+
+async fn insert_account_with_storage_for_snapshot_test()
+-> anyhow::Result<(SqliteStore, Account, StorageSlotName, StorageSlotName)> {
+    let store = create_test_store().await;
+
+    let value_slot_name =
+        StorageSlotName::new("miden::testing::sqlite_store::value").expect("valid slot name");
+    let map_slot_name =
+        StorageSlotName::new("miden::testing::sqlite_store::map").expect("valid slot name");
+
+    let dummy_component = AccountComponent::new(
+        basic_wallet_library(),
+        vec![
+            StorageSlot::with_empty_value(value_slot_name.clone()),
+            StorageSlot::with_empty_map(map_slot_name.clone()),
+        ],
+        AccountComponentMetadata::new("miden::testing::dummy_component", AccountType::all()),
+    )?;
+
+    let account = AccountBuilder::new([0; 32])
+        .account_type(AccountType::RegularAccountImmutableCode)
+        .with_auth_component(AuthSingleSig::new(
+            PublicKeyCommitment::from(EMPTY_WORD),
+            AuthSchemeId::Falcon512Poseidon2,
+        ))
+        .with_component(dummy_component)
+        .build_with_schema_commitment()?;
+
+    let default_address = Address::new(account.id());
+    store
+        .insert_account(&account, default_address, ClientAccountType::Native)
+        .await?;
+
+    Ok((store, account, value_slot_name, map_slot_name))
+}
+
+/// `with_forest_snapshot` must leave the in-memory `AccountSmtForest` unchanged when the
+/// closure returns an error, even after `apply_account_delta` has already mutated the
+/// working clone (vault tree, storage map tree, and staged roots).
+#[tokio::test]
+async fn with_forest_snapshot_leaves_forest_unchanged_on_error() -> anyhow::Result<()> {
+    let (store, account, value_slot_name, map_slot_name) =
+        insert_account_with_storage_for_snapshot_test().await?;
+
+    let (delta, account_after_delta) =
+        build_delta_for_snapshot_test(&account, value_slot_name, map_slot_name)?;
+    let final_state: AccountHeader = (&account_after_delta).into();
+
+    let forest_arc = store.smt_forest.clone();
+    let forest_before = forest_arc.read().expect("read lock").clone();
+
+    let init_header: AccountHeader = (&account).into();
+    let smt_forest = forest_arc.clone();
+    let outcome = store
+        .interact_with_connection(move |conn| {
+            with_forest_snapshot(conn, &smt_forest, |tx, forest| {
+                SqliteStore::apply_account_delta(
+                    tx,
+                    forest,
+                    &init_header,
+                    &final_state,
+                    BTreeMap::default(),
+                    &BTreeMap::new(),
+                    &delta,
+                )?;
+                Err::<(), _>(StoreError::DatabaseError("forced rollback".to_string()))
+            })
+        })
+        .await;
+
+    assert!(matches!(outcome, Err(StoreError::DatabaseError(_))));
+
+    let forest_after = forest_arc.read().expect("read lock").clone();
+    assert_eq!(
+        forest_after, forest_before,
+        "forest must be unchanged after a failed closure"
+    );
+
+    // The DB transaction was rolled back too — account state is still at nonce 0.
+    let (header, _) = store
+        .interact_with_connection(move |conn| SqliteStore::get_account_header(conn, account.id()))
+        .await?
+        .expect("account header present");
+    assert_eq!(header.nonce().as_canonical_u64(), 0);
+
+    Ok(())
+}
+
+/// `with_forest_snapshot` must NOT touch the forest when the closure returns `Ok` and the
+/// SQL commit succeeds. Mutations made inside the closure persist.
+#[tokio::test]
+async fn with_forest_snapshot_persists_forest_on_success() -> anyhow::Result<()> {
+    let (store, account, value_slot_name, map_slot_name) =
+        insert_account_with_storage_for_snapshot_test().await?;
+
+    let (delta, account_after_delta) =
+        build_delta_for_snapshot_test(&account, value_slot_name, map_slot_name)?;
+    let final_state: AccountHeader = (&account_after_delta).into();
+
+    let forest_arc = store.smt_forest.clone();
+    let forest_before = forest_arc.read().expect("read lock").clone();
+
+    let init_header: AccountHeader = (&account).into();
+    let account_id = account.id();
+    let smt_forest = forest_arc.clone();
+    store
+        .interact_with_connection(move |conn| {
+            with_forest_snapshot(conn, &smt_forest, |tx, forest| {
+                SqliteStore::apply_account_delta(
+                    tx,
+                    forest,
+                    &init_header,
+                    &final_state,
+                    BTreeMap::default(),
+                    &BTreeMap::new(),
+                    &delta,
+                )
+            })
+        })
+        .await?;
+
+    let forest_after = forest_arc.read().expect("read lock").clone();
+    assert_ne!(
+        forest_after, forest_before,
+        "forest must reflect the staged delta after a successful closure"
+    );
+
+    let (header, _) = store
+        .interact_with_connection(move |conn| SqliteStore::get_account_header(conn, account_id))
+        .await?
+        .expect("account header present");
+    assert_eq!(header.nonce().as_canonical_u64(), 1);
 
     Ok(())
 }

--- a/crates/sqlite-store/src/account/tests.rs
+++ b/crates/sqlite-store/src/account/tests.rs
@@ -1983,7 +1983,7 @@ async fn with_forest_snapshot_leaves_forest_unchanged_on_error() -> anyhow::Resu
     let forest_after = forest_arc.read().expect("read lock").clone();
     assert_eq!(forest_after, forest_before, "forest must be unchanged after a failed closure");
 
-    // The DB transaction was rolled back too — account state is still at nonce 0.
+    // The DB transaction was rolled back too; account state is still at nonce 0.
     let (header, _) = store
         .interact_with_connection(move |conn| SqliteStore::get_account_header(conn, account.id()))
         .await?

--- a/crates/sqlite-store/src/sync.rs
+++ b/crates/sqlite-store/src/sync.rs
@@ -21,7 +21,7 @@ use rusqlite::{Connection, Transaction, params};
 use super::SqliteStore;
 use crate::note::apply_note_updates_tx;
 use crate::sql_error::SqlResultExt;
-use crate::transaction::upsert_transaction_record;
+use crate::transaction::{upsert_transaction_record, with_forest_snapshot};
 use crate::{insert_sql, subst};
 
 impl SqliteStore {
@@ -116,92 +116,96 @@ impl SqliteStore {
             account_updates,
         } = state_sync_update;
 
-        let tx = conn.transaction().into_store_error()?;
+        with_forest_snapshot(conn, smt_forest, |tx, smt_forest| {
+            // Update blockchain checkpoint (block number and peaks) only if moving forward.
+            let new_peaks_bytes = partial_blockchain_updates.new_peaks.peaks().to_vec().to_bytes();
+            const BLOCKCHAIN_CHECKPOINT_QUERY: &str = "UPDATE blockchain_checkpoint SET block_num = ?, partial_blockchain_peaks = ? WHERE block_num < ?";
+            tx.execute(
+                BLOCKCHAIN_CHECKPOINT_QUERY,
+                params![
+                    i64::from(block_num.as_u32()),
+                    new_peaks_bytes,
+                    i64::from(block_num.as_u32())
+                ],
+            )
+            .into_store_error()?;
 
-        // Update blockchain checkpoint (block number and peaks) only if moving forward.
-        let new_peaks_bytes = partial_blockchain_updates.new_peaks.peaks().to_vec().to_bytes();
-        const BLOCKCHAIN_CHECKPOINT_QUERY: &str = "UPDATE blockchain_checkpoint SET block_num = ?, partial_blockchain_peaks = ? WHERE block_num < ?";
-        tx.execute(
-            BLOCKCHAIN_CHECKPOINT_QUERY,
-            params![i64::from(block_num.as_u32()), new_peaks_bytes, i64::from(block_num.as_u32())],
-        )
-        .into_store_error()?;
-
-        for (block_header, block_has_relevant_notes) in partial_blockchain_updates.block_headers() {
-            Self::insert_block_header_tx(&tx, block_header, *block_has_relevant_notes)?;
-        }
-
-        // Insert new authentication nodes (inner nodes of the PartialBlockchain)
-        Self::insert_partial_blockchain_nodes_tx(
-            &tx,
-            partial_blockchain_updates.new_authentication_nodes(),
-        )?;
-
-        // Update notes
-        apply_note_updates_tx(&tx, &note_updates)?;
-
-        // Remove tags
-        let tags_to_remove = note_updates
-            .updated_input_notes()
-            .filter_map(|note_update| {
-                let note = note_update.inner();
-                if note.is_committed() {
-                    Some(NoteTagRecord {
-                        tag: note.metadata().expect("Committed notes should have metadata").tag(),
-                        source: NoteTagSource::Note(note.id()),
-                    })
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
-
-        for tag in tags_to_remove {
-            remove_note_tag_tx(&tx, tag)?;
-        }
-
-        for transaction_record in transaction_updates
-            .committed_transactions()
-            .chain(transaction_updates.discarded_transactions())
-        {
-            upsert_transaction_record(&tx, transaction_record)?;
-        }
-
-        // Remove the accounts that are originated from the discarded transactions
-        let discarded_states: Vec<(AccountId, Word)> = transaction_updates
-            .discarded_transactions()
-            .map(|tx| (tx.details.account_id, tx.details.final_account_state))
-            .collect();
-
-        let mut smt_forest = smt_forest.write().expect("smt_forest write lock not poisoned");
-        Self::undo_account_state(&tx, &mut smt_forest, &discarded_states)?;
-
-        // For committed transactions, release the old staged roots.
-        for committed_tx in transaction_updates.committed_transactions() {
-            smt_forest.commit_roots(committed_tx.details.account_id);
-        }
-
-        // Update public accounts on the db that have been updated onchain
-        for update in account_updates.updated_public_accounts() {
-            match update {
-                PublicAccountUpdate::Full(account) => {
-                    Self::update_account_state(&tx, &mut smt_forest, account)?;
-                },
-                PublicAccountUpdate::Delta(delta) => {
-                    Self::apply_public_account_delta(&tx, &mut smt_forest, delta)?;
-                },
+            for (block_header, block_has_relevant_notes) in
+                partial_blockchain_updates.block_headers()
+            {
+                Self::insert_block_header_tx(tx, block_header, *block_has_relevant_notes)?;
             }
-        }
-        drop(smt_forest);
 
-        for (account_id, digest) in account_updates.mismatched_private_accounts() {
-            Self::lock_account_on_unexpected_commitment(&tx, account_id, digest)?;
-        }
+            // Insert new authentication nodes (inner nodes of the PartialBlockchain)
+            Self::insert_partial_blockchain_nodes_tx(
+                tx,
+                partial_blockchain_updates.new_authentication_nodes(),
+            )?;
 
-        // Commit the updates
-        tx.commit().into_store_error()?;
+            // Update notes
+            apply_note_updates_tx(tx, &note_updates)?;
 
-        Ok(())
+            // Remove tags
+            let tags_to_remove = note_updates
+                .updated_input_notes()
+                .filter_map(|note_update| {
+                    let note = note_update.inner();
+                    if note.is_committed() {
+                        Some(NoteTagRecord {
+                            tag: note
+                                .metadata()
+                                .expect("Committed notes should have metadata")
+                                .tag(),
+                            source: NoteTagSource::Note(note.id()),
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>();
+
+            for tag in tags_to_remove {
+                remove_note_tag_tx(tx, tag)?;
+            }
+
+            for transaction_record in transaction_updates
+                .committed_transactions()
+                .chain(transaction_updates.discarded_transactions())
+            {
+                upsert_transaction_record(tx, transaction_record)?;
+            }
+
+            // Remove the accounts that are originated from the discarded transactions
+            let discarded_states: Vec<(AccountId, Word)> = transaction_updates
+                .discarded_transactions()
+                .map(|tx| (tx.details.account_id, tx.details.final_account_state))
+                .collect();
+
+            Self::undo_account_state(tx, smt_forest, &discarded_states)?;
+
+            // For committed transactions, release the old staged roots.
+            for committed_tx in transaction_updates.committed_transactions() {
+                smt_forest.commit_roots(committed_tx.details.account_id);
+            }
+
+            // Update public accounts on the db that have been updated onchain
+            for update in account_updates.updated_public_accounts() {
+                match update {
+                    PublicAccountUpdate::Full(account) => {
+                        Self::update_account_state(tx, smt_forest, account)?;
+                    },
+                    PublicAccountUpdate::Delta(delta) => {
+                        Self::apply_public_account_delta(tx, smt_forest, delta)?;
+                    },
+                }
+            }
+
+            for (account_id, digest) in account_updates.mismatched_private_accounts() {
+                Self::lock_account_on_unexpected_commitment(tx, account_id, digest)?;
+            }
+
+            Ok(())
+        })
     }
 
     /// Reads the local account state, derives the [`AccountDelta`] from `delta`'s incremental

--- a/crates/sqlite-store/src/transaction.rs
+++ b/crates/sqlite-store/src/transaction.rs
@@ -138,6 +138,11 @@ impl SqliteStore {
     /// Applies a transaction's store update within the provided rusqlite transaction.
     /// Does NOT commit — caller is responsible for commit/rollback.
     ///
+    /// `smt_forest` must be a working snapshot (such as the clone handed out by
+    /// [`with_forest_snapshot`]), never the live forest: this stages root mutations into it
+    /// and provides no rollback of its own, relying on the caller to discard the snapshot on
+    /// error.
+    ///
     /// Pre-reads (fungible assets and storage map roots) are performed via the transaction so
     /// that each call sees writes made by prior calls within the same outer transaction.
     pub(crate) fn apply_transaction_in_txn(
@@ -223,7 +228,7 @@ impl SqliteStore {
 ///
 /// Cost: the clone is `AccountSmtForest::clone()`, which deep-clones the entire
 /// `SmtForest` (every tracked SMT plus root refcounts). This is O(forest size) per call
-/// and runs on every transaction apply and sync round — acceptable today but worth
+/// and runs on every transaction apply and sync round - acceptable today but worth
 /// revisiting (e.g. an inverse-op journal) if the forest grows large.
 pub(crate) fn with_forest_snapshot<F, T>(
     conn: &mut Connection,

--- a/crates/sqlite-store/src/transaction.rs
+++ b/crates/sqlite-store/src/transaction.rs
@@ -104,32 +104,35 @@ impl SqliteStore {
     }
 
     /// Inserts a transaction and updates the current state based on the `tx_result` changes.
+    ///
+    /// SQL writes and `AccountSmtForest` mutations are committed atomically: on any error
+    /// (including commit failure) the rusqlite transaction is rolled back and the in-memory
+    /// forest is left unchanged.
     pub fn apply_transaction(
         conn: &mut Connection,
         smt_forest: &Arc<RwLock<AccountSmtForest>>,
         tx_update: &TransactionStoreUpdate,
     ) -> Result<(), StoreError> {
-        let mut db_tx = conn.transaction().into_store_error()?;
-        Self::apply_transaction_in_txn(&mut db_tx, smt_forest, tx_update)?;
-        db_tx.commit().into_store_error()?;
-
-        Ok(())
+        with_forest_snapshot(conn, smt_forest, |db_tx, forest| {
+            Self::apply_transaction_in_txn(db_tx, forest, tx_update)
+        })
     }
 
     /// Applies a batch of [`TransactionStoreUpdate`]s atomically. Either every update in the
     /// slice is persisted or none are. Executes in order inside a single
-    /// [`rusqlite::Transaction`]; on any error the transaction is rolled back automatically.
+    /// [`rusqlite::Transaction`]; on any error the transaction is rolled back automatically
+    /// and the in-memory `AccountSmtForest` is left unchanged.
     pub fn apply_transaction_batch(
         conn: &mut Connection,
         smt_forest: &Arc<RwLock<AccountSmtForest>>,
         tx_updates: &[TransactionStoreUpdate],
     ) -> Result<(), StoreError> {
-        let mut db_tx = conn.transaction().into_store_error()?;
-        for update in tx_updates {
-            Self::apply_transaction_in_txn(&mut db_tx, smt_forest, update)?;
-        }
-        db_tx.commit().into_store_error()?;
-        Ok(())
+        with_forest_snapshot(conn, smt_forest, |db_tx, forest| {
+            for update in tx_updates {
+                Self::apply_transaction_in_txn(db_tx, forest, update)?;
+            }
+            Ok(())
+        })
     }
 
     /// Applies a transaction's store update within the provided rusqlite transaction.
@@ -139,7 +142,7 @@ impl SqliteStore {
     /// that each call sees writes made by prior calls within the same outer transaction.
     pub(crate) fn apply_transaction_in_txn(
         db_tx: &mut Transaction<'_>,
-        smt_forest: &Arc<RwLock<AccountSmtForest>>,
+        smt_forest: &mut AccountSmtForest,
         tx_update: &TransactionStoreUpdate,
     ) -> Result<(), StoreError> {
         let executed_transaction = tx_update.executed_transaction();
@@ -188,17 +191,15 @@ impl SqliteStore {
         upsert_transaction_record(db_tx, &transaction_record)?;
 
         // Account Data
-        let mut smt_forest = smt_forest.write().expect("smt_forest write lock not poisoned");
         Self::apply_account_delta(
             db_tx,
-            &mut smt_forest,
+            smt_forest,
             &executed_transaction.initial_account().into(),
             executed_transaction.final_account(),
             updated_fungible_assets,
             &old_map_roots,
             executed_transaction.account_delta(),
         )?;
-        drop(smt_forest);
 
         // Note Updates
         apply_note_updates_tx(db_tx, tx_update.note_updates())?;
@@ -210,6 +211,39 @@ impl SqliteStore {
 
         Ok(())
     }
+}
+
+/// Runs `f` inside a SQL transaction with the SMT forest write lock held, mutating a
+/// working clone of the forest and only swapping it into the live `RwLock` after the SQL
+/// commit succeeds.
+///
+/// Guarantees that the in-memory `AccountSmtForest` stays in sync with the `SQLite` store:
+/// either both are advanced atomically, or neither is. On any error path (`?` from `f`,
+/// commit failure) the live forest is untouched because mutations target the clone.
+///
+/// Cost: the clone is `AccountSmtForest::clone()`, which deep-clones the entire
+/// `SmtForest` (every tracked SMT plus root refcounts). This is O(forest size) per call
+/// and runs on every transaction apply and sync round — acceptable today but worth
+/// revisiting (e.g. an inverse-op journal) if the forest grows large.
+pub(crate) fn with_forest_snapshot<F, T>(
+    conn: &mut Connection,
+    smt_forest: &Arc<RwLock<AccountSmtForest>>,
+    f: F,
+) -> Result<T, StoreError>
+where
+    F: FnOnce(&mut Transaction<'_>, &mut AccountSmtForest) -> Result<T, StoreError>,
+{
+    let mut db_tx = conn.transaction().into_store_error()?;
+    let mut forest = smt_forest
+        .write()
+        .map_err(|_| StoreError::DatabaseError("smt_forest write lock poisoned".to_string()))?;
+    let mut working_forest = forest.clone();
+
+    let value = f(&mut db_tx, &mut working_forest)?;
+    db_tx.commit().into_store_error()?;
+
+    *forest = working_forest;
+    Ok(value)
 }
 
 /// Updates the transaction record in the database, inserting it if it doesn't exist.

--- a/crates/sqlite-store/src/transaction.rs
+++ b/crates/sqlite-store/src/transaction.rs
@@ -218,18 +218,14 @@ impl SqliteStore {
     }
 }
 
-/// Runs `f` inside a SQL transaction with the SMT forest write lock held, mutating a
-/// working clone of the forest and only swapping it into the live `RwLock` after the SQL
-/// commit succeeds.
+/// Runs `f` inside a SQL transaction with the forest write lock held, mutating a working
+/// clone and swapping it into the live `RwLock` only after the SQL commit succeeds. This
+/// keeps the `AccountSmtForest` and the `SQLite` store atomic: on any error (`?` from `f`
+/// or commit failure) the live forest is untouched, since all mutations target the clone.
 ///
-/// Guarantees that the in-memory `AccountSmtForest` stays in sync with the `SQLite` store:
-/// either both are advanced atomically, or neither is. On any error path (`?` from `f`,
-/// commit failure) the live forest is untouched because mutations target the clone.
-///
-/// Cost: the clone is `AccountSmtForest::clone()`, which deep-clones the entire
-/// `SmtForest` (every tracked SMT plus root refcounts). This is O(forest size) per call
-/// and runs on every transaction apply and sync round - acceptable today but worth
-/// revisiting (e.g. an inverse-op journal) if the forest grows large.
+/// Cost: `AccountSmtForest::clone()` deep-clones the whole `SmtForest` (every tracked SMT
+/// plus root refcounts), so this is O(forest size) per call. Acceptable now; revisit (e.g.
+/// an inverse-op journal) if the forest grows large.
 pub(crate) fn with_forest_snapshot<F, T>(
     conn: &mut Connection,
     smt_forest: &Arc<RwLock<AccountSmtForest>>,

--- a/crates/testing/miden-client-tests/src/tests/batch.rs
+++ b/crates/testing/miden-client-tests/src/tests/batch.rs
@@ -147,17 +147,6 @@ async fn batch_builder_submits_two_txs_on_one_account() {
 /// in-memory `AccountSmtForest`: if any per-tx update in the batch fails, no earlier update
 /// is persisted, and a follow-up `Store::update_account` on the affected account still
 /// works.
-///
-/// Setup: build a 2-account mock chain, create a client backed by it, register only account A
-/// with the client. Both accounts have committed state on the mock chain, so we can execute
-/// a valid transaction against each. Because B was never added to the client's store, its
-/// roots aren't in the store's `AccountSmtForest`, so `apply_account_delta` fails for B's
-/// update with `StoreError::AccountDataNotFound`. The test asserts that A's earlier update
-/// was rolled back (no transactions in the store, A's commitment unchanged) and then calls
-/// `update_account` for A: this path runs `replace_roots`, which asserts that no staged
-/// updates are pending for the account. Without the forest rollback the failed batch would
-/// leave A's old roots in `pending_old_roots`, and the `replace_roots` assertion would
-/// panic; with the rollback the forest is clean and the call succeeds.
 #[tokio::test]
 async fn apply_transaction_batch_rolls_back_on_mid_batch_failure() {
     // Build a fresh mock chain with two existing accounts.
@@ -189,7 +178,7 @@ async fn apply_transaction_batch_rolls_back_on_mid_batch_failure() {
     client.add_account(&account_a, false).await.unwrap();
 
     // Execute a trivial transaction against A and another against B, both via the mock chain.
-    // Both produce valid `ExecutedTransaction`s — the failure happens only at store-apply time.
+    // Both produce valid `ExecutedTransaction`s; the failure happens only at store-apply time.
     // Build each `TxContext` in its own statement so the mock-chain read guard is dropped
     // before `.execute().await` is reached (otherwise clippy flags await_holding_lock).
     let tx_ctx_a = rpc_api

--- a/crates/testing/miden-client-tests/src/tests/batch.rs
+++ b/crates/testing/miden-client-tests/src/tests/batch.rs
@@ -143,15 +143,21 @@ async fn batch_builder_submits_two_txs_on_one_account() {
     );
 }
 
-/// Verifies that `Store::apply_transaction_batch` is atomic: if any per-tx update in the batch
-/// fails, no earlier update is persisted.
+/// Verifies that `Store::apply_transaction_batch` is atomic across the SQL store AND the
+/// in-memory `AccountSmtForest`: if any per-tx update in the batch fails, no earlier update
+/// is persisted, and a follow-up `Store::update_account` on the affected account still
+/// works.
 ///
 /// Setup: build a 2-account mock chain, create a client backed by it, register only account A
 /// with the client. Both accounts have committed state on the mock chain, so we can execute
 /// a valid transaction against each. Because B was never added to the client's store, its
-/// roots aren't in the store's `AccountSmtForest` — `apply_account_delta` will fail for B's
-/// update with `StoreError::AccountDataNotFound`. Asserts that A's earlier update was also
-/// rolled back (no transactions in the store, account A unchanged).
+/// roots aren't in the store's `AccountSmtForest`, so `apply_account_delta` fails for B's
+/// update with `StoreError::AccountDataNotFound`. The test asserts that A's earlier update
+/// was rolled back (no transactions in the store, A's commitment unchanged) and then calls
+/// `update_account` for A: this path runs `replace_roots`, which asserts that no staged
+/// updates are pending for the account. Without the forest rollback the failed batch would
+/// leave A's old roots in `pending_old_roots`, and the `replace_roots` assertion would
+/// panic; with the rollback the forest is clean and the call succeeds.
 #[tokio::test]
 async fn apply_transaction_batch_rolls_back_on_mid_batch_failure() {
     // Build a fresh mock chain with two existing accounts.
@@ -248,6 +254,15 @@ async fn apply_transaction_batch_rolls_back_on_mid_batch_failure() {
         a_commitment_before,
         "account A state must be unchanged after atomic rollback"
     );
+
+    // Forest rollback check. `update_account_state` calls `replace_roots`, which asserts
+    // that the forest has no staged-but-uncommitted roots for the account. Without the
+    // forest rollback, the failed batch above would have left A's previous roots sitting
+    // in `pending_old_roots`, and this call would trip the assertion.
+    store
+        .update_account(&account_a)
+        .await
+        .expect("update_account on A must succeed after the failed batch was rolled back");
 }
 
 /// `BatchBuilder::push` must validate each transaction against the in-batch (stacked)


### PR DESCRIPTION
If an operation that mutates the DB and SMT Forest rolls back we were only rolling back the DB and not the SMT Forest, that left it in a corrupt state in which we then couldn't keep on working with it without issues.

This PR basically implements a `with_forest_snapshot` function that we use for wrapping the other DB methods that touch the SMT forest in order to ensure that the SMT Forest rollbacks are handled properly. We could've implemented another solution instead of that wrapper but the good thing of it is that there's no need to handle SMT Forest rollback logic in every place, so it avoids a potential footgun compared to other methods that may look "prettier" in code. I found this to have a good balance between robustness and code quality/clarity.

As an additional related fix in the methods `get_account_asset` and `get_account_map_item` we now lock the SMT Forest before getting the account header just in order to avoid undesired concurrent writes to the forest while we fetch the header.

Closes #2181