### PR TITLE
refactor: move input note upsert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* [FIX][rust] `Client::execute_transaction` no longer writes to the store before execution: the request's input notes and output note scripts are persisted only after the transaction executes successfully and is applied, so a failed execution leaves the store unchanged ([#2221](https://github.com/0xMiden/miden-client/issues/2221)).
 * [FIX][rust] `Client::send_private_note` is now durable across transient NTL failures: the relay payload is persisted to a durable outbox (a `Vec<NoteInfo>` under the `note_transport_outbox` settings key) before the transport call, so a failed or interrupted `send_note` no longer drops the note. `Client::sync_note_transport` retries the outbox on each sync (the receiver dedupes by note id) and a failing relay no longer blocks the sync; the new `Client::flush_relay_outbox()` lets callers drive retries directly ([#2127](https://github.com/0xMiden/miden-client/pull/2127)).
 * [FIX] Fixed `derive_account_commitments` to return the final account commitment when multiple transactions for the same account are committed in the same block ([#2164](https://github.com/0xMiden/miden-client/pull/2164)).
 * [FIX] Preserve a fungible asset's callback flag when the store replays a vault delta, fixing a `ConflictingRoots` error when consuming callback-bearing (e.g. agglayer-minted) assets ([#2225](https://github.com/0xMiden/miden-client/pull/2225)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-* [FIX][rust] `Client::execute_transaction` no longer writes to the store before execution: the request's input notes and output note scripts are persisted only after the transaction executes successfully and is applied, so a failed execution leaves the store unchanged ([#2221](https://github.com/0xMiden/miden-client/issues/2221)).
+* [FIX][rust] `Client::execute_transaction` no longer writes to the store before execution: the request's input notes and output note scripts are persisted only after the transaction executes successfully and is applied, so a failed execution leaves the store unchanged ([#2222](https://github.com/0xMiden/miden-client/pull/2222)).
 * [FIX][rust] `Client::send_private_note` is now durable across transient NTL failures: the relay payload is persisted to a durable outbox (a `Vec<NoteInfo>` under the `note_transport_outbox` settings key) before the transport call, so a failed or interrupted `send_note` no longer drops the note. `Client::sync_note_transport` retries the outbox on each sync (the receiver dedupes by note id) and a failing relay no longer blocks the sync; the new `Client::flush_relay_outbox()` lets callers drive retries directly ([#2127](https://github.com/0xMiden/miden-client/pull/2127)).
 * [FIX] Fixed `derive_account_commitments` to return the final account commitment when multiple transactions for the same account are committed in the same block ([#2164](https://github.com/0xMiden/miden-client/pull/2164)).
 * [FIX] Preserve a fungible asset's callback flag when the store replays a vault delta, fixing a `ConflictingRoots` error when consuming callback-bearing (e.g. agglayer-minted) assets ([#2225](https://github.com/0xMiden/miden-client/pull/2225)).

--- a/crates/rust-client/src/store/data_store/cache.rs
+++ b/crates/rust-client/src/store/data_store/cache.rs
@@ -1,0 +1,117 @@
+use alloc::collections::BTreeMap;
+use alloc::sync::Arc;
+
+use miden_protocol::Word;
+use miden_protocol::account::{AccountId, StorageMapKey, StorageMapWitness};
+use miden_protocol::block::BlockNumber;
+use miden_protocol::note::NoteScript;
+use miden_protocol::transaction::AccountInputs;
+use miden_tx::TransactionMastStore;
+
+use crate::utils::RwLock;
+
+// DATA STORE CACHE
+// ================================================================================================
+
+/// In-memory state that [`super::ClientDataStore`] serves to the executor without going through
+/// the persistent store.
+///
+/// This bundles everything that exists only for the duration of an execution session: data
+/// registered up front for the in-flight transaction request (account code, foreign account
+/// inputs, output note scripts) plus data cached lazily while the transaction executes (RPC-fetched
+/// foreign accounts and storage map witnesses, the reference block).
+pub(super) struct DataStoreCache {
+    /// Store used to provide MAST nodes to the transaction executor.
+    pub(super) mast_store: Arc<TransactionMastStore>,
+    /// Foreign account inputs that should be returned to the executor on demand.
+    foreign_account_inputs: RwLock<BTreeMap<AccountId, AccountInputs>>,
+    /// Note scripts known only to the in-flight transaction request (e.g. its expected output
+    /// note scripts): they must be resolvable while the transaction executes, but they are
+    /// persisted only as part of the store update applied after the transaction succeeds.
+    note_scripts: RwLock<BTreeMap<Word, NoteScript>>,
+    /// Storage map witnesses, keyed by (`map_root`, `map_key`). Avoids redundant RPC calls when
+    /// the same map entry is accessed multiple times within a transaction.
+    storage_map_witnesses: RwLock<BTreeMap<(Word, StorageMapKey), StorageMapWitness>>,
+    /// The transaction reference block number.
+    ref_block: RwLock<Option<BlockNumber>>,
+}
+
+impl DataStoreCache {
+    pub(super) fn new() -> Self {
+        Self {
+            mast_store: Arc::new(TransactionMastStore::new()),
+            foreign_account_inputs: RwLock::new(BTreeMap::new()),
+            note_scripts: RwLock::new(BTreeMap::new()),
+            storage_map_witnesses: RwLock::new(BTreeMap::new()),
+            ref_block: RwLock::new(None),
+        }
+    }
+
+    /// Replaces the cached foreign account inputs with the provided ones.
+    pub(super) fn replace_foreign_account_inputs(
+        &self,
+        foreign_accounts: impl IntoIterator<Item = AccountInputs>,
+    ) {
+        let mut cache = self.foreign_account_inputs.write();
+        cache.clear();
+
+        for account_inputs in foreign_accounts {
+            cache.insert(account_inputs.id(), account_inputs);
+        }
+    }
+
+    /// Caches the inputs of a single foreign account, overwriting any previous entry.
+    pub(super) fn insert_foreign_account_inputs(&self, account_inputs: AccountInputs) {
+        self.foreign_account_inputs.write().insert(account_inputs.id(), account_inputs);
+    }
+
+    /// Returns the cached inputs for the given foreign account, if any.
+    pub(super) fn get_foreign_account_inputs(
+        &self,
+        account_id: AccountId,
+    ) -> Option<AccountInputs> {
+        self.foreign_account_inputs.read().get(&account_id).cloned()
+    }
+
+    /// Registers note scripts, keyed by their root. Scripts accumulate across calls.
+    pub(super) fn insert_note_scripts(&self, note_scripts: impl IntoIterator<Item = NoteScript>) {
+        let mut cache = self.note_scripts.write();
+        for script in note_scripts {
+            cache.insert(script.root().into(), script);
+        }
+    }
+
+    /// Returns the registered note script with the given root, if any.
+    pub(super) fn get_note_script(&self, script_root: Word) -> Option<NoteScript> {
+        self.note_scripts.read().get(&script_root).cloned()
+    }
+
+    /// Caches a storage map witness for the given (`map_root`, `map_key`) pair.
+    pub(super) fn insert_storage_map_witness(
+        &self,
+        map_root: Word,
+        map_key: StorageMapKey,
+        witness: StorageMapWitness,
+    ) {
+        self.storage_map_witnesses.write().insert((map_root, map_key), witness);
+    }
+
+    /// Returns the cached storage map witness for the given (`map_root`, `map_key`) pair, if any.
+    pub(super) fn get_storage_map_witness(
+        &self,
+        map_root: Word,
+        map_key: StorageMapKey,
+    ) -> Option<StorageMapWitness> {
+        self.storage_map_witnesses.read().get(&(map_root, map_key)).cloned()
+    }
+
+    /// Returns the cached transaction reference block, if set.
+    pub(super) fn ref_block(&self) -> Option<BlockNumber> {
+        *self.ref_block.read()
+    }
+
+    /// Caches the transaction reference block so lazy-loading methods can use it.
+    pub(super) fn set_ref_block(&self, block_num: BlockNumber) {
+        *self.ref_block.write() = Some(block_num);
+    }
+}

--- a/crates/rust-client/src/store/data_store/cache.rs
+++ b/crates/rust-client/src/store/data_store/cache.rs
@@ -73,6 +73,15 @@ impl DataStoreCache {
         self.foreign_account_inputs.read().get(&account_id).cloned()
     }
 
+    /// Runs `f` against the cached inputs for the given foreign account, without cloning them.
+    pub(super) fn with_foreign_account_inputs<R>(
+        &self,
+        account_id: AccountId,
+        f: impl FnOnce(&AccountInputs) -> R,
+    ) -> Option<R> {
+        self.foreign_account_inputs.read().get(&account_id).map(f)
+    }
+
     /// Registers note scripts, keyed by their root. Scripts accumulate across calls.
     pub(super) fn insert_note_scripts(&self, note_scripts: impl IntoIterator<Item = NoteScript>) {
         let mut cache = self.note_scripts.write();

--- a/crates/rust-client/src/store/data_store/mod.rs
+++ b/crates/rust-client/src/store/data_store/mod.rs
@@ -332,32 +332,32 @@ impl DataStore for ClientDataStore {
             return Ok(witness);
         }
 
-        // Ensure the account inputs are cached before resolving the slot name.
-        let inputs = if let Some(inputs) = self.cache.get_foreign_account_inputs(account_id) {
-            inputs
+        // Resolve against the cached account inputs (without cloning them), fetching and caching
+        // the account first if it isn't cached yet.
+        let resolution = if let Some(resolution) =
+            self.cache.with_foreign_account_inputs(account_id, |inputs| {
+                resolve_witness_from_inputs(inputs, map_root, map_key)
+            }) {
+            resolution?
         } else {
             let account_state_at = self
                 .cache
                 .ref_block()
                 .map(AccountStateAt::Block)
                 .expect("reference block should be set");
-            self.fetch_and_cache_foreign_account(account_id, account_state_at).await?
+            let inputs = self.fetch_and_cache_foreign_account(account_id, account_state_at).await?;
+            resolve_witness_from_inputs(&inputs, map_root, map_key)?
         };
 
-        // Try to get the witness from the cached account inputs. It will miss if the account's
-        // storage is too big.
-        if let Some(partial_map) = inputs.storage().maps().find(|m| m.root() == map_root)
-            && let Ok(witness) = partial_map.open(&map_key)
-        {
-            return Ok(witness);
+        match resolution {
+            WitnessResolution::Witness(witness) => Ok(witness),
+            WitnessResolution::FetchParams(slot_name, known_code) => {
+                self.fetch_and_cache_storage_map_witness(
+                    account_id, map_root, slot_name, map_key, known_code,
+                )
+                .await
+            },
         }
-
-        let (slot_name, known_code) = resolve_slot_name_and_code(&inputs, map_root)?;
-
-        self.fetch_and_cache_storage_map_witness(
-            account_id, map_root, slot_name, map_key, known_code,
-        )
-        .await
     }
 
     /// Returns the [`AccountInputs`] for the given foreign account from the cache or alternatively
@@ -438,11 +438,27 @@ impl MastForestStore for ClientDataStore {
 // HELPER FUNCTIONS
 // ================================================================================================
 
-/// Resolves the slot name and account code for a map root from the given foreign account inputs.
-fn resolve_slot_name_and_code(
+/// Outcome of resolving a storage map witness against an account's inputs: either the witness
+/// itself, or the parameters needed to fetch it via RPC.
+enum WitnessResolution {
+    Witness(StorageMapWitness),
+    FetchParams(StorageSlotName, AccountCode),
+}
+
+/// Tries to open the witness from the inputs' partial storage maps (this can miss if the
+/// account's storage is too big); on a miss, resolves the slot name and account code needed to
+/// fetch the witness via RPC.
+fn resolve_witness_from_inputs(
     inputs: &AccountInputs,
     map_root: Word,
-) -> Result<(StorageSlotName, AccountCode), DataStoreError> {
+    map_key: StorageMapKey,
+) -> Result<WitnessResolution, DataStoreError> {
+    if let Some(partial_map) = inputs.storage().maps().find(|m| m.root() == map_root)
+        && let Ok(witness) = partial_map.open(&map_key)
+    {
+        return Ok(WitnessResolution::Witness(witness));
+    }
+
     let account_id = inputs.id();
     let slot_name = inputs
         .storage()
@@ -456,7 +472,7 @@ fn resolve_slot_name_and_code(
             ))
         })?;
 
-    Ok((slot_name, inputs.code().clone()))
+    Ok(WitnessResolution::FetchParams(slot_name, inputs.code().clone()))
 }
 
 /// Builds a [`PartialMmr`] from the given peaks and a list of blocks that should be

--- a/crates/rust-client/src/store/data_store/mod.rs
+++ b/crates/rust-client/src/store/data_store/mod.rs
@@ -442,6 +442,8 @@ impl MastForestStore for ClientDataStore {
 /// itself, or the parameters needed to fetch it via RPC.
 enum WitnessResolution {
     Witness(StorageMapWitness),
+    /// The [`AccountCode`] is not needed to build the witness: it is only sent along with the
+    /// RPC request so the node can omit the account code from its response.
     FetchParams(StorageSlotName, AccountCode),
 }
 

--- a/crates/rust-client/src/store/data_store/mod.rs
+++ b/crates/rust-client/src/store/data_store/mod.rs
@@ -1,4 +1,4 @@
-use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::collections::BTreeSet;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 
@@ -33,7 +33,9 @@ use crate::rpc::domain::account::{
 use crate::rpc::{AccountStateAt, NodeRpcClient};
 use crate::store::StoreError;
 use crate::transaction::fetch_public_account_inputs;
-use crate::utils::RwLock;
+
+mod cache;
+use cache::DataStoreCache;
 
 // DATA STORE
 // ================================================================================================
@@ -42,15 +44,8 @@ use crate::utils::RwLock;
 pub struct ClientDataStore {
     /// Local database containing information about the accounts managed by this client.
     store: alloc::sync::Arc<dyn Store>,
-    /// Store used to provide MAST nodes to the transaction executor.
-    transaction_mast_store: Arc<TransactionMastStore>,
-    /// Cache of foreign account inputs that should be returned to the executor on demand.
-    foreign_account_inputs: RwLock<BTreeMap<AccountId, AccountInputs>>,
-    /// Cache of storage map witnesses, keyed by (`map_root`, `map_key`). Avoids redundant RPC
-    /// calls when the same map entry is accessed multiple times within a transaction.
-    storage_map_cache: RwLock<BTreeMap<(Word, StorageMapKey), StorageMapWitness>>,
-    /// The transaction reference block number.
-    ref_block: RwLock<Option<BlockNumber>>,
+    /// In-memory state served to the executor for the duration of the execution session.
+    cache: DataStoreCache,
     /// RPC client used to lazy-load foreign account data on cache miss.
     rpc_api: Arc<dyn NodeRpcClient>,
 }
@@ -59,16 +54,13 @@ impl ClientDataStore {
     pub fn new(store: alloc::sync::Arc<dyn Store>, rpc_api: Arc<dyn NodeRpcClient>) -> Self {
         Self {
             store,
-            transaction_mast_store: Arc::new(TransactionMastStore::new()),
-            foreign_account_inputs: RwLock::new(BTreeMap::new()),
-            storage_map_cache: RwLock::new(BTreeMap::new()),
-            ref_block: RwLock::new(None),
+            cache: DataStoreCache::new(),
             rpc_api,
         }
     }
 
     pub fn mast_store(&self) -> Arc<TransactionMastStore> {
-        self.transaction_mast_store.clone()
+        self.cache.mast_store.clone()
     }
 
     /// Stores the provided foreign account inputs so they can be served to the executor upon
@@ -77,12 +69,16 @@ impl ClientDataStore {
         &self,
         foreign_accounts: impl IntoIterator<Item = AccountInputs>,
     ) {
-        let mut cache = self.foreign_account_inputs.write();
-        cache.clear();
+        self.cache.replace_foreign_account_inputs(foreign_accounts);
+    }
 
-        for account_inputs in foreign_accounts {
-            cache.insert(account_inputs.id(), account_inputs);
-        }
+    /// Registers note scripts so they can be served to the executor upon request.
+    ///
+    /// Scripts accumulate across calls (they are not cleared) so that a data store reused for
+    /// several executions — e.g. by [`crate::transaction::BatchBuilder`] — keeps serving the
+    /// scripts registered for earlier transactions.
+    pub fn register_note_scripts(&self, note_scripts: impl IntoIterator<Item = NoteScript>) {
+        self.cache.insert_note_scripts(note_scripts);
     }
 
     /// Attempts to resolve a storage map witness from the local store.
@@ -141,8 +137,8 @@ impl ClientDataStore {
             DataStoreError::other_with_source("failed to fetch foreign account inputs", err)
         })?;
 
-        self.transaction_mast_store.load_account_code(account_inputs.code());
-        self.foreign_account_inputs.write().insert(account_id, account_inputs.clone());
+        self.cache.mast_store.load_account_code(account_inputs.code());
+        self.cache.insert_foreign_account_inputs(account_inputs.clone());
 
         Ok(account_inputs)
     }
@@ -201,35 +197,8 @@ impl ClientDataStore {
         let witness = StorageMapWitness::new(proof, [map_key]).map_err(|err| {
             DataStoreError::other_with_source("failed to create storage map witness", err)
         })?;
-        self.storage_map_cache.write().insert((map_root, map_key), witness.clone());
+        self.cache.insert_storage_map_witness(map_root, map_key, witness.clone());
         Ok(witness)
-    }
-
-    /// Resolves the slot name and account code for a map root from the cached foreign account
-    /// inputs.
-    fn resolve_slot_name_and_code(
-        &self,
-        account_id: AccountId,
-        map_root: Word,
-    ) -> Result<(StorageSlotName, AccountCode), DataStoreError> {
-        let cache = self.foreign_account_inputs.read();
-        let inputs = cache
-            .get(&account_id)
-            .ok_or_else(|| DataStoreError::AccountNotFound(account_id))?;
-
-        let slot_name = inputs
-            .storage()
-            .header()
-            .slots()
-            .find(|slot| slot.slot_type().is_map() && slot.value() == map_root)
-            .map(|slot| slot.name().clone())
-            .ok_or_else(|| {
-                DataStoreError::other(format!(
-                    "did not find map slot with root {map_root} for foreign account {account_id}"
-                ))
-            })?;
-
-        Ok((slot_name, inputs.code().clone()))
     }
 }
 
@@ -245,7 +214,7 @@ impl DataStore for ClientDataStore {
         let ref_block = block_refs.pop_last().ok_or(DataStoreError::other("block set is empty"))?;
 
         // Cache the reference block so lazy-loading methods can use it
-        *self.ref_block.write() = Some(ref_block);
+        self.cache.set_ref_block(ref_block);
 
         let partial_account_record = self
             .store
@@ -351,10 +320,8 @@ impl DataStore for ClientDataStore {
         map_root: Word,
         map_key: StorageMapKey,
     ) -> Result<StorageMapWitness, DataStoreError> {
-        let cache_key = (map_root, map_key);
-
         // Check the in-memory witness cache first.
-        if let Some(witness) = self.storage_map_cache.read().get(&cache_key).cloned() {
+        if let Some(witness) = self.cache.get_storage_map_witness(map_root, map_key) {
             return Ok(witness);
         }
 
@@ -366,25 +333,26 @@ impl DataStore for ClientDataStore {
         }
 
         // Ensure the account inputs are cached before resolving the slot name.
-        if !self.foreign_account_inputs.read().contains_key(&account_id) {
+        let inputs = if let Some(inputs) = self.cache.get_foreign_account_inputs(account_id) {
+            inputs
+        } else {
             let account_state_at = self
-                .ref_block
-                .read()
+                .cache
+                .ref_block()
                 .map(AccountStateAt::Block)
                 .expect("reference block should be set");
-            self.fetch_and_cache_foreign_account(account_id, account_state_at).await?;
-        }
+            self.fetch_and_cache_foreign_account(account_id, account_state_at).await?
+        };
 
         // Try to get the witness from the cached account inputs. It will miss if the account's
         // storage is too big.
-        if let Some(inputs) = self.foreign_account_inputs.read().get(&account_id)
-            && let Some(partial_map) = inputs.storage().maps().find(|m| m.root() == map_root)
+        if let Some(partial_map) = inputs.storage().maps().find(|m| m.root() == map_root)
             && let Ok(witness) = partial_map.open(&map_key)
         {
             return Ok(witness);
         }
 
-        let (slot_name, known_code) = self.resolve_slot_name_and_code(account_id, map_root)?;
+        let (slot_name, known_code) = resolve_slot_name_and_code(&inputs, map_root)?;
 
         self.fetch_and_cache_storage_map_witness(
             account_id, map_root, slot_name, map_key, known_code,
@@ -399,28 +367,31 @@ impl DataStore for ClientDataStore {
         foreign_account_id: AccountId,
         ref_block: BlockNumber,
     ) -> Result<AccountInputs, DataStoreError> {
-        // Fast path: check the cache first (drop the read guard before any async work).
-        {
-            let cache = self.foreign_account_inputs.read();
-            if let Some(inputs) = cache.get(&foreign_account_id).cloned() {
-                return Ok(inputs);
-            }
+        // Fast path: check the cache first.
+        if let Some(inputs) = self.cache.get_foreign_account_inputs(foreign_account_id) {
+            return Ok(inputs);
         }
 
         self.fetch_and_cache_foreign_account(foreign_account_id, AccountStateAt::Block(ref_block))
             .await
     }
 
-    /// Returns the [`NoteScript`] for the given script root from the store or alternatively
-    /// fetching it from the RPC if not available locally.
+    /// Returns the [`NoteScript`] for the given script root from the registered session scripts,
+    /// the store, or alternatively fetching it from the RPC if not available locally.
     fn get_note_script(
         &self,
         script_root: NoteScriptRoot,
     ) -> impl FutureMaybeSend<Result<Option<NoteScript>, DataStoreError>> {
+        let registered_script = self.cache.get_note_script(script_root.into());
         let store = self.store.clone();
         let rpc_api = self.rpc_api.clone();
 
         async move {
+            // Fastest path: scripts registered for the in-flight transaction request.
+            if let Some(note_script) = registered_script {
+                return Ok(Some(note_script));
+            }
+
             // Fast path: check the local store first.
             match store.get_note_script(script_root.into()).await {
                 Ok(note_script) => return Ok(Some(note_script)),
@@ -460,12 +431,33 @@ impl DataStore for ClientDataStore {
 
 impl MastForestStore for ClientDataStore {
     fn get(&self, procedure_hash: &Word) -> Option<Arc<MastForest>> {
-        self.transaction_mast_store.get(procedure_hash)
+        self.cache.mast_store.get(procedure_hash)
     }
 }
 
 // HELPER FUNCTIONS
 // ================================================================================================
+
+/// Resolves the slot name and account code for a map root from the given foreign account inputs.
+fn resolve_slot_name_and_code(
+    inputs: &AccountInputs,
+    map_root: Word,
+) -> Result<(StorageSlotName, AccountCode), DataStoreError> {
+    let account_id = inputs.id();
+    let slot_name = inputs
+        .storage()
+        .header()
+        .slots()
+        .find(|slot| slot.slot_type().is_map() && slot.value() == map_root)
+        .map(|slot| slot.name().clone())
+        .ok_or_else(|| {
+            DataStoreError::other(format!(
+                "did not find map slot with root {map_root} for foreign account {account_id}"
+            ))
+        })?;
+
+    Ok((slot_name, inputs.code().clone()))
+}
 
 /// Builds a [`PartialMmr`] from the given peaks and a list of blocks that should be
 /// authenticated against them.

--- a/crates/rust-client/src/transaction/batch/data_store.rs
+++ b/crates/rust-client/src/transaction/batch/data_store.rs
@@ -66,6 +66,12 @@ impl InMemoryBatchDataStore {
     ) {
         self.inner.register_foreign_account_inputs(foreign_accounts);
     }
+
+    /// Registers note scripts on the inner [`ClientDataStore`] so the executor can resolve
+    /// the request's output note scripts during transaction execution.
+    pub(crate) fn register_note_scripts(&self, note_scripts: impl IntoIterator<Item = NoteScript>) {
+        self.inner.register_note_scripts(note_scripts);
+    }
 }
 
 // DATA STORE IMPL

--- a/crates/rust-client/src/transaction/batch/mod.rs
+++ b/crates/rust-client/src/transaction/batch/mod.rs
@@ -291,6 +291,7 @@ where
     let prep = client.prepare_transaction(&account, transaction_request).await?;
 
     data_store.register_foreign_account_inputs(prep.foreign_account_inputs.iter().cloned());
+    data_store.register_note_scripts(prep.output_note_scripts());
     for fpi_account in &prep.foreign_account_inputs {
         data_store.mast_store().load_account_code(fpi_account.code());
     }
@@ -299,7 +300,9 @@ where
 
     let mut notes = prep.notes;
     if prep.ignore_invalid_notes {
-        notes = client.get_valid_input_notes(&account, notes, prep.tx_args.clone()).await?;
+        notes = client
+            .get_valid_input_notes(&account, notes, prep.tx_args.clone(), &prep.output_recipients)
+            .await?;
     }
 
     let executed_transaction = client

--- a/crates/rust-client/src/transaction/batch/mod.rs
+++ b/crates/rust-client/src/transaction/batch/mod.rs
@@ -290,11 +290,11 @@ where
     let account_id = account.id();
     let prep = client.prepare_transaction(&account, transaction_request).await?;
 
-    data_store.register_foreign_account_inputs(prep.foreign_account_inputs.iter().cloned());
     data_store.register_note_scripts(prep.output_note_scripts());
     for fpi_account in &prep.foreign_account_inputs {
         data_store.mast_store().load_account_code(fpi_account.code());
     }
+    data_store.register_foreign_account_inputs(prep.foreign_account_inputs);
 
     data_store.mast_store().load_account_code(account.code());
 

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -302,6 +302,7 @@ where
 
         let data_store = ClientDataStore::new(self.store.clone(), self.rpc_api.clone());
         data_store.register_foreign_account_inputs(prep.foreign_account_inputs.iter().cloned());
+        data_store.register_note_scripts(prep.output_note_scripts());
         for fpi_account in &prep.foreign_account_inputs {
             data_store.mast_store().load_account_code(fpi_account.code());
         }
@@ -310,7 +311,14 @@ where
 
         let mut notes = prep.notes;
         if prep.ignore_invalid_notes {
-            notes = self.get_valid_input_notes(&account, notes, prep.tx_args.clone()).await?;
+            notes = self
+                .get_valid_input_notes(
+                    &account,
+                    notes,
+                    prep.tx_args.clone(),
+                    &prep.output_recipients,
+                )
+                .await?;
         }
 
         let executed_transaction = self
@@ -325,8 +333,10 @@ where
     /// Performs the data-store-independent setup shared by `execute_transaction` and
     /// `execute_transaction_for_batch`: validates the request against the supplied
     /// `account`, loads/filters input notes, builds the transaction script and args,
-    /// retrieves foreign-account inputs, upserts output note scripts, and computes the
-    /// reference block number.
+    /// retrieves foreign-account inputs, and computes the reference block number.
+    ///
+    /// This method does not write to the store: any state produced by the transaction is
+    /// persisted only after the transaction executes successfully.
     ///
     /// `account` is the state validation runs against — for a single transaction this is
     /// the persisted account; inside [`crate::transaction::BatchBuilder::push`] it is the
@@ -361,23 +371,6 @@ where
         // Only keep authenticated input notes from the store.
         stored_note_records.retain(InputNoteRecord::is_authenticated);
 
-        let authenticated_note_ids =
-            stored_note_records.iter().filter_map(InputNoteRecord::id).collect::<Vec<_>>();
-
-        // Upsert request notes missing from the store so they can be tracked and updated.
-        // NOTE: Unauthenticated notes may be stored locally in an unverified/invalid state at
-        // this point. The upsert will replace the state to an InputNoteState::Expected (with
-        // metadata included).
-        let unauthenticated_input_notes = transaction_request
-            .input_notes()
-            .iter()
-            .filter(|n| !authenticated_note_ids.contains(&n.id()))
-            .cloned()
-            .map(Into::into)
-            .collect::<Vec<_>>();
-
-        self.store.upsert_input_notes(&unauthenticated_input_notes).await?;
-
         let notes = transaction_request.build_input_notes(stored_note_records)?;
 
         let output_recipients =
@@ -395,10 +388,6 @@ where
             self.retrieve_foreign_account_inputs(foreign_accounts).await?;
 
         let ignore_invalid_notes = transaction_request.ignore_invalid_input_notes();
-
-        let output_note_scripts: Vec<NoteScript> =
-            output_recipients.iter().map(|r| r.script().clone()).collect();
-        self.store.upsert_note_scripts(&output_note_scripts).await?;
 
         let block_num = if let Some(block_num) = fpi_block_num {
             block_num
@@ -662,14 +651,21 @@ where
         Ok(())
     }
 
+    /// Filters the provided input notes down to the subset that can be consumed by the account.
+    ///
+    /// `output_recipients` are the request's expected output recipients; their scripts are
+    /// registered on the consumption-check data store so output note creation can resolve them
+    /// without them being present in the store.
     pub(crate) async fn get_valid_input_notes(
         &self,
         account: &Account,
         mut input_notes: InputNotes<InputNote>,
         tx_args: TransactionArgs,
+        output_recipients: &[NoteRecipient],
     ) -> Result<InputNotes<InputNote>, ClientError> {
         loop {
             let data_store = ClientDataStore::new(self.store.clone(), self.rpc_api.clone());
+            data_store.register_note_scripts(output_recipients.iter().map(|r| r.script().clone()));
 
             data_store.mast_store().load_account_code(account.code());
             let execution = NoteConsumptionChecker::new(&self.build_executor(&data_store)?)
@@ -905,12 +901,30 @@ where
             )
         }));
 
-        // Locally consumed notes
+        // Locally consumed notes. Notes already tracked by the store only need their state
+        // advanced; the rest (the request's unauthenticated notes, which are not persisted
+        // before the transaction succeeds) are tracked from this point on, so records for them
+        // are built from the executed transaction's inputs.
         let consumed_note_ids =
             executed_tx.tx_inputs().input_notes().iter().map(InputNote::id).collect();
 
         let consumed_notes =
             self.store.get_input_notes(NoteFilter::List(consumed_note_ids)).await?;
+
+        let tracked_note_ids =
+            consumed_notes.iter().filter_map(InputNoteRecord::id).collect::<BTreeSet<_>>();
+
+        for input_note in executed_tx.tx_inputs().input_notes() {
+            if !tracked_note_ids.contains(&input_note.id()) {
+                let mut input_note_record = InputNoteRecord::from(input_note.clone());
+                input_note_record.consumed_locally(
+                    executed_tx.account_id(),
+                    executed_tx.id(),
+                    current_timestamp,
+                )?;
+                new_input_notes.push(input_note_record);
+            }
+        }
 
         let mut updated_input_notes = vec![];
 
@@ -918,7 +932,7 @@ where
             if input_note_record.consumed_locally(
                 executed_tx.account_id(),
                 executed_tx.id(),
-                self.store.get_current_timestamp(),
+                current_timestamp,
             )? {
                 updated_input_notes.push(input_note_record);
             }
@@ -986,6 +1000,14 @@ pub(crate) struct PreparedTransaction {
     pub(crate) foreign_account_inputs: Vec<AccountInputs>,
     pub(crate) block_num: BlockNumber,
     pub(crate) ignore_invalid_notes: bool,
+}
+
+impl PreparedTransaction {
+    /// Returns the scripts of the request's expected output notes. These must be registered on
+    /// the executor's data store so output note creation can resolve them during execution.
+    pub(crate) fn output_note_scripts(&self) -> impl Iterator<Item = NoteScript> + '_ {
+        self.output_recipients.iter().map(|recipient| recipient.script().clone())
+    }
 }
 
 /// Helper to get the account outgoing assets.

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -301,11 +301,11 @@ where
         let prep = self.prepare_transaction(&account, transaction_request).await?;
 
         let data_store = ClientDataStore::new(self.store.clone(), self.rpc_api.clone());
-        data_store.register_foreign_account_inputs(prep.foreign_account_inputs.iter().cloned());
         data_store.register_note_scripts(prep.output_note_scripts());
         for fpi_account in &prep.foreign_account_inputs {
             data_store.mast_store().load_account_code(fpi_account.code());
         }
+        data_store.register_foreign_account_inputs(prep.foreign_account_inputs);
 
         data_store.mast_store().load_account_code(account.code());
 
@@ -773,14 +773,14 @@ where
 
         let data_store = ClientDataStore::new(self.store.clone(), self.rpc_api.clone());
 
-        data_store.register_foreign_account_inputs(foreign_account_inputs.iter().cloned());
-
         // Ensure code is loaded on MAST store
         data_store.mast_store().load_account_code(account.code());
 
         for fpi_account in &foreign_account_inputs {
             data_store.mast_store().load_account_code(fpi_account.code());
         }
+
+        data_store.register_foreign_account_inputs(foreign_account_inputs);
 
         Ok((data_store, block_ref))
     }

--- a/crates/testing/miden-client-tests/src/tests/transaction.rs
+++ b/crates/testing/miden-client-tests/src/tests/transaction.rs
@@ -4,6 +4,8 @@ use alloc::sync::Arc;
 use miden_client::assembly::CodeBuilder;
 use miden_client::auth::{AuthSchemeId, AuthSecretKey, AuthSingleSig, RPO_FALCON_SCHEME_ID};
 use miden_client::keystore::Keystore;
+use miden_client::note::{NoteAttachments, P2idNote};
+use miden_client::store::NoteFilter;
 use miden_client::transaction::{
     ProvenTransaction,
     TransactionExecutorError,
@@ -25,7 +27,8 @@ use miden_protocol::account::{
 };
 use miden_protocol::assembly::diagnostics::miette::GraphicalReportHandler;
 use miden_protocol::asset::{Asset, FungibleAsset};
-use miden_protocol::note::NoteType;
+use miden_protocol::crypto::rand::FeltRng;
+use miden_protocol::note::{NoteRecipient, NoteStorage, NoteType};
 use miden_protocol::testing::account_id::{
     ACCOUNT_ID_PRIVATE_FUNGIBLE_FAUCET,
     ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
@@ -130,6 +133,93 @@ async fn transaction_error_reports_source_line() {
         },
         other => panic!("unexpected error variant: {other:?}"),
     }
+}
+
+/// Regression test for #2221: a transaction request whose execution fails must leave the store
+/// unchanged — no orphaned input notes and no orphaned output note scripts.
+#[tokio::test]
+async fn execute_transaction_failure_leaves_store_unchanged() {
+    let (mut client, _, keystore) = Box::pin(create_test_client()).await;
+    let (wallet, faucet) =
+        setup_wallet_and_faucet(&mut client, AccountType::Private, &keystore, RPO_FALCON_SCHEME_ID)
+            .await
+            .unwrap();
+
+    // A note targeting the wallet that is not tracked by the store. Passing it as a request
+    // input note is what would trigger an input-note write during preparation.
+    let asset = FungibleAsset::new(faucet.id(), 100).unwrap();
+    let unauthenticated_note = P2idNote::create(
+        faucet.id(),
+        wallet.id(),
+        vec![asset.into()],
+        NoteType::Private,
+        NoteAttachments::empty(),
+        client.rng(),
+    )
+    .unwrap();
+    let note_id = unauthenticated_note.id();
+
+    // An expected output recipient with a non-standard script. Declaring it in the request is
+    // what would trigger a note-script write during preparation.
+    let output_note_script = client
+        .code_builder()
+        .compile_note_script(
+            "@note_script
+            pub proc main
+                nop
+            end",
+        )
+        .unwrap();
+    let script_root = output_note_script.root();
+    let serial_num = client.rng().draw_word();
+    let output_recipient =
+        NoteRecipient::new(serial_num, output_note_script, NoteStorage::new(vec![]).unwrap());
+
+    // A transaction script that always fails, forcing execution to error after preparation has
+    // succeeded.
+    let failing_script = client
+        .code_builder()
+        .compile_tx_script("begin push.0 push.2 assert_eq end")
+        .unwrap();
+
+    let tx_request = TransactionRequestBuilder::new()
+        .input_notes([(unauthenticated_note, None)])
+        .expected_output_recipients(vec![output_recipient])
+        .custom_script(failing_script)
+        .build()
+        .unwrap();
+
+    // Neither the note nor the script is tracked before execution.
+    assert!(
+        client
+            .get_input_notes(NoteFilter::List(vec![note_id]))
+            .await
+            .unwrap()
+            .is_empty(),
+        "note should not be tracked before execution"
+    );
+    assert!(
+        client.test_store().get_note_script(script_root.into()).await.is_err(),
+        "output note script should not be stored before execution"
+    );
+
+    Box::pin(client.execute_transaction(wallet.id(), tx_request))
+        .await
+        .expect_err("transaction execution should fail");
+
+    // The failed execution must leave the store unchanged.
+    assert!(
+        client
+            .get_input_notes(NoteFilter::List(vec![note_id]))
+            .await
+            .unwrap()
+            .is_empty(),
+        "execution failure must not persist the request's input notes"
+    );
+    assert!(
+        client.test_store().get_note_script(script_root.into()).await.is_err(),
+        "execution failure must not persist the request's output note scripts"
+    );
 }
 
 // MOCK PROVERS


### PR DESCRIPTION
Closes #2221
Also factors out a bit of code into a new `execute_prepared_transaction()`.

For context, before, we needed to have the input notes in the store because the `DataStore` would load them from there. However, this happens naturally now (because they need to be passed explicitly) so there's no need to do so.

  - Introduces `DataStoreCache`: `ClientDataStore`'s in-memory state (MAST store, foreign accounts, note scripts, witnesses, ref block) is bundled into a new module. This is mostly just moving code around
 - #2221: `prepare_transaction` no longer writes input notes or note scripts to the stor. Scripts are served from the in memory cache during execution and everything persists only after the transaction succeeds.
  - Fewer allocations: foreign-account inputs are moved into the data store instead of deep-cloned, and witness resolution borrows cached inputs under the lock instead of cloning them.