### PR TITLE
fix(rust-client): recover private notes committed beyond the NTL lookback window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Bumped `miden-vm` workspace dependencies from 0.22.1 to 0.22.4.
 
+### Fixes
+
+* [FIX][rust] Private notes committed on-chain are no longer silently lost when their Note Transport Layer delivery lags beyond the import lookback window. `Client::sync_state` now reconciles every `Expected` input note against the chain by note ID — independent of any block window — applying the inclusion proof once committed, and retried on every sync so late delivery and transient failures are self-healing ([#2212](https://github.com/0xMiden/miden-client/pull/2212)).
+
 ## 0.14.7 (2026-06-05)
 
 ### Enhancements

--- a/crates/rust-client/src/note/import.rs
+++ b/crates/rust-client/src/note/import.rs
@@ -136,6 +136,72 @@ where
         Ok(imported_note_ids)
     }
 
+    /// Re-verifies every `Expected` input note against the chain by note ID, independent of any
+    /// block-lookback window.
+    ///
+    /// A private note delivered through the note transport layer (or imported manually via
+    /// [`NoteFile::NoteDetails`]) is stored as `Expected` until its on-chain commitment is
+    /// confirmed. The windowed scan in `Client::fetch_transport_notes` only looks a fixed number of
+    /// blocks back from the current sync height, so it can miss a commitment that predates the
+    /// window when transport delivery lags far behind the commitment block. Because chain sync only
+    /// reports notes committed in newly synced blocks, such a note would otherwise never be
+    /// confirmed and the funds would be silently lost.
+    ///
+    /// This reconciliation closes that gap: it fetches each expected note by ID (the node returns
+    /// the inclusion proof regardless of block height) and, when committed, applies the inclusion
+    /// proof and block header so the note transitions to `Committed`. Notes that are not yet
+    /// committed are left untouched and retried on the next sync, so transient failures are
+    /// self-healing.
+    pub(crate) async fn reconcile_expected_notes(&self) -> Result<(), ClientError> {
+        let expected_notes = self.get_input_notes(NoteFilter::Expected).await?;
+        if expected_notes.is_empty() {
+            return Ok(());
+        }
+
+        let note_ids: Vec<NoteId> = expected_notes.iter().map(InputNoteRecord::id).collect();
+        let fetched_notes = self.rpc_api.get_notes_by_id(&note_ids).await?;
+
+        let mut proofs: BTreeMap<NoteId, (NoteMetadata, NoteInclusionProof)> = BTreeMap::new();
+        for fetched_note in fetched_notes {
+            let (note_id, metadata, inclusion_proof) = match fetched_note {
+                FetchedNote::Private(header, inclusion_proof) => {
+                    (header.id(), header.metadata().clone(), inclusion_proof)
+                },
+                FetchedNote::Public(note, inclusion_proof) => {
+                    (note.id(), note.metadata().clone(), inclusion_proof)
+                },
+            };
+            proofs.insert(note_id, (metadata, inclusion_proof));
+        }
+
+        for mut note_record in expected_notes {
+            let Some((metadata, inclusion_proof)) = proofs.remove(&note_record.id()) else {
+                // Not yet committed on-chain; leave as Expected and retry on the next sync.
+                continue;
+            };
+
+            let block_num = inclusion_proof.location().block_num();
+            let mut current_partial_mmr = self.store.get_current_partial_mmr().await?;
+            let block_header = self
+                .get_and_store_authenticated_block(block_num, &mut current_partial_mmr)
+                .await?;
+
+            let tag = metadata.tag();
+            let mut note_changed =
+                note_record.inclusion_proof_received(inclusion_proof, metadata)?;
+            note_changed |= note_record.block_header_received(&block_header)?;
+
+            if note_changed {
+                self.store
+                    .remove_note_tag(NoteTagRecord::with_note_source(tag, note_record.id()))
+                    .await?;
+                self.store.upsert_input_notes(&[note_record]).await?;
+            }
+        }
+
+        Ok(())
+    }
+
     // HELPERS
     // ================================================================================================
 

--- a/crates/rust-client/src/note/import.rs
+++ b/crates/rust-client/src/note/import.rs
@@ -174,6 +174,7 @@ where
             proofs.insert(note_id, (metadata, inclusion_proof));
         }
 
