### PR TITLE
refactor(client): reject output notes with a foreign sender during request validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 * [FIX] Fixed `derive_account_commitments` to return the final account commitment when multiple transactions for the same account are committed in the same block ([#2164](https://github.com/0xMiden/miden-client/pull/2164)).
+* [FIX][rust] Transaction requests whose output notes declare a sender other than the executing account are now rejected up front during request validation with a clear `TransactionRequestError::OutputNoteSenderMismatch`, instead of failing late inside transaction script building (the late failure surfaced as a cryptic `account interface error: invalid sender account` and could leave wallet integrations stuck retrying). ([#89](https://github.com/0xMiden/wallet-adapter/issues/89))
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 * [FIX] Fixed `derive_account_commitments` to return the final account commitment when multiple transactions for the same account are committed in the same block ([#2164](https://github.com/0xMiden/miden-client/pull/2164)).
-* [FIX][rust] Transaction requests whose output notes declare a sender other than the executing account are now rejected up front during request validation with a clear `TransactionRequestError::OutputNoteSenderMismatch`, instead of failing late inside transaction script building (the late failure surfaced as a cryptic `account interface error: invalid sender account` and could leave wallet integrations stuck retrying). ([#89](https://github.com/0xMiden/wallet-adapter/issues/89))
+* [rust] Expanded validation for output notes before executing a `TransactionRequest`. ([#89](https://github.com/0xMiden/wallet-adapter/issues/89))
 
 ### Changes
 

--- a/crates/rust-client/src/errors.rs
+++ b/crates/rust-client/src/errors.rs
@@ -292,6 +292,17 @@ impl From<&TransactionRequestError> for Option<ErrorHint> {
                 ),
                 docs_url: Some(TROUBLESHOOTING_DOC),
             }),
+            TransactionRequestError::OutputNoteSenderMismatch { expected, actual } => {
+                Some(ErrorHint {
+                    message: format!(
+                        "A note's sender is the account that emits it: it must be the account \
+                         executing the transaction. This transaction runs as account {expected}, \
+                         but one of its output notes declares sender {actual}. Rebuild the note \
+                         with {expected} as its sender, or execute the transaction from {actual}."
+                    ),
+                    docs_url: Some(TROUBLESHOOTING_DOC),
+                })
+            },
             _ => None,
         }
     }

--- a/crates/rust-client/src/errors.rs
+++ b/crates/rust-client/src/errors.rs
@@ -285,13 +285,6 @@ impl From<&TransactionRequestError> for Option<ErrorHint> {
                           Add at least one fungible or non-fungible asset to the note.".to_string(),
                 docs_url: Some(TROUBLESHOOTING_DOC),
             }),
-            TransactionRequestError::InvalidSenderAccount(account_id) => Some(ErrorHint {
-                message: format!(
-                    "Account {account_id} is not tracked by this client. Import or create the \
-                     account first, then retry the transaction."
-                ),
-                docs_url: Some(TROUBLESHOOTING_DOC),
-            }),
             TransactionRequestError::OutputNoteSenderMismatch { expected, actual } => {
                 Some(ErrorHint {
                     message: format!(

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -999,12 +999,45 @@ pub(super) fn validate_account_request(
     transaction_request: &TransactionRequest,
     account: &Account,
 ) -> Result<(), ClientError> {
+    // Output notes emitted by this transaction must declare the executing account as their
+    // sender. The kernel binds an emitted note's sender to the account that produces it, and
+    // note scripts (e.g. P2IDE reclaim) authorize on that field, so a foreign sender is
+    // unsatisfiable. Reject it here — read-only, before any execution or store writes —
+    // instead of failing deep in transaction script building.
+    validate_output_note_senders(transaction_request, account.id())?;
+
     if account.is_faucet() {
         // TODO(SantiagoPittella): Add faucet validations.
         Ok(())
     } else {
         validate_basic_account_request(transaction_request, account)
     }
+}
+
+/// Verifies that every output note emitted directly by the transaction declares `account_id` as
+/// its sender.
+///
+/// A note's sender is bound by the kernel to the account that emits it, and note scripts (e.g.
+/// P2IDE reclaim) authorize on that field, so an output note declaring a foreign sender can never
+/// be executed. Catching it here yields a clear, immediate error instead of a cryptic failure deep
+/// in transaction script building.
+fn validate_output_note_senders(
+    transaction_request: &TransactionRequest,
+    account_id: AccountId,
+) -> Result<(), ClientError> {
+    for note in transaction_request.expected_output_own_notes() {
+        let sender = note.metadata().sender();
+        if sender != account_id {
+            return Err(ClientError::TransactionRequestError(
+                TransactionRequestError::OutputNoteSenderMismatch {
+                    expected: account_id,
+                    actual: sender,
+                },
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 /// Ensures a transaction request is compatible with the current account state,
@@ -1148,4 +1181,97 @@ pub(crate) fn validate_executed_transaction(
     }
 
     Ok(())
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use miden_protocol::Word;
+    use miden_protocol::account::AccountId;
+    use miden_protocol::asset::FungibleAsset;
+    use miden_protocol::crypto::rand::RandomCoin;
+    use miden_protocol::note::{Note, NoteAttachments, NoteType};
+    use miden_protocol::testing::account_id::{
+        ACCOUNT_ID_PRIVATE_FUNGIBLE_FAUCET,
+        ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE,
+        ACCOUNT_ID_SENDER,
+    };
+    use miden_standards::note::P2idNote;
+
+    use super::{TransactionRequestBuilder, validate_output_note_senders};
+    use crate::ClientError;
+    use crate::transaction::TransactionRequestError;
+
+    fn own_note_with_sender(sender: AccountId) -> Note {
+        let faucet_id = AccountId::try_from(ACCOUNT_ID_PRIVATE_FUNGIBLE_FAUCET).unwrap();
+        let target_id =
+            AccountId::try_from(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE).unwrap();
+        let mut rng = RandomCoin::new(Word::default());
+
+        P2idNote::create(
+            sender,
+            target_id,
+            vec![FungibleAsset::new(faucet_id, 100).unwrap().into()],
+            NoteType::Public,
+            NoteAttachments::empty(),
+            &mut rng,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn output_note_with_foreign_sender_is_rejected() {
+        let account_id =
+            AccountId::try_from(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE).unwrap();
+        let foreign_sender = AccountId::try_from(ACCOUNT_ID_SENDER).unwrap();
+        assert_ne!(account_id, foreign_sender);
+
+        let request = TransactionRequestBuilder::new()
+            .own_output_notes(vec![own_note_with_sender(foreign_sender)])
+            .build()
+            .unwrap();
+
+        let err = validate_output_note_senders(&request, account_id).unwrap_err();
+        match err {
+            ClientError::TransactionRequestError(
+                TransactionRequestError::OutputNoteSenderMismatch { expected, actual },
+            ) => {
+                assert_eq!(expected, account_id);
+                assert_eq!(actual, foreign_sender);
+            },
+            other => panic!("expected OutputNoteSenderMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn output_note_with_matching_sender_is_accepted() {
+        let account_id =
+            AccountId::try_from(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE).unwrap();
+
+        let request = TransactionRequestBuilder::new()
+            .own_output_notes(vec![own_note_with_sender(account_id)])
+            .build()
+            .unwrap();
+
+        validate_output_note_senders(&request, account_id).unwrap();
+    }
+
+    #[test]
+    fn request_without_own_output_notes_is_accepted() {
+        let account_id =
+            AccountId::try_from(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE).unwrap();
+        let faucet_id = AccountId::try_from(ACCOUNT_ID_PRIVATE_FUNGIBLE_FAUCET).unwrap();
+
+        // A consume-only request (input note, no own output notes) must pass the sender check.
+        let request = TransactionRequestBuilder::new()
+            .input_notes(vec![(own_note_with_sender(faucet_id), None)])
+            .build()
+            .unwrap();
+
+        validate_output_note_senders(&request, account_id).unwrap();
+    }
 }

--- a/crates/rust-client/src/transaction/request/mod.rs
+++ b/crates/rust-client/src/transaction/request/mod.rs
@@ -504,8 +504,6 @@ pub enum TransactionRequestError {
         "output note declares sender {actual} but the transaction is executed by account {expected}"
     )]
     OutputNoteSenderMismatch { expected: AccountId, actual: AccountId },
-    #[error("sender account {0} is not tracked by this client or does not exist")]
-    InvalidSenderAccount(AccountId),
     #[error("invalid transaction script")]
     InvalidTransactionScript(#[from] TransactionScriptError),
     #[error("merkle proof error")]

--- a/crates/rust-client/src/transaction/request/mod.rs
+++ b/crates/rust-client/src/transaction/request/mod.rs
@@ -500,6 +500,10 @@ pub enum TransactionRequestError {
     InputNoteNotAuthenticated(NoteId),
     #[error("note {0} has already been consumed")]
     InputNoteAlreadyConsumed(NoteId),
+    #[error(
+        "output note declares sender {actual} but the transaction is executed by account {expected}"
+    )]
+    OutputNoteSenderMismatch { expected: AccountId, actual: AccountId },
     #[error("sender account {0} is not tracked by this client or does not exist")]
     InvalidSenderAccount(AccountId),
     #[error("invalid transaction script")]


### PR DESCRIPTION
Closes #2220

## Summary

Improves the developer experience for [0xMiden/wallet-adapter#89](https://github.com/0xMiden/wallet-adapter/issues/89) — *"Sending a note bricks the wallet if NoteMetadata sender is not the wallet account itself."*

An output note's sender is bound by the kernel to the account that emits it, and note scripts (e.g. P2IDE reclaim) authorize on that field — so a transaction request whose output note declares a *different* sender can never execute. Previously this surfaced only deep in transaction-script building (`AccountInterface::build_send_notes_script`), as a cryptic `account interface error: invalid sender account: 0x…` raised partway through `execute_transaction`.

This PR turns that unsatisfiable request into an **immediate, read-only rejection with an actionable error**, before any execution work begins.

## Change

- `validate_account_request` now runs `validate_output_note_senders` up front — read-only, before execution — and returns the new `TransactionRequestError::OutputNoteSenderMismatch { expected, actual }` with an `ErrorHint`. Because the check lives in the shared helper, both the execute path and the standalone `Client::validate_request` are covered, for all account types.
- The error replaces the late, cryptic failure with a clear message: *a note's sender must be the account executing the transaction; rebuild the note with the executing account as its sender, or execute the transaction from the declaring sender.*

Note: the pre-existing `TransactionRequestError::InvalidSenderAccount` variant was intentionally **not** reused — its "not tracked by this client" wording describes a different condition and would mislead here.

## Scope (what this is and isn't)

This is a **validation / error-clarity** improvement, not a fix for the wallet "bricking" itself. The reported "executing forever / only reinstalling recovers" symptom is wallet-side stuck-transaction handling, which is already addressed on `0xMiden/wallet` (#215/#216/#150 mark hard-failing transactions `Failed`). With those in place, the cryptic error would already surface cleanly; this PR additionally makes it surface *early and legibly* at the client layer.

It also only intercepts the sender-mismatch path. The more general "don't leave partial state when execution fails for any reason" concern (`execute_transaction` persists to the store via `upsert_input_notes` / `upsert_note_scripts` before the executor runs) is tracked as a separate follow-up: making `execute_transaction` atomic w.r.t. the store.

## Tests

New unit tests in `transaction::tests`:
- `output_note_with_foreign_sender_is_rejected` — asserts `OutputNoteSenderMismatch` with the correct `expected`/`actual`.
- `output_note_with_matching_sender_is_accepted`.
- `request_without_own_output_notes_is_accepted` — a consume-only request is unaffected.

`cargo test -p miden-client --lib --features std`, clippy, and `fmt --check` all pass.
