### PR TITLE
refactor: remove `RandomCoin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Changes
 
+* [BREAKING][rust] Removed the `RandomCoin` re-export from `miden_client::crypto`. The client now ships a `ChaCha20`-backed `FeltRng` as its default RNG (`DefaultFeltRng`), and `FeltRngAdapter` lifts any `RngCore` into a `FeltRng`. ([#2223](https://github.com/0xMiden/miden-client/pull/2223))
 * [BREAKING][rust] Added a `Subscription(Word)` variant to `NoteTagSource`. ([#2248](https://github.com/0xMiden/miden-client/pull/2248))
 * [rust] Added `Store::apply_settings_mutations` for batched `settings` writes. ([#2248](https://github.com/0xMiden/miden-client/pull/2248))
 * [BREAKING][param][rust] `NodeRpcClient::get_block_by_number()` now takes an `include_proof: bool` parameter to control whether the block proof is included in the response. ([#1991](https://github.com/0xMiden/miden-client/pull/1991))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2077,6 +2077,7 @@ dependencies = [
  "prost",
  "prost-types",
  "rand 0.9.4",
+ "rand_chacha",
  "serde",
  "serde_json",
  "tempfile",

--- a/bin/integration-tests/src/tests/config.rs
+++ b/bin/integration-tests/src/tests/config.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use miden_client::builder::ClientBuilder;
-use miden_client::crypto::RandomCoin;
+use miden_client::crypto::DefaultFeltRng;
 use miden_client::grpc_support::{DEVNET_PROVER_ENDPOINT, TESTNET_PROVER_ENDPOINT};
 use miden_client::note_transport::grpc::GrpcNoteTransportClient;
 use miden_client::note_transport::{
@@ -15,7 +15,7 @@ use miden_client::note_transport::{
 };
 use miden_client::rpc::{Endpoint, GrpcClient};
 use miden_client::testing::common::{FilesystemKeyStore, TestClient, create_test_store_path};
-use miden_client::{DebugMode, Felt, RemoteTransactionProver};
+use miden_client::{DebugMode, RemoteTransactionProver};
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use rand::Rng;
 use uuid::Uuid;
@@ -135,9 +135,9 @@ impl ClientConfig {
         let (rpc_endpoint, rpc_timeout, store_config, auth_path) = self.as_parts();
 
         let mut rng = rand::rng();
-        let coin_seed: [u64; 4] = rng.random();
+        let seed: [u8; 32] = rng.random();
 
-        let rng = RandomCoin::new(coin_seed.map(Felt::new_unchecked).into());
+        let rng = DefaultFeltRng::from_seed(seed);
 
         let keystore = FilesystemKeyStore::new(auth_path.clone()).with_context(|| {
             format!("failed to create keystore at path: {}", auth_path.to_string_lossy())

--- a/bin/integration-tests/src/tests/custom_transaction.rs
+++ b/bin/integration-tests/src/tests/custom_transaction.rs
@@ -2,7 +2,14 @@ use anyhow::{Context, Result};
 use miden_client::account::{AccountId, AccountType};
 use miden_client::asset::FungibleAsset;
 use miden_client::auth::RPO_FALCON_SCHEME_ID;
-use miden_client::crypto::{FeltRng, MerkleStore, MerkleTree, NodeIndex, Poseidon2, RandomCoin};
+use miden_client::crypto::{
+    DefaultFeltRng,
+    FeltRng,
+    MerkleStore,
+    MerkleTree,
+    NodeIndex,
+    Poseidon2,
+};
 use miden_client::note::{
     Note,
     NoteAssets,
@@ -318,7 +325,7 @@ async fn mint_custom_note(
     target_account_id: AccountId,
 ) -> Result<Note> {
     // Prepare transaction
-    let mut random_coin = RandomCoin::new(Default::default());
+    let mut random_coin = DefaultFeltRng::from_seed([0u8; 32]);
     let note = create_custom_note(client, faucet_account_id, target_account_id, &mut random_coin)?;
 
     let transaction_request =
@@ -335,7 +342,7 @@ fn create_custom_note(
     client: &TestClient,
     faucet_account_id: AccountId,
     target_account_id: AccountId,
-    rng: &mut RandomCoin,
+    rng: &mut impl FeltRng,
 ) -> Result<Note> {
     let mem_addr: u32 = 1000;
 

--- a/bin/miden-bench/src/config.rs
+++ b/bin/miden-bench/src/config.rs
@@ -2,10 +2,10 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use miden_client::builder::ClientBuilder;
-use miden_client::crypto::RandomCoin;
+use miden_client::crypto::DefaultFeltRng;
 use miden_client::keystore::FilesystemKeyStore;
 use miden_client::rpc::{Endpoint, GrpcClient};
-use miden_client::{Client, DebugMode, Felt};
+use miden_client::{Client, DebugMode};
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use rand::Rng;
 
@@ -44,8 +44,8 @@ pub async fn create_client(
     std::fs::create_dir_all(&keystore_path)?;
 
     let mut rng = rand::rng();
-    let coin_seed: [u64; 4] = rng.random();
-    let rng_coin = RandomCoin::new(coin_seed.map(Felt::new_unchecked).into());
+    let seed: [u8; 32] = rng.random();
+    let rng_coin = DefaultFeltRng::from_seed(seed);
 
     let client = ClientBuilder::new()
         .rpc(Arc::new(GrpcClient::new(endpoint, 30_000)))

--- a/bin/miden-cli/tests/cli.rs
+++ b/bin/miden-cli/tests/cli.rs
@@ -12,7 +12,7 @@ use miden_client::account::{AccountId, AccountType, FaucetMetadata};
 use miden_client::address::{Address, NetworkId};
 use miden_client::auth::{RPO_FALCON_SCHEME_ID, TransactionAuthenticator};
 use miden_client::builder::ClientBuilder;
-use miden_client::crypto::{FeltRng, RandomCoin};
+use miden_client::crypto::{DefaultFeltRng, FeltRng};
 use miden_client::keystore::Keystore;
 use miden_client::note::{
     Note,
@@ -37,7 +37,7 @@ use miden_client::testing::common::{
 };
 use miden_client::transaction::TransactionRequestBuilder;
 use miden_client::utils::Serializable;
-use miden_client::{self, Client, DebugMode, Felt};
+use miden_client::{self, Client, DebugMode};
 use miden_client_cli::MIDEN_DIR;
 use miden_client_cli::config::Network;
 use miden_client_sqlite_store::SqliteStore;
@@ -1515,9 +1515,9 @@ async fn create_rust_client_with_store_path(
     };
 
     let mut rng = rand::rng();
-    let coin_seed: [u64; 4] = rng.random();
+    let seed: [u8; 32] = rng.random();
 
-    let rng = Box::new(RandomCoin::new(coin_seed.map(Felt::new_unchecked).into()));
+    let rng = Box::new(DefaultFeltRng::from_seed(seed));
 
     let keystore = FilesystemKeyStore::new(temp_dir())?;
 

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -84,6 +84,7 @@ hex          = { workspace = true }
 prost        = { features = ["derive"], workspace = true }
 prost-types  = { version = "0.14" }
 rand         = { workspace = true }
+rand_chacha  = { workspace = true }
 serde        = { workspace = true }
 serde_json   = { workspace = true }
 tempfile     = { optional = true, workspace = true }

--- a/crates/rust-client/src/builder.rs
+++ b/crates/rust-client/src/builder.rs
@@ -3,8 +3,7 @@ use alloc::sync::Arc;
 
 use miden_protocol::assembly::{DefaultSourceManager, SourceManagerSync};
 use miden_protocol::block::BlockNumber;
-use miden_protocol::crypto::rand::RandomCoin;
-use miden_protocol::{Felt, MAX_TX_EXECUTION_CYCLES, MIN_TX_EXECUTION_CYCLES};
+use miden_protocol::{MAX_TX_EXECUTION_CYCLES, MIN_TX_EXECUTION_CYCLES};
 use miden_tx::{ExecutionOptions, LocalTransactionProver};
 use rand::Rng;
 
@@ -14,6 +13,7 @@ use crate::alloc::string::ToString;
 use crate::keystore::FilesystemKeyStore;
 use crate::keystore::Keystore;
 use crate::note_transport::NoteTransportClient;
+use crate::rng::DefaultFeltRng;
 use crate::rpc::{Endpoint, NodeRpcClient};
 use crate::store::{Store, StoreError};
 use crate::transaction::TransactionProver;
@@ -482,8 +482,8 @@ where
             user_rng
         } else {
             let mut seed_rng = rand::rng();
-            let coin_seed: [u64; 4] = seed_rng.random();
-            Box::new(RandomCoin::new(coin_seed.map(Felt::new_unchecked).into()))
+            let seed: [u8; 32] = seed_rng.random();
+            Box::new(DefaultFeltRng::from_seed(seed))
         };
 
         // Set default prover if not provided

--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -130,6 +130,8 @@ pub mod utils;
 
 pub mod builder;
 
+mod rng;
+
 #[cfg(feature = "testing")]
 mod test_utils;
 
@@ -270,7 +272,9 @@ pub mod crypto {
         NodeIndex,
         SparseMerklePath,
     };
-    pub use miden_protocol::crypto::rand::{FeltRng, RandomCoin};
+    pub use miden_protocol::crypto::rand::FeltRng;
+
+    pub use crate::rng::{DefaultFeltRng, FeltRngAdapter};
 }
 
 /// Provides types for working with addresses within the Miden network.

--- a/crates/rust-client/src/rng.rs
+++ b/crates/rust-client/src/rng.rs
@@ -1,0 +1,81 @@
+//! Random number generation utilities for the client.
+//!
+//! The client draws randomness through the [`FeltRng`] trait. [`FeltRngAdapter`] lifts any
+//! [`RngCore`] into a [`FeltRng`], and [`DefaultFeltRng`] is the client's default RNG, backed by
+//! a `ChaCha20` generator.
+
+use miden_protocol::crypto::rand::FeltRng;
+use miden_protocol::{Felt, Word};
+use rand::{RngCore, SeedableRng};
+use rand_chacha::ChaCha20Rng;
+
+// FELT RNG ADAPTER
+// ================================================================================================
+
+/// Adapts any [`RngCore`] into a [`FeltRng`].
+///
+/// Field elements are produced by rejection sampling over `[0, Felt::ORDER)`, yielding a uniform
+/// distribution over the field. A single draw is rejected with probability about `2^-32`.
+#[derive(Debug, Clone)]
+pub struct FeltRngAdapter<R>(R);
+
+impl<R: RngCore> FeltRngAdapter<R> {
+    /// Wraps the given [`RngCore`] so it can be used as a [`FeltRng`].
+    pub fn new(rng: R) -> Self {
+        Self(rng)
+    }
+}
+
+impl<R: RngCore> RngCore for FeltRngAdapter<R> {
+    fn next_u32(&mut self) -> u32 {
+        self.0.next_u32()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.0.next_u64()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.0.fill_bytes(dest);
+    }
+}
+
+impl<R: RngCore> FeltRng for FeltRngAdapter<R> {
+    fn draw_element(&mut self) -> Felt {
+        // Rejection sampling keeps the draw uniform over the field by discarding the few `u64`
+        // values that fall outside the canonical range `[0, Felt::ORDER)`. The retained value is
+        // already canonical, so `new_unchecked` avoids a redundant reduction.
+        loop {
+            let value = self.0.next_u64();
+            if value < Felt::ORDER {
+                return Felt::new_unchecked(value);
+            }
+        }
+    }
+
+    fn draw_word(&mut self) -> Word {
+        [
+            self.draw_element(),
+            self.draw_element(),
+            self.draw_element(),
+            self.draw_element(),
+        ]
+        .into()
+    }
+}
+
+// DEFAULT FELT RNG
+// ================================================================================================
+
+/// The client's default [`FeltRng`], backed by a `ChaCha20` generator.
+///
+/// `ChaCha20` is value-stable across releases, so an instance built from a fixed seed reproduces
+/// the same sequence of elements. This makes it suitable for deterministic testing.
+pub type DefaultFeltRng = FeltRngAdapter<ChaCha20Rng>;
+
+impl DefaultFeltRng {
+    /// Creates a [`DefaultFeltRng`] from a 32-byte seed.
+    pub fn from_seed(seed: [u8; 32]) -> Self {
+        FeltRngAdapter(ChaCha20Rng::from_seed(seed))
+    }
+}

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -1224,10 +1224,8 @@ pub(crate) fn validate_executed_transaction(
 mod tests {
     use alloc::vec;
 
-    use miden_protocol::Word;
     use miden_protocol::account::AccountId;
     use miden_protocol::asset::FungibleAsset;
-    use miden_protocol::crypto::rand::RandomCoin;
     use miden_protocol::note::{Note, NoteAttachments, NoteType};
     use miden_protocol::testing::account_id::{
         ACCOUNT_ID_PRIVATE_FUNGIBLE_FAUCET,
@@ -1238,13 +1236,14 @@ mod tests {
 
     use super::{TransactionRequestBuilder, validate_output_note_senders};
     use crate::ClientError;
+    use crate::rng::DefaultFeltRng;
     use crate::transaction::TransactionRequestError;
 
     fn own_note_with_sender(sender: AccountId) -> Note {
         let faucet_id = AccountId::try_from(ACCOUNT_ID_PRIVATE_FUNGIBLE_FAUCET).unwrap();
         let target_id =
             AccountId::try_from(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE).unwrap();
-        let mut rng = RandomCoin::new(Word::default());
+        let mut rng = DefaultFeltRng::from_seed([0u8; 32]);
 
         P2idNote::create(
             sender,

--- a/crates/rust-client/src/transaction/request/mod.rs
+++ b/crates/rust-client/src/transaction/request/mod.rs
@@ -566,7 +566,7 @@ mod tests {
         StorageSlotName,
     };
     use miden_protocol::asset::FungibleAsset;
-    use miden_protocol::crypto::rand::{FeltRng, RandomCoin};
+    use miden_protocol::crypto::rand::FeltRng;
     use miden_protocol::note::{NoteAttachments, NoteTag, NoteType};
     use miden_protocol::testing::account_id::{
         ACCOUNT_ID_PRIVATE_FUNGIBLE_FAUCET,
@@ -580,6 +580,7 @@ mod tests {
     use miden_tx::utils::serde::{Deserializable, Serializable};
 
     use super::{TransactionRequest, TransactionRequestBuilder};
+    use crate::rng::DefaultFeltRng;
     use crate::rpc::domain::account::AccountStorageRequirements;
     use crate::transaction::ForeignAccount;
 
@@ -610,7 +611,7 @@ mod tests {
         let target_id =
             AccountId::try_from(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE).unwrap();
         let faucet_id = AccountId::try_from(ACCOUNT_ID_PRIVATE_FUNGIBLE_FAUCET).unwrap();
-        let mut rng = RandomCoin::new(Word::default());
+        let mut rng = DefaultFeltRng::from_seed([0u8; 32]);
 
         let mut notes = vec![];
         for i in 0..6 {

--- a/crates/testing/miden-client-tests/src/tests.rs
+++ b/crates/testing/miden-client-tests/src/tests.rs
@@ -17,6 +17,7 @@ use miden_client::auth::{
     RPO_FALCON_SCHEME_ID,
 };
 use miden_client::builder::ClientBuilder;
+use miden_client::crypto::DefaultFeltRng;
 use miden_client::keystore::{FilesystemKeyStore, Keystore};
 use miden_client::note::{BlockNumber, NetworkAccountTarget, NoteExecutionHint};
 use miden_client::rpc::NodeRpcClient;
@@ -85,7 +86,7 @@ use miden_protocol::asset::{
     FungibleAsset,
     TokenSymbol,
 };
-use miden_protocol::crypto::rand::{FeltRng, RandomCoin};
+use miden_protocol::crypto::rand::FeltRng;
 use miden_protocol::note::{
     Note,
     NoteAssets,
@@ -1355,8 +1356,7 @@ async fn input_note_reader_finds_externally_consumed_notes() {
     chain.prove_next_block().unwrap();
 
     // Build a client backed by this chain.
-    let rng =
-        RandomCoin::new(rand::random::<[u64; 4]>().map(|v| Felt::new_unchecked(v >> 1)).into());
+    let rng = DefaultFeltRng::from_seed(rand::random());
     let keystore_path = std::env::temp_dir();
     let keystore = FilesystemKeyStore::new(keystore_path).unwrap();
     let mock_rpc = MockRpcApi::new(chain);
@@ -1433,22 +1433,16 @@ async fn setup_prunable_block_scenario(
     let mut builder = MockChainBuilder::new();
     let mock_account = builder.add_existing_mock_account(miden_testing::Auth::IncrNonce).unwrap();
 
-    let note_first = NoteBuilder::new(
-        mock_account.id(),
-        RandomCoin::new([0, 0, 0, 0].map(Felt::new_unchecked).into()),
-    )
-    .note_type(NoteType::Public)
-    .tag(NoteTag::new(0).into())
-    .build()
-    .unwrap();
-    let note_second = NoteBuilder::new(
-        mock_account.id(),
-        RandomCoin::new([0, 0, 0, 1].map(Felt::new_unchecked).into()),
-    )
-    .note_type(NoteType::Public)
-    .tag(NoteTag::new(0).into())
-    .build()
-    .unwrap();
+    let note_first = NoteBuilder::new(mock_account.id(), DefaultFeltRng::from_seed([0u8; 32]))
+        .note_type(NoteType::Public)
+        .tag(NoteTag::new(0).into())
+        .build()
+        .unwrap();
+    let note_second = NoteBuilder::new(mock_account.id(), DefaultFeltRng::from_seed([1u8; 32]))
+        .note_type(NoteType::Public)
+        .tag(NoteTag::new(0).into())
+        .build()
+        .unwrap();
 
     let spawn_note_1 = builder.add_spawn_note(std::slice::from_ref(&note_first)).unwrap();
     let spawn_note_2 = builder.add_spawn_note(std::slice::from_ref(&note_second)).unwrap();
@@ -1490,8 +1484,7 @@ async fn setup_prunable_block_scenario(
     chain.add_pending_executed_transaction(&tx).unwrap();
     chain.prove_next_block().unwrap();
 
-    let rng =
-        RandomCoin::new(rand::random::<[u64; 4]>().map(|v| Felt::new_unchecked(v >> 1)).into());
+    let rng = DefaultFeltRng::from_seed(rand::random());
     let keystore = FilesystemKeyStore::new(std::env::temp_dir()).unwrap();
     let mock_rpc = MockRpcApi::new(chain);
 
@@ -3258,8 +3251,8 @@ async fn import_watched_account_by_id_rejects_already_tracked_native_account() {
     let rpc_api = MockRpcApi::new(mock_chain_builder.build().unwrap());
     let arc_rpc_api = Arc::new(rpc_api);
     let mut rng = rand::rng();
-    let coin_seed: [u64; 4] = rng.random();
-    let rng = RandomCoin::new(coin_seed.map(|v| Felt::new_unchecked(v >> 1)).into());
+    let seed: [u8; 32] = rng.random();
+    let rng = DefaultFeltRng::from_seed(seed);
     let keystore = FilesystemKeyStore::new(temp_dir()).unwrap();
     let mut client = ClientBuilder::new()
         .rpc(arc_rpc_api)
@@ -3515,7 +3508,7 @@ async fn sync_stores_private_note_attachments() {
     // 2. Build a PRIVATE P2ID note carrying a NetworkAccountTarget attachment.
     let ntx_target = NetworkAccountTarget::new(target.id(), NoteExecutionHint::Always).unwrap();
     let attachments = NoteAttachments::new(vec![ntx_target.into()]).unwrap();
-    let mut note_rng = RandomCoin::new([1, 2, 3, 4].map(Felt::new_unchecked).into());
+    let mut note_rng = DefaultFeltRng::from_seed([1u8; 32]);
     let private_note = P2idNote::create(
         sender.id(),
         target.id(),
@@ -3555,8 +3548,7 @@ async fn sync_stores_private_note_attachments() {
     let rpc_api = Arc::new(MockRpcApi::new(mock_chain));
     rpc_api.register_private_note_attachments(private_note.id(), attachments.clone());
 
-    let rng =
-        RandomCoin::new(rand::random::<[u64; 4]>().map(|v| Felt::new_unchecked(v >> 1)).into());
+    let rng = DefaultFeltRng::from_seed(rand::random());
     let keystore = FilesystemKeyStore::new(std::env::temp_dir()).unwrap();
     let mut client = ClientBuilder::new()
         .rpc(rpc_api)
@@ -3701,8 +3693,8 @@ async fn sync_large_public_account() {
     // 4. Build a client and add the ORIGINAL (pre-tx) account.
     // The pre-tx commitment differs from on-chain, which triggers sync.
     let mut rng = rand::rng();
-    let coin_seed: [u64; 4] = rng.random();
-    let rng = RandomCoin::new(coin_seed.map(|v| Felt::new_unchecked(v >> 1)).into());
+    let seed: [u8; 32] = rng.random();
+    let rng = DefaultFeltRng::from_seed(seed);
 
     let keystore_path = temp_dir();
     let keystore = FilesystemKeyStore::new(keystore_path).unwrap();
@@ -3766,8 +3758,8 @@ async fn prepare_offline_bootstrap_inserts_mock_chain_genesis() {
     use miden_protocol::transaction::TransactionKernel;
 
     let mut rng_seed = rand::rng();
-    let coin_seed: [u64; 4] = rng_seed.random();
-    let rng = RandomCoin::new(coin_seed.map(Felt::new_unchecked).into());
+    let seed: [u8; 32] = rng_seed.random();
+    let rng = DefaultFeltRng::from_seed(seed);
 
     let reference_rpc = MockRpcApi::default();
     let (expected_genesis, _) = reference_rpc
@@ -3817,9 +3809,9 @@ pub async fn create_test_client() -> (MockClient<FilesystemKeyStore>, MockRpcApi
 pub async fn create_test_client_builder()
 -> (ClientBuilder<FilesystemKeyStore>, MockRpcApi, FilesystemKeyStore) {
     let mut rng = rand::rng();
-    let coin_seed: [u64; 4] = rng.random();
+    let seed: [u8; 32] = rng.random();
 
-    let rng = RandomCoin::new(coin_seed.map(|v| Felt::new_unchecked(v >> 1)).into());
+    let rng = DefaultFeltRng::from_seed(seed);
 
     let keystore_path = temp_dir();
     let keystore = FilesystemKeyStore::new(keystore_path).unwrap();
@@ -3844,23 +3836,17 @@ pub async fn create_prebuilt_mock_chain() -> MockChain {
         .add_existing_mock_account(miden_testing::Auth::IncrNonce)
         .unwrap();
 
-    let note_first = NoteBuilder::new(
-        mock_account.id(),
-        RandomCoin::new([0, 0, 0, 0].map(Felt::new_unchecked).into()),
-    )
-    .note_type(NoteType::Public)
-    .tag(NoteTag::new(0).into())
-    .build()
-    .unwrap();
+    let note_first = NoteBuilder::new(mock_account.id(), DefaultFeltRng::from_seed([0u8; 32]))
+        .note_type(NoteType::Public)
+        .tag(NoteTag::new(0).into())
+        .build()
+        .unwrap();
 
-    let note_second = NoteBuilder::new(
-        mock_account.id(),
-        RandomCoin::new([0, 0, 0, 1].map(Felt::new_unchecked).into()),
-    )
-    .note_type(NoteType::Public)
-    .tag(NoteTag::new(0).into())
-    .build()
-    .unwrap();
+    let note_second = NoteBuilder::new(mock_account.id(), DefaultFeltRng::from_seed([1u8; 32]))
+        .note_type(NoteType::Public)
+        .tag(NoteTag::new(0).into())
+        .build()
+        .unwrap();
     let spawn_note_1 =
         mock_chain_builder.add_spawn_note(std::slice::from_ref(&note_first)).unwrap();
     let spawn_note_2 =

--- a/crates/testing/miden-client-tests/src/tests/batch.rs
+++ b/crates/testing/miden-client-tests/src/tests/batch.rs
@@ -5,6 +5,7 @@ use miden_client::account::AccountType;
 use miden_client::asset::{Asset, FungibleAsset};
 use miden_client::auth::RPO_FALCON_SCHEME_ID;
 use miden_client::builder::ClientBuilder;
+use miden_client::crypto::DefaultFeltRng;
 use miden_client::keystore::FilesystemKeyStore;
 use miden_client::note::{NoteType, NoteUpdateTracker};
 use miden_client::rpc::NodeRpcClient;
@@ -26,8 +27,6 @@ use miden_client::transaction::{
 };
 use miden_client::{ClientError, DebugMode};
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-use miden_protocol::Felt;
-use miden_protocol::crypto::rand::RandomCoin;
 use miden_testing::{Auth, MockChainBuilder, TxContextInput};
 
 use crate::tests::create_test_client;
@@ -158,8 +157,7 @@ async fn apply_transaction_batch_rolls_back_on_mid_batch_failure() {
     let mock_chain = chain_builder.build().unwrap();
 
     // Build a client backed by the mock chain.
-    let rng =
-        RandomCoin::new(rand::random::<[u64; 4]>().map(|v| Felt::new_unchecked(v >> 1)).into());
+    let rng = DefaultFeltRng::from_seed(rand::random());
     let keystore = FilesystemKeyStore::new(std::env::temp_dir()).unwrap();
     let rpc_api = MockRpcApi::new(mock_chain);
     let mut client = ClientBuilder::new()
@@ -435,7 +433,7 @@ async fn batch_builder_submits_txs_across_multiple_accounts() {
     let account_id_b = account_b.id();
     let mock_chain = chain_builder.build().unwrap();
 
-    let rng = RandomCoin::new(rand::random::<[u64; 4]>().map(Felt::new_unchecked).into());
+    let rng = DefaultFeltRng::from_seed(rand::random());
     let keystore = FilesystemKeyStore::new(std::env::temp_dir()).unwrap();
     let rpc_api = MockRpcApi::new(mock_chain);
     let mut client = ClientBuilder::new()

--- a/crates/testing/miden-client-tests/src/tests/transport.rs
+++ b/crates/testing/miden-client-tests/src/tests/transport.rs
@@ -5,6 +5,7 @@ use miden_client::DebugMode;
 use miden_client::account::{Account, AccountType};
 use miden_client::address::{Address, AddressInterface, RoutingParameters};
 use miden_client::builder::ClientBuilder;
+use miden_client::crypto::DefaultFeltRng;
 use miden_client::keystore::FilesystemKeyStore;
 use miden_client::note::{NoteAttachments, NoteDetails, NoteTag, NoteType};
 use miden_client::note_transport::NoteTransportClient;
@@ -18,8 +19,6 @@ use miden_client::testing::note_transport::{
 };
 use miden_client::utils::RwLock;
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-use miden_protocol::Felt;
-use miden_protocol::crypto::rand::RandomCoin;
 use miden_protocol::note::NoteType as ProtocolNoteType;
 use miden_protocol::transaction::RawOutputNote;
 use miden_protocol::utils::serde::Serializable;
@@ -248,14 +247,11 @@ async fn fetch_private_notes_finds_note_committed_at_sync_height() {
         .add_existing_mock_account(miden_testing::Auth::IncrNonce)
         .unwrap();
 
-    let private_note = NoteBuilder::new(
-        mock_account.id(),
-        RandomCoin::new([1, 2, 3, 4].map(Felt::new_unchecked).into()),
-    )
-    .note_type(ProtocolNoteType::Private)
-    .tag(NoteTag::new(0).into())
-    .build()
-    .unwrap();
+    let private_note = NoteBuilder::new(mock_account.id(), DefaultFeltRng::from_seed([1u8; 32]))
+        .note_type(ProtocolNoteType::Private)
+        .tag(NoteTag::new(0).into())
+        .build()
+        .unwrap();
 
     let spawn_note =
         mock_chain_builder.add_spawn_note(std::slice::from_ref(&private_note)).unwrap();
@@ -289,8 +285,8 @@ async fn fetch_private_notes_finds_note_committed_at_sync_height() {
     let transport_client = MockNoteTransportApi::new(mock_transport_node.clone());
 
     let mut rng = rand::rng();
-    let coin_seed: [u64; 4] = rng.random();
-    let rng = RandomCoin::new(coin_seed.map(|v| Felt::new_unchecked(v >> 1)).into());
+    let seed: [u8; 32] = rng.random();
+    let rng = DefaultFeltRng::from_seed(seed);
 
     let keystore_path = temp_dir();
     let keystore = FilesystemKeyStore::new(keystore_path.clone()).unwrap();


### PR DESCRIPTION
We are currently investigating whether it's possible to remove custom randomness from crypto:

> Why do we have our own Rng traits? Can't we implement Rng from rand on types directly?

https://github.com/0xMiden/miden-vm/issues/3531#issuecomment-4519698839

Part of this effort is to see if the client can get away without it. In this PR two things are important in that respect:

1. We can replace `RandomCoin` with a client's own struct: `DefaultFeltRng` (ChaCha20).
2. Yet we still depend on the `FeltRng` trait itself, as some signatures need to satisfy it (note creation and `TransactionRequestBuilder` take `impl FeltRng`). For this we'd need to replace the places where `FeltRng` is required with something more generic like `Rng`, which implies making changes to both protocol and node*.

* biggest setback about this is the need of switching back node's protocol dependency to `next`, which would bring breaking changes to devnet (thus postponed momentarily).

Tackles #2204