+        let current_block_num = self.get_sync_height().await?;
         for mut note_record in expected_notes {
             let Some((metadata, inclusion_proof)) = proofs.remove(&note_record.id()) else {
                 // Not yet committed on-chain; leave as Expected and retry on the next sync.
@@ -181,6 +182,13 @@ where
             };
 
             let block_num = inclusion_proof.location().block_num();
+            // Only authenticate commitments at or behind the synced chain tip; the local partial
+            // MMR forest doesn't include blocks ahead of the sync height. A note committed in a
+            // block we haven't synced to yet is left Expected and reconciled on a later sync.
+            if block_num > current_block_num {
+                continue;
+            }
+
             let mut current_partial_mmr = self.store.get_current_partial_mmr().await?;
             let block_header = self
                 .get_and_store_authenticated_block(block_num, &mut current_partial_mmr)

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -128,6 +128,12 @@ where
             let cursor = self.store.get_note_transport_cursor().await?;
             let note_tags = self.store.get_unique_note_tags().await?;
             self.fetch_transport_notes(cursor, note_tags).await?;
+
+            // Reconcile expected notes against the chain by note ID. This confirms private notes
+            // whose on-chain commitment predates the transport-import lookback window (which would
+            // otherwise be silently lost); it is block-window independent and retried on every
+            // sync.
+            self.reconcile_expected_notes().await?;
         }
 
         // Build sync state components

--- a/crates/testing/miden-client-tests/src/tests/transport.rs
+++ b/crates/testing/miden-client-tests/src/tests/transport.rs
@@ -277,6 +277,120 @@ async fn fetch_private_notes_finds_note_committed_at_sync_height() {
     );
 }
 
+/// Reproduces RC-2 (silent private-note loss): when the NTL delivers a private note's details
+/// more than `NOTE_LOOKBACK_BLOCKS` (20) blocks after the note was committed on-chain, the
+/// fixed-size lookback in `fetch_transport_notes` scans `[sync_height - 20, sync_height]`, which
+/// no longer covers the note's commitment block. `check_expected_notes` finds nothing, the note
+/// stays Expected with no inclusion proof, and no later sync recovers it (the bound only ever
+/// moves forward). The note is permanently lost despite being committed on-chain.
+///
+/// This is the same shape as `fetch_private_notes_finds_note_committed_at_sync_height` but with
+/// the NTL delivery lagging beyond the lookback window — which matches the production signature
+/// under load (high NTL delivery latency: private-note p99 ~123s).
+#[tokio::test]
+async fn fetch_private_notes_finds_note_committed_beyond_lookback_window() {
+    // Lookback window used by `fetch_transport_notes` (kept in sync with the production constant).
+    const NOTE_LOOKBACK_BLOCKS: u32 = 20;
+
+    // 1. Build a mock chain with a private note committed at block 1.
+    let mut mock_chain_builder = MockChainBuilder::new();
+    let mock_account = mock_chain_builder
+        .add_existing_mock_account(miden_testing::Auth::IncrNonce)
+        .unwrap();
+
+    let private_note =
+        NoteBuilder::new(mock_account.id(), RandomCoin::new([1, 2, 3, 4].map(Felt::new).into()))
+            .note_type(ProtocolNoteType::Private)
+            .tag(NoteTag::new(0).into())
+            .build()
+            .unwrap();
+
+    let spawn_note =
+        mock_chain_builder.add_spawn_note(std::slice::from_ref(&private_note)).unwrap();
+    let mut mock_chain = mock_chain_builder.build().unwrap();
+
+    // Block 1: commit the private note.
+    let tx = Box::pin(
+        mock_chain
+            .build_tx_context(TxContextInput::AccountId(mock_account.id()), &[], &[spawn_note])
+            .unwrap()
+            .extend_expected_output_notes(vec![RawOutputNote::Full(private_note.clone())])
+            .build()
+            .unwrap()
+            .execute(),
+    )
+    .await
+    .unwrap();
+    mock_chain.add_pending_executed_transaction(&tx).unwrap();
+    mock_chain.prove_next_block().unwrap();
+    let commitment_block = 1u32;
+
+    // Advance the chain well past `commitment_block + NOTE_LOOKBACK_BLOCKS` so the fixed-size
+    // lookback window can no longer reach the note's commitment block.
+    for _ in 0..(NOTE_LOOKBACK_BLOCKS + 10) {
+        mock_chain.prove_next_block().unwrap();
+    }
+
+    // 2. Create client with empty NTL (note not yet delivered).
+    let mock_transport_node = Arc::new(RwLock::new(MockNoteTransportNode::new()));
+
+    let rpc_api = MockRpcApi::new(mock_chain);
+    let arc_rpc_api = Arc::new(rpc_api);
+    let transport_client = MockNoteTransportApi::new(mock_transport_node.clone());
+
+    let mut rng = rand::rng();
+    let coin_seed: [u64; 4] = rng.random();
+    let rng = RandomCoin::new(coin_seed.map(Felt::new).into());
+
+    let keystore_path = temp_dir();
+    let keystore = FilesystemKeyStore::new(keystore_path.clone()).unwrap();
+
+    let builder: ClientBuilder<FilesystemKeyStore> = ClientBuilder::new()
+        .rpc(arc_rpc_api)
+        .rng(Box::new(rng))
+        .sqlite_store(create_test_store_path())
+        .authenticator(Arc::new(keystore))
+        .in_debug_mode(DebugMode::Enabled)
+        .tx_discard_delta(None)
+        .note_transport(Arc::new(transport_client));
+
+    let mut client = builder.build().await.unwrap();
+    client.ensure_genesis_in_place().await.unwrap();
+
+    // 3. Register tag 0 so chain sync sees the note's block.
+    client.add_note_tag(NoteTag::new(0)).await.unwrap();
+
+    // 4. Sync to chain tip. The NTL is empty so no transport notes are imported.
+    client.sync_state().await.unwrap();
+    let sync_height = client.get_sync_height().await.unwrap();
+    assert!(
+        sync_height.as_u32() > commitment_block + NOTE_LOOKBACK_BLOCKS,
+        "precondition: sync_height ({}) must be more than {} blocks past the commitment block ({})",
+        sync_height.as_u32(),
+        NOTE_LOOKBACK_BLOCKS,
+        commitment_block,
+    );
+
+    // 5. Now the NTL delivers the note (simulates delivery lagging beyond the lookback window).
+    let details = NoteDetails::from(private_note.clone());
+    let details_bytes = details.to_bytes();
+    mock_transport_node
+        .write()
+        .add_note(private_note.header().clone(), details_bytes);
+
+    // 6. Second sync_state: fetch_transport_notes imports the note, but the lookback window
+    // `[sync_height - 20, sync_height]` no longer covers the commitment block, so the note's
+    // inclusion proof is never retrieved.
+    client.sync_state().await.unwrap();
+
+    // 7. The note must still become Committed — it is on-chain and the client knows its details.
+    let committed_notes = client.get_input_notes(NoteFilter::Committed).await.unwrap();
+    assert!(
+        committed_notes.iter().any(|n| n.id() == private_note.id()),
+        "note committed beyond the lookback window must still be found (RC-2 silent private-note loss)"
+    );
+}
+
 // HELPERS
 // ================================================================================================
 


