### PR TITLE
fix: satisfy newer nightly clippy (unused_async_trait_impl) across workspace

### DIFF
--- a/crates/rust-client/src/keystore/fs_keystore.rs
+++ b/crates/rust-client/src/keystore/fs_keystore.rs
@@ -1,6 +1,7 @@
 use alloc::boxed::Box;
 use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::string::String;
+use core::future::Future;
 use std::fs;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::io::Write;
@@ -229,23 +230,23 @@ impl TransactionAuthenticator for FilesystemKeyStore {
     /// # Errors
     /// If the public key isn't found in the store, [`AuthenticationError::UnknownPublicKey`] is
     /// returned.
-    async fn get_signature(
+    fn get_signature(
         &self,
         pub_key: PublicKeyCommitment,
         signing_info: &SigningInputs,
-    ) -> Result<Signature, AuthenticationError> {
+    ) -> impl Future<Output = Result<Signature, AuthenticationError>> {
         let message = signing_info.to_commitment();
+        let secret_key = self.get_key_sync(pub_key);
 
-        let secret_key = self
-            .get_key_sync(pub_key)
-            .map_err(|err| {
-                AuthenticationError::other_with_source("failed to load secret key", err)
-            })?
-            .ok_or(AuthenticationError::UnknownPublicKey(pub_key))?;
+        async move {
+            let secret_key = secret_key
+                .map_err(|err| {
+                    AuthenticationError::other_with_source("failed to load secret key", err)
+                })?
+                .ok_or(AuthenticationError::UnknownPublicKey(pub_key))?;
 
-        let signature = secret_key.sign(message);
-
-        Ok(signature)
+            Ok(secret_key.sign(message))
+        }
     }
 
     /// Retrieves a public key for a specific public key commitment.

--- a/crates/sqlite-store/src/db_management/pool_manager.rs
+++ b/crates/sqlite-store/src/db_management/pool_manager.rs
@@ -1,3 +1,4 @@
+use core::future::{Future, ready};
 use std::path::PathBuf;
 
 use deadpool::Runtime;
@@ -73,7 +74,11 @@ impl Manager for SqlitePoolManager {
         deadpool_sync::SyncWrapper::new(RUNTIME, move || conn).await
     }
 
-    async fn recycle(&self, _: &mut Self::Type, _: &Metrics) -> RecycleResult<Self::Error> {
-        Ok(())
+    fn recycle(
+        &self,
+        _: &mut Self::Type,
+        _: &Metrics,
+    ) -> impl Future<Output = RecycleResult<Self::Error>> {
+        ready(Ok(()))
     }
 }


### PR DESCRIPTION
## Summary

`make clippy` runs `cargo +nightly clippy --workspace --all-targets` (floating nightly). A newer nightly clippy rejects async trait-impl methods with no `.await` under `unused_async_trait_impl` / `-D warnings`. Two synchronous trait-impl methods now trip it, **breaking CI Clippy on every open PR** (unrelated to whatever each PR changes). `main`'s green Clippy is just stale (last ran on an older nightly).

Fixes:
- `FilesystemKeyStore::get_signature` (rust-client) — signs synchronously.
- `SqlitePoolManager::recycle` (sqlite-store) — deadpool `Manager::recycle`, a no-op.

## Fix

Desugar both from `async fn` to a regular `fn` returning `impl Future`. For `get_signature` the synchronous key lookup runs eagerly, wrapped in `async move`. For `recycle`, returning an async block would instead trip `manual_async_fn`, so it returns a concrete `core::future::ready(...)`. **No behavior change** in either.

## Verification

- `cargo +nightly clippy --workspace --features "testing std" --all-targets -- -D warnings` — exit 0, zero errors (verified on nightly 1.98.0 2026-06-01, matching CI)
- No CHANGELOG entry: internal lint fix, not user-visible ("no changelog" label applied).