### PR DESCRIPTION
## Summary

Closes #2211. Fixes a silent loss of private notes on the **receiver** side: a note whose transaction has committed on-chain never becomes spendable in the recipient's wallet, with no error surfaced. Private-note only — public notes are unaffected.

## Root cause

Private note details are delivered out-of-band via the Note Transport Layer (NTL). On `sync_state`, `fetch_transport_notes` imports the delivered note and then looks for its on-chain commitment using a **fixed lookback window**:

```rust
const NOTE_LOOKBACK_BLOCKS: u32 = 20;
let after_block_num = BlockNumber::from(sync_height.as_u32().saturating_sub(NOTE_LOOKBACK_BLOCKS));
```

`check_expected_notes` then scans only `[sync_height - 20, sync_height]`. If NTL delivery lags **more than 20 blocks** behind the commitment block — routine under load (observed private-note delivery p99 ≈ 123s) — the commitment is outside the window. The note is stored as `Expected` with no inclusion proof and **never recovers**, because chain sync only reports notes committed in *newly synced* blocks, and every later sync recomputes `after_block_num` from an even higher `sync_height`.

This matches the observed signature exactly: committed on-chain (`GetNotesById` returns the note with an inclusion proof), absent from the receiver's `inputNotes`, private-only, intermittent and load-dependent.

## Fix

`reconcile_expected_notes`, called from `sync_state` on the transport path, re-verifies every `Expected` input note against the chain **by note ID** (`get_notes_by_id`, independent of any block window). When committed, it applies the inclusion proof and block header so the note transitions to `Committed`; notes not yet committed are left untouched and retried on the next sync. This is durable by construction — it survives arbitrarily late delivery, the window cliff, and transient RPC failures (retried each sync) — and self-limiting, since notes leave `Expected` once committed.

## Relationship to #2127

Complementary, not a substitute. #2127 fixes the **sender** side (a failed `send_note` relay is no longer lost); this fixes the **receiver** side (a successfully-relayed note delivered late is dropped). Both produce the same loss signature, and #2127 can *increase* exposure here (durably-retried relays arrive later). Both are needed.

## Tests

- New deterministic repro `fetch_private_notes_finds_note_committed_beyond_lookback_window` — commits a private note, advances the chain past the 20-block window, then delivers via the NTL; fails on the unfixed code path, passes with the fix.
- The existing within-window race test (`fetch_private_notes_finds_note_committed_at_sync_height`) and the other transport tests remain green (6/6).

## Test plan

- [x] `cargo clippy -p miden-client --lib` clean
- [x] `cargo test -p miden-client-unit-tests --lib transport::` — 6 passed
- [x] `make format`
- [ ] CI full suite (the full local lib suite is unrelated/slow to run here; CI gates it)
