### PR TITLE
chore: bump protocol to `0.15.3` and node to `0.15.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * [BREAKING] Note attachments are no longer carried on the note-transport wire format (only `NoteHeader` + serialized `NoteDetails`). ([#2185](https://github.com/0xMiden/miden-client/pull/2185))
 * [BREAKING][rust] Removed the top-level `miden_client::standards` alias. Use the curated client paths as before, or the new raw upstream namespaces `miden_client::account::standards::*`, `miden_client::note::standards::*`, and `miden_client::testing::standards::*`. ([#2185](https://github.com/0xMiden/miden-client/pull/2185))
 * Added a blanket implementation for `NodeRpcClient::get_account_details` ([#2196](https://github.com/0xMiden/miden-client/pull/2196)).
+* [BREAKING][param][rust] `NodeRpcClient::sync_storage_maps` and `NodeRpcClient::sync_account_vault` now take a required `block_to: BlockNumber` instead of `Option<BlockNumber>`. The node rejects ranges that extend beyond the chain tip, so callers must pass an explicit upper bound (e.g. the client's sync height). ([#2229](https://github.com/0xMiden/miden-client/pull/2229))
 
 ### Enhancements
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3276,7 +3276,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client"
-version = "0.15.0-rc"
+version = "0.15.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3315,7 +3315,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-bench"
-version = "0.15.0-rc"
+version = "0.15.0-rc.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-cli"
-version = "0.15.0-rc"
+version = "0.15.0-rc.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-integration-tests"
-version = "0.15.0-rc"
+version = "0.15.0-rc.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3379,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-sqlite-store"
-version = "0.15.0-rc"
+version = "0.15.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3397,7 +3397,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-unit-tests"
-version = "0.15.0-rc"
+version = "0.15.0-rc.0"
 dependencies = [
  "miden-client",
  "miden-client-sqlite-store",
@@ -3611,8 +3611,8 @@ dependencies = [
 
 [[package]]
 name = "miden-large-smt-backend-rocksdb"
-version = "0.15.0-rc.1"
-source = "git+https://github.com/0xMiden/node.git?rev=3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4#3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4"
+version = "0.15.0-rc.3"
+source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0-rc.3#73b0eb9ed63321a74abead9e214559048d5bd9aa"
 dependencies = [
  "miden-crypto",
  "miden-node-rocksdb-cxx-linkage-fix",
@@ -3708,8 +3708,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-block-producer"
-version = "0.15.0-rc.1"
-source = "git+https://github.com/0xMiden/node.git?rev=3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4#3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4"
+version = "0.15.0-rc.3"
+source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0-rc.3#73b0eb9ed63321a74abead9e214559048d5bd9aa"
 dependencies = [
  "anyhow",
  "futures",
@@ -3732,8 +3732,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-db"
-version = "0.15.0-rc.1"
-source = "git+https://github.com/0xMiden/node.git?rev=3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4#3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4"
+version = "0.15.0-rc.3"
+source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0-rc.3#73b0eb9ed63321a74abead9e214559048d5bd9aa"
 dependencies = [
  "anyhow",
  "build-rs",
@@ -3752,8 +3752,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-grpc-error-macro"
-version = "0.15.0-rc.1"
-source = "git+https://github.com/0xMiden/node.git?rev=3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4#3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4"
+version = "0.15.0-rc.3"
+source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0-rc.3#73b0eb9ed63321a74abead9e214559048d5bd9aa"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -3761,8 +3761,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto"
-version = "0.15.0-rc.1"
-source = "git+https://github.com/0xMiden/node.git?rev=3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4#3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4"
+version = "0.15.0-rc.3"
+source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0-rc.3#73b0eb9ed63321a74abead9e214559048d5bd9aa"
 dependencies = [
  "anyhow",
  "build-rs",
@@ -3787,8 +3787,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.15.0-rc.1"
-source = "git+https://github.com/0xMiden/node.git?rev=3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4#3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4"
+version = "0.15.0-rc.3"
+source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0-rc.3#73b0eb9ed63321a74abead9e214559048d5bd9aa"
 dependencies = [
  "build-rs",
  "codegen",
@@ -3800,13 +3800,13 @@ dependencies = [
 
 [[package]]
 name = "miden-node-rocksdb-cxx-linkage-fix"
-version = "0.15.0-rc.1"
-source = "git+https://github.com/0xMiden/node.git?rev=3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4#3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4"
+version = "0.15.0-rc.3"
+source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0-rc.3#73b0eb9ed63321a74abead9e214559048d5bd9aa"
 
 [[package]]
 name = "miden-node-rpc"
-version = "0.15.0-rc.1"
-source = "git+https://github.com/0xMiden/node.git?rev=3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4#3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4"
+version = "0.15.0-rc.3"
+source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0-rc.3#73b0eb9ed63321a74abead9e214559048d5bd9aa"
 dependencies = [
  "anyhow",
  "futures",
@@ -3835,8 +3835,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-store"
-version = "0.15.0-rc.1"
-source = "git+https://github.com/0xMiden/node.git?rev=3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4#3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4"
+version = "0.15.0-rc.3"
+source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0-rc.3#73b0eb9ed63321a74abead9e214559048d5bd9aa"
 dependencies = [
  "anyhow",
  "build-rs",
@@ -3868,8 +3868,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-utils"
-version = "0.15.0-rc.1"
-source = "git+https://github.com/0xMiden/node.git?rev=3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4#3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4"
+version = "0.15.0-rc.3"
+source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0-rc.3#73b0eb9ed63321a74abead9e214559048d5bd9aa"
 dependencies = [
  "anyhow",
  "backon",
@@ -3916,8 +3916,8 @@ dependencies = [
 
 [[package]]
 name = "miden-ntx-builder"
-version = "0.15.0-rc.1"
-source = "git+https://github.com/0xMiden/node.git?rev=3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4#3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4"
+version = "0.15.0-rc.3"
+source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0-rc.3#73b0eb9ed63321a74abead9e214559048d5bd9aa"
 dependencies = [
  "anyhow",
  "backon",
@@ -4043,8 +4043,8 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover-client"
-version = "0.15.0-rc.1"
-source = "git+https://github.com/0xMiden/node.git?rev=3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4#3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4"
+version = "0.15.0-rc.3"
+source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0-rc.3#73b0eb9ed63321a74abead9e214559048d5bd9aa"
 dependencies = [
  "build-rs",
  "fs-err",
@@ -4205,8 +4205,8 @@ dependencies = [
 
 [[package]]
 name = "miden-validator"
-version = "0.15.0-rc.1"
-source = "git+https://github.com/0xMiden/node.git?rev=3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4#3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4"
+version = "0.15.0-rc.3"
+source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0-rc.3#73b0eb9ed63321a74abead9e214559048d5bd9aa"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -4346,7 +4346,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "node-builder"
-version = "0.15.0-rc"
+version = "0.15.0-rc.0"
 dependencies = [
  "anyhow",
  "miden-node-block-producer",
@@ -6534,7 +6534,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "testing-remote-prover"
-version = "0.15.0-rc"
+version = "0.15.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3462,7 +3462,8 @@ dependencies = [
 [[package]]
 name = "miden-large-smt-backend-rocksdb"
 version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0#29a876c32ad4d3604101df089e8fbfeacfc91928"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5a525afade452fb9d7eddfec6aa8fe9a10968d38c10e67ede5c9ef831a6415"
 dependencies = [
  "miden-crypto",
  "miden-node-rocksdb-cxx-linkage-fix",
@@ -3559,7 +3560,8 @@ dependencies = [
 [[package]]
 name = "miden-node-block-producer"
 version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0#29a876c32ad4d3604101df089e8fbfeacfc91928"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed090748c9377d6a94d0cad1e692e6a4b4b84435dcce1bc6f97507323222017"
 dependencies = [
  "anyhow",
  "futures",
@@ -3584,7 +3586,8 @@ dependencies = [
 [[package]]
 name = "miden-node-db"
 version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0#29a876c32ad4d3604101df089e8fbfeacfc91928"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e668571c9dcc18c96ac1a29426341616a9fea58d90b1c4c726b9f18f81a0831"
 dependencies = [
  "anyhow",
  "build-rs",
@@ -3604,7 +3607,8 @@ dependencies = [
 [[package]]
 name = "miden-node-grpc-error-macro"
 version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0#29a876c32ad4d3604101df089e8fbfeacfc91928"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eddc5adf6c7b45eb1cdb79efbe30aeb40d0f993e31926f550401a32b52fb316"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -3613,7 +3617,8 @@ dependencies = [
 [[package]]
 name = "miden-node-proto"
 version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0#29a876c32ad4d3604101df089e8fbfeacfc91928"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1106f2d9e91c3f164d59ee9449307163265e98f7849d80c5a9ea090a7c063e38"
 dependencies = [
  "anyhow",
  "build-rs",
@@ -3639,7 +3644,8 @@ dependencies = [
 [[package]]
 name = "miden-node-proto-build"
 version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0#29a876c32ad4d3604101df089e8fbfeacfc91928"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef3b301741cedd6d0b532583690bc21dbf856d4e14218c591f3924bc905c660a"
 dependencies = [
  "build-rs",
  "codegen",
@@ -3652,12 +3658,14 @@ dependencies = [
 [[package]]
 name = "miden-node-rocksdb-cxx-linkage-fix"
 version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0#29a876c32ad4d3604101df089e8fbfeacfc91928"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29026f8a0cb2121933d85f0147d49bcb23bc56887699d112c9e880a2d1996e3"
 
 [[package]]
 name = "miden-node-rpc"
 version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0#29a876c32ad4d3604101df089e8fbfeacfc91928"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86f8b5784533e27c77be27783701847571b80bb1b2dfc63050ad52126911536"
 dependencies = [
  "anyhow",
  "futures",
@@ -3688,7 +3696,8 @@ dependencies = [
 [[package]]
 name = "miden-node-store"
 version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0#29a876c32ad4d3604101df089e8fbfeacfc91928"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29b9c2ea58d1254aa8b83adb48b3658074ed35bdf1e5404ecadea95bf84d5b3"
 dependencies = [
  "anyhow",
  "build-rs",
@@ -3720,7 +3729,8 @@ dependencies = [
 [[package]]
 name = "miden-node-utils"
 version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0#29a876c32ad4d3604101df089e8fbfeacfc91928"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebb0f721bd2c51ea932b599ba333d393afde1d01ffa6b07a19f67cca8c865a7d"
 dependencies = [
  "anyhow",
  "backon",
@@ -3768,7 +3778,8 @@ dependencies = [
 [[package]]
 name = "miden-ntx-builder"
 version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0#29a876c32ad4d3604101df089e8fbfeacfc91928"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14f60e56e8552e4b03b9399b11c5b0d1be3b7d750101cd38bfffda6dce351e2e"
 dependencies = [
  "anyhow",
  "backon",
@@ -3895,7 +3906,8 @@ dependencies = [
 [[package]]
 name = "miden-remote-prover-client"
 version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0#29a876c32ad4d3604101df089e8fbfeacfc91928"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2acdb9494689feeec0f60e3b61901b5eb2362b49b993b4cbc3eb75ad83514dd"
 dependencies = [
  "build-rs",
  "fs-err",
@@ -4057,7 +4069,8 @@ dependencies = [
 [[package]]
 name = "miden-validator"
 version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0#29a876c32ad4d3604101df089e8fbfeacfc91928"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993f832aac6379381715691e18818752803b56fe3e716bf3e6df246cbda192bf"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3185,9 +3185,9 @@ dependencies = [
 
 [[package]]
 name = "miden-agglayer"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3e46490926f6084d6216067ef9c0e606e547361ba492b1ca311dcfd780b185"
+checksum = "a52fa470d035f75ec7d48e37cc297a3988858abfffe4b0c514c2561a7a92b1d1"
 dependencies = [
  "alloy-sol-types",
  "fs-err",
@@ -3266,9 +3266,9 @@ dependencies = [
 
 [[package]]
 name = "miden-block-prover"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1829e10ccf220c6052cdcc4181c820307f177612e070623213c8670766de64"
+checksum = "baf9952b224950d826230146f513b45ebf9eb9dcc6066fb7c442afe83532dc4c"
 dependencies = [
  "miden-protocol",
  "thiserror 2.0.18",
@@ -3276,7 +3276,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client"
-version = "0.15.0"
+version = "0.15.0-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3315,7 +3315,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-bench"
-version = "0.15.0"
+version = "0.15.0-rc"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-cli"
-version = "0.15.0"
+version = "0.15.0-rc"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-integration-tests"
-version = "0.15.0"
+version = "0.15.0-rc"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3379,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-sqlite-store"
-version = "0.15.0"
+version = "0.15.0-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3397,7 +3397,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-unit-tests"
-version = "0.15.0"
+version = "0.15.0-rc"
 dependencies = [
  "miden-client",
  "miden-client-sqlite-store",
@@ -3611,8 +3611,8 @@ dependencies = [
 
 [[package]]
 name = "miden-large-smt-backend-rocksdb"
-version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?rev=6649a4ce774bc842c08e6bdc314f6ddafb816282#6649a4ce774bc842c08e6bdc314f6ddafb816282"
+version = "0.15.0-rc.1"
+source = "git+https://github.com/0xMiden/node.git?rev=3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4#3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4"
 dependencies = [
  "miden-crypto",
  "miden-node-rocksdb-cxx-linkage-fix",
@@ -3708,8 +3708,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-block-producer"
-version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?rev=6649a4ce774bc842c08e6bdc314f6ddafb816282#6649a4ce774bc842c08e6bdc314f6ddafb816282"
+version = "0.15.0-rc.1"
+source = "git+https://github.com/0xMiden/node.git?rev=3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4#3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4"
 dependencies = [
  "anyhow",
  "futures",
@@ -3732,8 +3732,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-db"
-version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?rev=6649a4ce774bc842c08e6bdc314f6ddafb816282#6649a4ce774bc842c08e6bdc314f6ddafb816282"
+version = "0.15.0-rc.1"
+source = "git+https://github.com/0xMiden/node.git?rev=3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4#3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4"
 dependencies = [
  "anyhow",
  "build-rs",
@@ -3752,8 +3752,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-grpc-error-macro"
-version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?rev=6649a4ce774bc842c08e6bdc314f6ddafb816282#6649a4ce774bc842c08e6bdc314f6ddafb816282"
+version = "0.15.0-rc.1"
+source = "git+https://github.com/0xMiden/node.git?rev=3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4#3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -3761,8 +3761,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto"
-version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?rev=6649a4ce774bc842c08e6bdc314f6ddafb816282#6649a4ce774bc842c08e6bdc314f6ddafb816282"
+version = "0.15.0-rc.1"
+source = "git+https://github.com/0xMiden/node.git?rev=3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4#3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4"
 dependencies = [
  "anyhow",
  "build-rs",
@@ -3787,8 +3787,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?rev=6649a4ce774bc842c08e6bdc314f6ddafb816282#6649a4ce774bc842c08e6bdc314f6ddafb816282"
+version = "0.15.0-rc.1"
+source = "git+https://github.com/0xMiden/node.git?rev=3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4#3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4"
 dependencies = [
  "build-rs",
  "codegen",
@@ -3800,13 +3800,13 @@ dependencies = [
 
 [[package]]
 name = "miden-node-rocksdb-cxx-linkage-fix"
-version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?rev=6649a4ce774bc842c08e6bdc314f6ddafb816282#6649a4ce774bc842c08e6bdc314f6ddafb816282"
+version = "0.15.0-rc.1"
+source = "git+https://github.com/0xMiden/node.git?rev=3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4#3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4"
 
 [[package]]
 name = "miden-node-rpc"
-version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?rev=6649a4ce774bc842c08e6bdc314f6ddafb816282#6649a4ce774bc842c08e6bdc314f6ddafb816282"
+version = "0.15.0-rc.1"
+source = "git+https://github.com/0xMiden/node.git?rev=3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4#3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4"
 dependencies = [
  "anyhow",
  "futures",
@@ -3835,8 +3835,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-store"
-version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?rev=6649a4ce774bc842c08e6bdc314f6ddafb816282#6649a4ce774bc842c08e6bdc314f6ddafb816282"
+version = "0.15.0-rc.1"
+source = "git+https://github.com/0xMiden/node.git?rev=3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4#3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4"
 dependencies = [
  "anyhow",
  "build-rs",
@@ -3868,8 +3868,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-utils"
-version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?rev=6649a4ce774bc842c08e6bdc314f6ddafb816282#6649a4ce774bc842c08e6bdc314f6ddafb816282"
+version = "0.15.0-rc.1"
+source = "git+https://github.com/0xMiden/node.git?rev=3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4#3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4"
 dependencies = [
  "anyhow",
  "backon",
@@ -3916,8 +3916,8 @@ dependencies = [
 
 [[package]]
 name = "miden-ntx-builder"
-version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?rev=6649a4ce774bc842c08e6bdc314f6ddafb816282#6649a4ce774bc842c08e6bdc314f6ddafb816282"
+version = "0.15.0-rc.1"
+source = "git+https://github.com/0xMiden/node.git?rev=3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4#3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4"
 dependencies = [
  "anyhow",
  "backon",
@@ -3998,9 +3998,9 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b70acd2c57f7f9185c5174966dd47080389271410f25f6a3539970a4474fd440"
+checksum = "2a1759044f21d139e6f82ecd47c55271b23f76999e87aa78869d862b4fd77ae3"
 dependencies = [
  "bech32",
  "fs-err",
@@ -4043,8 +4043,8 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover-client"
-version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?rev=6649a4ce774bc842c08e6bdc314f6ddafb816282#6649a4ce774bc842c08e6bdc314f6ddafb816282"
+version = "0.15.0-rc.1"
+source = "git+https://github.com/0xMiden/node.git?rev=3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4#3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4"
 dependencies = [
  "build-rs",
  "fs-err",
@@ -4074,9 +4074,9 @@ dependencies = [
 
 [[package]]
 name = "miden-standards"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc788da5d0dc43f93d6489a302d453cc6c67a12923208c9c8963e43073db0b3b"
+checksum = "d3e80fd9b9e508cbdfae19dac06e19ec28f01635f67c76e593f99de0701ab7a2"
 dependencies = [
  "bon",
  "fs-err",
@@ -4113,9 +4113,9 @@ dependencies = [
 
 [[package]]
 name = "miden-testing"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f8cdaa93307907537ae95f3c30efbba94ed9d393bbc75c057c763cceff8599"
+checksum = "f589ec7d6bb05e96cbdb8cdc0847467b0fe650854047abe6ca85896d98a49fe5"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -4134,9 +4134,9 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3cfee228a8b02efa9130bbe6ea086d1c8ffc1b4c93df10f880c9a9a3dfe634"
+checksum = "c529e50c553269c8a349e1379daade04025b1e9f0c9b32b969d1f31e2e1eb54d"
 dependencies = [
  "miden-processor",
  "miden-protocol",
@@ -4148,9 +4148,9 @@ dependencies = [
 
 [[package]]
 name = "miden-tx-batch-prover"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ff829d060dc0cf38816fbe179fe22f0916d2a141974b2518606d58fe0bd1b37"
+checksum = "935aaeeb1ee2fd8a1ac5df281a76fd553204221e3d574d6ae8a43906066bfc90"
 dependencies = [
  "miden-protocol",
  "miden-tx",
@@ -4205,8 +4205,8 @@ dependencies = [
 
 [[package]]
 name = "miden-validator"
-version = "0.15.0"
-source = "git+https://github.com/0xMiden/node.git?rev=6649a4ce774bc842c08e6bdc314f6ddafb816282#6649a4ce774bc842c08e6bdc314f6ddafb816282"
+version = "0.15.0-rc.1"
+source = "git+https://github.com/0xMiden/node.git?rev=3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4#3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -4346,7 +4346,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "node-builder"
-version = "0.15.0"
+version = "0.15.0-rc"
 dependencies = [
  "anyhow",
  "miden-node-block-producer",
@@ -6534,7 +6534,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "testing-remote-prover"
-version = "0.15.0"
+version = "0.15.0-rc"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,81 +43,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "alloy-primitives"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
-dependencies = [
- "bytes",
- "cfg-if",
- "const-hex",
- "derive_more",
- "itoa",
- "paste",
- "ruint",
- "rustc-hash",
- "sha3 0.11.0",
-]
-
-[[package]]
-name = "alloy-sol-macro"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "840128ed2b2971d6d4668a553fe403a82683d3acc646c73e75887e7157408033"
-dependencies = [
- "alloy-sol-macro-expander",
- "alloy-sol-macro-input",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "alloy-sol-macro-expander"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63ec265e5d65d725175f6ca7711c970824c90ef9c0d1f1973711d4150ee612dd"
-dependencies = [
- "alloy-sol-macro-input",
- "const-hex",
- "heck",
- "indexmap",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "sha3 0.11.0",
- "syn 2.0.117",
- "syn-solidity",
-]
-
-[[package]]
-name = "alloy-sol-macro-input"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89bf01077f18650876cfa682eb1f949967b5cde03f1a51c955c469d2c9b4aa67"
-dependencies = [
- "const-hex",
- "dunce",
- "heck",
- "macro-string",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "syn-solidity",
-]
-
-[[package]]
-name = "alloy-sol-types"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384cf252de0db2dec52821eac037a7f57e2aa33fe5b900ce6fe39973402341f1"
-dependencies = [
- "alloy-primitives",
- "alloy-sol-macro",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,18 +1124,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-hex"
-version = "1.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "proptest",
- "serde_core",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,15 +1140,6 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
-
-[[package]]
-name = "convert_case"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "core-foundation"
@@ -1567,12 +1471,10 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
  "syn 2.0.117",
- "unicode-xid",
 ]
 
 [[package]]
@@ -1908,15 +1810,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "fixed-hash"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
-dependencies = [
- "static_assertions",
-]
 
 [[package]]
 name = "fixedbitset"
@@ -2881,16 +2774,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "keccak"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
-]
-
-[[package]]
 name = "lalrpop"
 version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2904,7 +2787,7 @@ dependencies = [
  "petgraph 0.7.1",
  "regex",
  "regex-syntax",
- "sha3 0.10.9",
+ "sha3",
  "string_cache",
  "term",
  "unicode-xid",
@@ -3135,17 +3018,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "macro-string"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3181,28 +3053,6 @@ dependencies = [
  "miden-core",
  "miden-crypto",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "miden-agglayer"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a52fa470d035f75ec7d48e37cc297a3988858abfffe4b0c514c2561a7a92b1d1"
-dependencies = [
- "alloy-sol-types",
- "fs-err",
- "miden-assembly",
- "miden-core",
- "miden-crypto",
- "miden-protocol",
- "miden-standards",
- "miden-utils-sync",
- "primitive-types",
- "regex",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "walkdir",
 ]
 
 [[package]]
@@ -3266,9 +3116,9 @@ dependencies = [
 
 [[package]]
 name = "miden-block-prover"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf9952b224950d826230146f513b45ebf9eb9dcc6066fb7c442afe83532dc4c"
+checksum = "292ded918a0ddd056dc34db471f0bef6ac7991467d513ba505a4fcc0b1ecfac4"
 dependencies = [
  "miden-protocol",
  "thiserror 2.0.18",
@@ -3276,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client"
-version = "0.15.0-rc.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3315,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-bench"
-version = "0.15.0-rc.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3331,7 +3181,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-cli"
-version = "0.15.0-rc.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3358,7 +3208,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-integration-tests"
-version = "0.15.0-rc.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3379,7 +3229,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-sqlite-store"
-version = "0.15.0-rc.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3397,7 +3247,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-unit-tests"
-version = "0.15.0-rc.0"
+version = "0.15.0"
 dependencies = [
  "miden-client",
  "miden-client-sqlite-store",
@@ -3487,7 +3337,7 @@ dependencies = [
  "rocksdb",
  "serde",
  "sha2 0.10.9",
- "sha3 0.10.9",
+ "sha3",
  "subtle",
  "thiserror 2.0.18",
  "x25519-dalek",
@@ -3611,8 +3461,8 @@ dependencies = [
 
 [[package]]
 name = "miden-large-smt-backend-rocksdb"
-version = "0.15.0-rc.3"
-source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0-rc.3#73b0eb9ed63321a74abead9e214559048d5bd9aa"
+version = "0.15.0"
+source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0#29a876c32ad4d3604101df089e8fbfeacfc91928"
 dependencies = [
  "miden-crypto",
  "miden-node-rocksdb-cxx-linkage-fix",
@@ -3708,8 +3558,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-block-producer"
-version = "0.15.0-rc.3"
-source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0-rc.3#73b0eb9ed63321a74abead9e214559048d5bd9aa"
+version = "0.15.0"
+source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0#29a876c32ad4d3604101df089e8fbfeacfc91928"
 dependencies = [
  "anyhow",
  "futures",
@@ -3726,14 +3576,15 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
+ "tonic-health",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "miden-node-db"
-version = "0.15.0-rc.3"
-source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0-rc.3#73b0eb9ed63321a74abead9e214559048d5bd9aa"
+version = "0.15.0"
+source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0#29a876c32ad4d3604101df089e8fbfeacfc91928"
 dependencies = [
  "anyhow",
  "build-rs",
@@ -3752,8 +3603,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-grpc-error-macro"
-version = "0.15.0-rc.3"
-source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0-rc.3#73b0eb9ed63321a74abead9e214559048d5bd9aa"
+version = "0.15.0"
+source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0#29a876c32ad4d3604101df089e8fbfeacfc91928"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -3761,8 +3612,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto"
-version = "0.15.0-rc.3"
-source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0-rc.3#73b0eb9ed63321a74abead9e214559048d5bd9aa"
+version = "0.15.0"
+source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0#29a876c32ad4d3604101df089e8fbfeacfc91928"
 dependencies = [
  "anyhow",
  "build-rs",
@@ -3787,8 +3638,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.15.0-rc.3"
-source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0-rc.3#73b0eb9ed63321a74abead9e214559048d5bd9aa"
+version = "0.15.0"
+source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0#29a876c32ad4d3604101df089e8fbfeacfc91928"
 dependencies = [
  "build-rs",
  "codegen",
@@ -3800,13 +3651,13 @@ dependencies = [
 
 [[package]]
 name = "miden-node-rocksdb-cxx-linkage-fix"
-version = "0.15.0-rc.3"
-source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0-rc.3#73b0eb9ed63321a74abead9e214559048d5bd9aa"
+version = "0.15.0"
+source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0#29a876c32ad4d3604101df089e8fbfeacfc91928"
 
 [[package]]
 name = "miden-node-rpc"
-version = "0.15.0-rc.3"
-source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0-rc.3#73b0eb9ed63321a74abead9e214559048d5bd9aa"
+version = "0.15.0"
+source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0#29a876c32ad4d3604101df089e8fbfeacfc91928"
 dependencies = [
  "anyhow",
  "futures",
@@ -3825,6 +3676,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
+ "tonic-health",
  "tonic-reflection",
  "tonic-web",
  "tower",
@@ -3835,8 +3687,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-store"
-version = "0.15.0-rc.3"
-source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0-rc.3#73b0eb9ed63321a74abead9e214559048d5bd9aa"
+version = "0.15.0"
+source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0#29a876c32ad4d3604101df089e8fbfeacfc91928"
 dependencies = [
  "anyhow",
  "build-rs",
@@ -3847,7 +3699,6 @@ dependencies = [
  "hex",
  "indexmap",
  "libsqlite3-sys",
- "miden-agglayer",
  "miden-crypto",
  "miden-large-smt-backend-rocksdb",
  "miden-node-db",
@@ -3868,8 +3719,8 @@ dependencies = [
 
 [[package]]
 name = "miden-node-utils"
-version = "0.15.0-rc.3"
-source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0-rc.3#73b0eb9ed63321a74abead9e214559048d5bd9aa"
+version = "0.15.0"
+source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0#29a876c32ad4d3604101df089e8fbfeacfc91928"
 dependencies = [
  "anyhow",
  "backon",
@@ -3916,8 +3767,8 @@ dependencies = [
 
 [[package]]
 name = "miden-ntx-builder"
-version = "0.15.0-rc.3"
-source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0-rc.3#73b0eb9ed63321a74abead9e214559048d5bd9aa"
+version = "0.15.0"
+source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0#29a876c32ad4d3604101df089e8fbfeacfc91928"
 dependencies = [
  "anyhow",
  "backon",
@@ -3998,9 +3849,9 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a1759044f21d139e6f82ecd47c55271b23f76999e87aa78869d862b4fd77ae3"
+checksum = "66340243e37da5936cb278a8dd11037813f1dc6731c2fc866703b76ed465ebc3"
 dependencies = [
  "bech32",
  "fs-err",
@@ -4043,8 +3894,8 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover-client"
-version = "0.15.0-rc.3"
-source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0-rc.3#73b0eb9ed63321a74abead9e214559048d5bd9aa"
+version = "0.15.0"
+source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0#29a876c32ad4d3604101df089e8fbfeacfc91928"
 dependencies = [
  "build-rs",
  "fs-err",
@@ -4074,9 +3925,9 @@ dependencies = [
 
 [[package]]
 name = "miden-standards"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e80fd9b9e508cbdfae19dac06e19ec28f01635f67c76e593f99de0701ab7a2"
+checksum = "c7c7146b028e637f4079b5bdefeefc54d7d6e47a805451fa0a18859d19efa2ff"
 dependencies = [
  "bon",
  "fs-err",
@@ -4113,9 +3964,9 @@ dependencies = [
 
 [[package]]
 name = "miden-testing"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f589ec7d6bb05e96cbdb8cdc0847467b0fe650854047abe6ca85896d98a49fe5"
+checksum = "d4096fc44a4c88f37405be284e25efdce194d6051e9472ae136ab9249659433c"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -4134,9 +3985,9 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c529e50c553269c8a349e1379daade04025b1e9f0c9b32b969d1f31e2e1eb54d"
+checksum = "94092b45bc0abc656af25473c9807d1e6cee8e682c58d3b1186f0bd0fb6471fb"
 dependencies = [
  "miden-processor",
  "miden-protocol",
@@ -4148,9 +3999,9 @@ dependencies = [
 
 [[package]]
 name = "miden-tx-batch-prover"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "935aaeeb1ee2fd8a1ac5df281a76fd553204221e3d574d6ae8a43906066bfc90"
+checksum = "f60add2b40559352661bc86970541f88ffcf98c528f301295f9dc3bf15481b46"
 dependencies = [
  "miden-protocol",
  "miden-tx",
@@ -4205,8 +4056,8 @@ dependencies = [
 
 [[package]]
 name = "miden-validator"
-version = "0.15.0-rc.3"
-source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0-rc.3#73b0eb9ed63321a74abead9e214559048d5bd9aa"
+version = "0.15.0"
+source = "git+https://github.com/0xMiden/node.git?tag=v0.15.0#29a876c32ad4d3604101df089e8fbfeacfc91928"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -4346,7 +4197,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "node-builder"
-version = "0.15.0-rc.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "miden-node-block-producer",
@@ -5068,16 +4919,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "primitive-types"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721a1da530b5a2633218dc9f75713394c983c352be88d2d7c9ee85e2c4c21794"
-dependencies = [
- "fixed-hash",
- "uint",
-]
-
-[[package]]
 name = "priority-queue"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5095,28 +4936,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit 0.25.12+spec-1.1.0",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -5384,15 +5203,6 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "rand_core 0.6.4",
-]
 
 [[package]]
 name = "rand"
@@ -5675,27 +5485,6 @@ dependencies = [
  "syn 2.0.117",
  "unicode-ident",
 ]
-
-[[package]]
-name = "ruint"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
-dependencies = [
- "proptest",
- "rand 0.8.6",
- "rand 0.9.4",
- "ruint-macro",
- "serde_core",
- "valuable",
- "zeroize",
-]
-
-[[package]]
-name = "ruint-macro"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rusqlite"
@@ -6166,17 +5955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
- "keccak 0.1.6",
-]
-
-[[package]]
-name = "sha3"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
-dependencies = [
- "digest 0.11.3",
- "keccak 0.2.0",
+ "keccak",
 ]
 
 [[package]]
@@ -6427,18 +6206,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn-solidity"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec005042c7d952febc1a3ef5b0f6674e9054aa836877a31c90b20e25b3d31744"
-dependencies = [
- "paste",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6534,7 +6301,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "testing-remote-prover"
-version = "0.15.0-rc.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7218,18 +6985,6 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
-name = "uint"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ edition      = "2024"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/miden-client"
 rust-version = "1.93"
-version      = "0.15.0-rc"
+version      = "0.15.0-rc.0"
 
 [profile.dev]
 codegen-units = 16
@@ -31,8 +31,8 @@ opt-level = 1
 
 [workspace.dependencies]
 # Workspace crates
-miden-client              = { default-features = false, path = "crates/rust-client", version = "0.15.0-rc" }
-miden-client-sqlite-store = { default-features = false, path = "crates/sqlite-store", version = "0.15.0-rc" }
+miden-client              = { default-features = false, path = "crates/rust-client", version = "0.15.0-rc.0" }
+miden-client-sqlite-store = { default-features = false, path = "crates/sqlite-store", version = "0.15.0-rc.0" }
 
 # Miden protocol dependencies
 miden-protocol        = { default-features = false, version = "0.15.2" }
@@ -42,18 +42,18 @@ miden-tx              = { default-features = false, version = "0.15.2" }
 miden-tx-batch-prover = { default-features = false, version = "0.15.2" }
 
 # Miden node dependencies
-miden-node-block-producer = { git = "https://github.com/0xMiden/node.git", rev = "3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4" }
-miden-node-proto = { git = "https://github.com/0xMiden/node.git", rev = "3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4" }
-miden-node-proto-build = { default-features = false, git = "https://github.com/0xMiden/node.git", rev = "3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4" }
-miden-node-rpc = { git = "https://github.com/0xMiden/node.git", rev = "3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4" }
-miden-node-store = { git = "https://github.com/0xMiden/node.git", rev = "3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4" }
-miden-node-utils = { git = "https://github.com/0xMiden/node.git", rev = "3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4" }
+miden-node-block-producer = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0-rc.3" }
+miden-node-proto = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0-rc.3" }
+miden-node-proto-build = { default-features = false, git = "https://github.com/0xMiden/node.git", tag = "v0.15.0-rc.3" }
+miden-node-rpc = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0-rc.3" }
+miden-node-store = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0-rc.3" }
+miden-node-utils = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0-rc.3" }
 miden-note-transport-proto-build = { default-features = false, version = "0.2" }
-miden-ntx-builder = { git = "https://github.com/0xMiden/node.git", rev = "3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4" }
+miden-ntx-builder = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0-rc.3" }
 miden-remote-prover-client = { default-features = false, features = [
   "tx-prover",
-], git = "https://github.com/0xMiden/node.git", rev = "3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4" }
-miden-validator = { git = "https://github.com/0xMiden/node.git", rev = "3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4" }
+], git = "https://github.com/0xMiden/node.git", tag = "v0.15.0-rc.3" }
+miden-validator = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0-rc.3" }
 
 # Miden debug dependency
 miden-debug     = { default-features = false, features = ["dap", "std"], version = "0.8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ edition      = "2024"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/miden-client"
 rust-version = "1.93"
-version      = "0.15.0"
+version      = "0.15.0-rc"
 
 [profile.dev]
 codegen-units = 16
@@ -31,29 +31,29 @@ opt-level = 1
 
 [workspace.dependencies]
 # Workspace crates
-miden-client              = { default-features = false, path = "crates/rust-client", version = "0.15.0" }
-miden-client-sqlite-store = { default-features = false, path = "crates/sqlite-store", version = "0.15.0" }
+miden-client              = { default-features = false, path = "crates/rust-client", version = "0.15.0-rc" }
+miden-client-sqlite-store = { default-features = false, path = "crates/sqlite-store", version = "0.15.0-rc" }
 
 # Miden protocol dependencies
-miden-protocol        = { default-features = false, version = "0.15" }
-miden-standards       = { default-features = false, version = "0.15" }
-miden-testing         = { default-features = false, version = "0.15" }
-miden-tx              = { default-features = false, version = "0.15" }
-miden-tx-batch-prover = { default-features = false, version = "0.15" }
+miden-protocol        = { default-features = false, version = "0.15.2" }
+miden-standards       = { default-features = false, version = "0.15.2" }
+miden-testing         = { default-features = false, version = "0.15.2" }
+miden-tx              = { default-features = false, version = "0.15.2" }
+miden-tx-batch-prover = { default-features = false, version = "0.15.2" }
 
 # Miden node dependencies
-miden-node-block-producer = { git = "https://github.com/0xMiden/node.git", rev = "6649a4ce774bc842c08e6bdc314f6ddafb816282" }
-miden-node-proto = { git = "https://github.com/0xMiden/node.git", rev = "6649a4ce774bc842c08e6bdc314f6ddafb816282" }
-miden-node-proto-build = { default-features = false, git = "https://github.com/0xMiden/node.git", rev = "6649a4ce774bc842c08e6bdc314f6ddafb816282" }
-miden-node-rpc = { git = "https://github.com/0xMiden/node.git", rev = "6649a4ce774bc842c08e6bdc314f6ddafb816282" }
-miden-node-store = { git = "https://github.com/0xMiden/node.git", rev = "6649a4ce774bc842c08e6bdc314f6ddafb816282" }
-miden-node-utils = { git = "https://github.com/0xMiden/node.git", rev = "6649a4ce774bc842c08e6bdc314f6ddafb816282" }
+miden-node-block-producer = { git = "https://github.com/0xMiden/node.git", rev = "3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4" }
+miden-node-proto = { git = "https://github.com/0xMiden/node.git", rev = "3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4" }
+miden-node-proto-build = { default-features = false, git = "https://github.com/0xMiden/node.git", rev = "3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4" }
+miden-node-rpc = { git = "https://github.com/0xMiden/node.git", rev = "3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4" }
+miden-node-store = { git = "https://github.com/0xMiden/node.git", rev = "3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4" }
+miden-node-utils = { git = "https://github.com/0xMiden/node.git", rev = "3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4" }
 miden-note-transport-proto-build = { default-features = false, version = "0.2" }
-miden-ntx-builder = { git = "https://github.com/0xMiden/node.git", rev = "6649a4ce774bc842c08e6bdc314f6ddafb816282" }
+miden-ntx-builder = { git = "https://github.com/0xMiden/node.git", rev = "3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4" }
 miden-remote-prover-client = { default-features = false, features = [
   "tx-prover",
-], git = "https://github.com/0xMiden/node.git", rev = "6649a4ce774bc842c08e6bdc314f6ddafb816282" }
-miden-validator = { git = "https://github.com/0xMiden/node.git", rev = "6649a4ce774bc842c08e6bdc314f6ddafb816282" }
+], git = "https://github.com/0xMiden/node.git", rev = "3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4" }
+miden-validator = { git = "https://github.com/0xMiden/node.git", rev = "3a3ace2ca53bf0d0cc7c5647dfa27d95704eecb4" }
 
 # Miden debug dependency
 miden-debug     = { default-features = false, features = ["dap", "std"], version = "0.8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,18 +42,16 @@ miden-tx              = { default-features = false, version = "0.15.3" }
 miden-tx-batch-prover = { default-features = false, version = "0.15.3" }
 
 # Miden node dependencies
-miden-node-block-producer = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0" }
-miden-node-proto = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0" }
-miden-node-proto-build = { default-features = false, git = "https://github.com/0xMiden/node.git", tag = "v0.15.0" }
-miden-node-rpc = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0" }
-miden-node-store = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0" }
-miden-node-utils = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0" }
+miden-node-block-producer        = { version = "0.15.0" }
+miden-node-proto                 = { version = "0.15.0" }
+miden-node-proto-build           = { default-features = false, version = "0.15.0" }
+miden-node-rpc                   = { version = "0.15.0" }
+miden-node-store                 = { version = "0.15.0" }
+miden-node-utils                 = { version = "0.15.0" }
 miden-note-transport-proto-build = { default-features = false, version = "0.2" }
-miden-ntx-builder = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0" }
-miden-remote-prover-client = { default-features = false, features = [
-  "tx-prover",
-], git = "https://github.com/0xMiden/node.git", tag = "v0.15.0" }
-miden-validator = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0" }
+miden-ntx-builder                = { version = "0.15.0" }
+miden-remote-prover-client       = { default-features = false, features = ["tx-prover"], version = "0.15.0" }
+miden-validator                  = { version = "0.15.0" }
 
 # Miden debug dependency
 miden-debug     = { default-features = false, features = ["dap", "std"], version = "0.8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ edition      = "2024"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/miden-client"
 rust-version = "1.93"
-version      = "0.15.0-rc.0"
+version      = "0.15.0"
 
 [profile.dev]
 codegen-units = 16
@@ -31,29 +31,29 @@ opt-level = 1
 
 [workspace.dependencies]
 # Workspace crates
-miden-client              = { default-features = false, path = "crates/rust-client", version = "0.15.0-rc.0" }
-miden-client-sqlite-store = { default-features = false, path = "crates/sqlite-store", version = "0.15.0-rc.0" }
+miden-client              = { default-features = false, path = "crates/rust-client", version = "0.15.0" }
+miden-client-sqlite-store = { default-features = false, path = "crates/sqlite-store", version = "0.15.0" }
 
 # Miden protocol dependencies
-miden-protocol        = { default-features = false, version = "0.15.2" }
-miden-standards       = { default-features = false, version = "0.15.2" }
-miden-testing         = { default-features = false, version = "0.15.2" }
-miden-tx              = { default-features = false, version = "0.15.2" }
-miden-tx-batch-prover = { default-features = false, version = "0.15.2" }
+miden-protocol        = { default-features = false, version = "0.15.3" }
+miden-standards       = { default-features = false, version = "0.15.3" }
+miden-testing         = { default-features = false, version = "0.15.3" }
+miden-tx              = { default-features = false, version = "0.15.3" }
+miden-tx-batch-prover = { default-features = false, version = "0.15.3" }
 
 # Miden node dependencies
-miden-node-block-producer = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0-rc.3" }
-miden-node-proto = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0-rc.3" }
-miden-node-proto-build = { default-features = false, git = "https://github.com/0xMiden/node.git", tag = "v0.15.0-rc.3" }
-miden-node-rpc = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0-rc.3" }
-miden-node-store = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0-rc.3" }
-miden-node-utils = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0-rc.3" }
+miden-node-block-producer = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0" }
+miden-node-proto = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0" }
+miden-node-proto-build = { default-features = false, git = "https://github.com/0xMiden/node.git", tag = "v0.15.0" }
+miden-node-rpc = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0" }
+miden-node-store = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0" }
+miden-node-utils = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0" }
 miden-note-transport-proto-build = { default-features = false, version = "0.2" }
-miden-ntx-builder = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0-rc.3" }
+miden-ntx-builder = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0" }
 miden-remote-prover-client = { default-features = false, features = [
   "tx-prover",
-], git = "https://github.com/0xMiden/node.git", tag = "v0.15.0-rc.3" }
-miden-validator = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0-rc.3" }
+], git = "https://github.com/0xMiden/node.git", tag = "v0.15.0" }
+miden-validator = { git = "https://github.com/0xMiden/node.git", tag = "v0.15.0" }
 
 # Miden debug dependency
 miden-debug     = { default-features = false, features = ["dap", "std"], version = "0.8" }

--- a/bin/integration-tests/src/tests/client.rs
+++ b/bin/integration-tests/src/tests/client.rs
@@ -1590,12 +1590,12 @@ pub async fn test_unused_rpc_api(client_config: ClientConfig) -> Result<()> {
         .expect("node should have the note script registered");
     let sync_storage_maps = client
         .test_rpc_api()
-        .sync_storage_maps(0.into(), None, account_with_map_item.id())
+        .sync_storage_maps(0.into(), sync_height, account_with_map_item.id())
         .await
         .unwrap();
     let account_vault_info = client
         .test_rpc_api()
-        .sync_account_vault(0.into(), None, first_basic_account.id())
+        .sync_account_vault(0.into(), sync_height, first_basic_account.id())
         .await
         .unwrap();
     let transactions = client

--- a/bin/integration-tests/src/tests/network_transaction.rs
+++ b/bin/integration-tests/src/tests/network_transaction.rs
@@ -55,11 +55,7 @@ use miden_client::testing::common::{
     wait_for_blocks,
     wait_for_tx,
 };
-use miden_client::transaction::{
-    TransactionKernel,
-    TransactionRequestBuilder,
-    TransactionScriptRoot,
-};
+use miden_client::transaction::{TransactionKernel, TransactionRequestBuilder};
 use miden_client::{Felt, Word, ZERO};
 use rand::{Rng, RngCore};
 
@@ -71,22 +67,6 @@ use crate::tests::config::ClientConfig;
 pub(crate) static COUNTER_SLOT_NAME: LazyLock<StorageSlotName> = LazyLock::new(|| {
     StorageSlotName::new("miden::testing::counter_contract::counter").expect("slot name is valid")
 });
-
-/// Root of the transaction-expiration script the node's network-transaction builder runs against
-/// every network account.
-pub(crate) static NTX_EXPIRATION_TX_SCRIPT_ROOT: LazyLock<TransactionScriptRoot> = LazyLock::new(
-    || {
-        // Mirrors the node ntx-builder's `DEFAULT_TX_EXPIRATION_DELTA`
-        const NTX_EXPIRATION_DELTA: u16 = 30;
-        let source = format!(
-            "begin\n    push.{NTX_EXPIRATION_DELTA} exec.::miden::protocol::tx::update_expiration_block_delta\nend"
-        );
-        CodeBuilder::new()
-            .compile_tx_script(source)
-            .expect("network-tx expiration script should compile")
-            .root()
-    },
-);
 
 const COUNTER_CONTRACT: &str = r#"
         use miden::protocol::active_account
@@ -141,11 +121,9 @@ pub(crate) async fn deploy_network_counter_contract(
     allowed_note_script_roots: &[NoteScriptRoot],
 ) -> Result<Account> {
     let roots = allowed_note_script_roots.iter().copied().collect::<BTreeSet<NoteScriptRoot>>();
-    let allowed_tx_scripts = BTreeSet::from_iter([*NTX_EXPIRATION_TX_SCRIPT_ROOT]);
     let auth = AuthNetworkAccount::with_allowed_notes(roots)
         .map_err(|err| anyhow::anyhow!(err))
-        .context("failed to build network account auth component")?
-        .with_allowed_tx_scripts(allowed_tx_scripts);
+        .context("failed to build network account auth component")?;
     deploy_counter_with_auth(client, auth).await
 }
 
@@ -500,10 +478,8 @@ pub async fn test_ntx_mint_produces_public_p2id(client_config: ClientConfig) -> 
     // the node uses to route MINT notes to it and enforces that only allowlisted notes are consumed
     // with no tx script. The scriptless deploy transaction below is authorized by this same auth.
     let allowed_roots = [MintNote::script_root()].into_iter().collect::<BTreeSet<_>>();
-    let allowed_tx_scripts = BTreeSet::from_iter([*NTX_EXPIRATION_TX_SCRIPT_ROOT]);
     let network_auth = AuthNetworkAccount::with_allowed_notes(allowed_roots)
-        .map_err(|err| anyhow!("failed to build faucet network-account auth: {err}"))?
-        .with_allowed_tx_scripts(allowed_tx_scripts);
+        .map_err(|err| anyhow!("failed to build faucet network-account auth: {err}"))?;
 
     let mut init_seed = [0u8; 32];
     client.rng().fill_bytes(&mut init_seed);

--- a/bin/integration-tests/src/tests/network_transaction.rs
+++ b/bin/integration-tests/src/tests/network_transaction.rs
@@ -55,7 +55,11 @@ use miden_client::testing::common::{
     wait_for_blocks,
     wait_for_tx,
 };
-use miden_client::transaction::{TransactionKernel, TransactionRequestBuilder};
+use miden_client::transaction::{
+    TransactionKernel,
+    TransactionRequestBuilder,
+    TransactionScriptRoot,
+};
 use miden_client::{Felt, Word, ZERO};
 use rand::{Rng, RngCore};
 
@@ -67,6 +71,22 @@ use crate::tests::config::ClientConfig;
 pub(crate) static COUNTER_SLOT_NAME: LazyLock<StorageSlotName> = LazyLock::new(|| {
     StorageSlotName::new("miden::testing::counter_contract::counter").expect("slot name is valid")
 });
+
+/// Root of the transaction-expiration script the node's network-transaction builder runs against
+/// every network account.
+pub(crate) static NTX_EXPIRATION_TX_SCRIPT_ROOT: LazyLock<TransactionScriptRoot> = LazyLock::new(
+    || {
+        // Mirrors the node ntx-builder's `DEFAULT_TX_EXPIRATION_DELTA`
+        const NTX_EXPIRATION_DELTA: u16 = 30;
+        let source = format!(
+            "begin\n    push.{NTX_EXPIRATION_DELTA} exec.::miden::protocol::tx::update_expiration_block_delta\nend"
+        );
+        CodeBuilder::new()
+            .compile_tx_script(source)
+            .expect("network-tx expiration script should compile")
+            .root()
+    },
+);
 
 const COUNTER_CONTRACT: &str = r#"
         use miden::protocol::active_account
@@ -121,9 +141,11 @@ pub(crate) async fn deploy_network_counter_contract(
     allowed_note_script_roots: &[NoteScriptRoot],
 ) -> Result<Account> {
     let roots = allowed_note_script_roots.iter().copied().collect::<BTreeSet<NoteScriptRoot>>();
-    let auth = AuthNetworkAccount::with_allowlist(roots)
+    let allowed_tx_scripts = BTreeSet::from_iter([*NTX_EXPIRATION_TX_SCRIPT_ROOT]);
+    let auth = AuthNetworkAccount::with_allowed_notes(roots)
         .map_err(|err| anyhow::anyhow!(err))
-        .context("failed to build network account auth component")?;
+        .context("failed to build network account auth component")?
+        .with_allowed_tx_scripts(allowed_tx_scripts);
     deploy_counter_with_auth(client, auth).await
 }
 
@@ -478,8 +500,10 @@ pub async fn test_ntx_mint_produces_public_p2id(client_config: ClientConfig) -> 
     // the node uses to route MINT notes to it and enforces that only allowlisted notes are consumed
     // with no tx script. The scriptless deploy transaction below is authorized by this same auth.
     let allowed_roots = [MintNote::script_root()].into_iter().collect::<BTreeSet<_>>();
-    let network_auth = AuthNetworkAccount::with_allowlist(allowed_roots)
-        .map_err(|err| anyhow!("failed to build faucet network-account auth: {err}"))?;
+    let allowed_tx_scripts = BTreeSet::from_iter([*NTX_EXPIRATION_TX_SCRIPT_ROOT]);
+    let network_auth = AuthNetworkAccount::with_allowed_notes(allowed_roots)
+        .map_err(|err| anyhow!("failed to build faucet network-account auth: {err}"))?
+        .with_allowed_tx_scripts(allowed_tx_scripts);
 
     let mut init_seed = [0u8; 32];
     client.rng().fill_bytes(&mut init_seed);

--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -207,6 +207,7 @@ pub mod auth {
         PublicKeyCommitment,
         Signature,
     };
+    pub use miden_standards::AuthMethod;
     pub use miden_standards::account::auth::{
         AuthMultisig,
         AuthMultisigConfig,

--- a/crates/rust-client/src/rpc/mod.rs
+++ b/crates/rust-client/src/rpc/mod.rs
@@ -354,9 +354,8 @@ pub trait NodeRpcClient: Send + Sync {
         if !details.vault_details.too_many_assets {
             return Ok(());
         }
-        let vault_info = self
-            .sync_account_vault(BlockNumber::GENESIS, Some(block_to), account_id)
-            .await?;
+        let vault_info =
+            self.sync_account_vault(BlockNumber::GENESIS, block_to, account_id).await?;
         let mut updates = vault_info.updates;
         // The node returns the full history of vault entries, so a given key may appear in more
         // than one block. Sort by block so the BTreeMap keeps the latest value per key.
@@ -384,7 +383,7 @@ pub trait NodeRpcClient: Send + Sync {
         if !details.storage_details.map_details.iter().any(|m| m.too_many_entries) {
             return Ok(());
         }
-        let info = self.sync_storage_maps(BlockNumber::GENESIS, Some(block_to), account_id).await?;
+        let info = self.sync_storage_maps(BlockNumber::GENESIS, block_to, account_id).await?;
         for map_details in &mut details.storage_details.map_details {
             if !map_details.too_many_entries {
                 continue;
@@ -511,13 +510,13 @@ pub trait NodeRpcClient: Send + Sync {
     /// using the `/SyncStorageMaps` RPC endpoint.
     ///
     /// - `block_from`: The starting block number for the range (inclusive).
-    /// - `block_to`: The ending block number for the range (inclusive). If `None`, syncs up to the
-    ///   chain tip.
+    /// - `block_to`: The ending block number for the range (inclusive). The node rejects values
+    ///   greater than the chain tip.
     /// - `account_id`: The account ID for which to fetch storage map updates.
     async fn sync_storage_maps(
         &self,
         block_from: BlockNumber,
-        block_to: Option<BlockNumber>,
+        block_to: BlockNumber,
         account_id: AccountId,
     ) -> Result<StorageMapInfo, RpcError>;
 
@@ -525,13 +524,13 @@ pub trait NodeRpcClient: Send + Sync {
     /// using the `/SyncAccountVault` RPC endpoint.
     ///
     /// - `block_from`: The starting block number for the range (inclusive).
-    /// - `block_to`: The ending block number for the range (inclusive). If `None`, syncs up to the
-    ///   chain tip.
+    /// - `block_to`: The ending block number for the range (inclusive). The node rejects values
+    ///   greater than the chain tip.
     /// - `account_id`: The account ID for which to fetch storage map updates.
     async fn sync_account_vault(
         &self,
         block_from: BlockNumber,
-        block_to: Option<BlockNumber>,
+        block_to: BlockNumber,
         account_id: AccountId,
     ) -> Result<AccountVaultInfo, RpcError>;
 

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -305,6 +305,12 @@ impl GrpcClient {
             .map(tonic::Response::into_inner)
             .and_then(RpcStatusInfo::try_from)
     }
+
+    /// Fetches the latest block header and returns its block number.
+    async fn resolve_chain_tip(&self) -> Result<BlockNumber, RpcError> {
+        let (header, _) = self.get_block_header_by_number(None, false).await?;
+        Ok(header.block_num())
+    }
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
@@ -752,14 +758,18 @@ impl NodeRpcClient for GrpcClient {
         block_to: Option<BlockNumber>,
         account_id: AccountId,
     ) -> Result<StorageMapInfo, RpcError> {
-        let mut pagination = BlockPagination::new(block_from, block_to);
+        let block_to = match block_to {
+            Some(block_to) => block_to,
+            None => self.resolve_chain_tip().await?,
+        };
+        let mut pagination = BlockPagination::new(block_from, Some(block_to));
         let mut updates = Vec::new();
 
         let (chain_tip, block_number) = loop {
             let request = proto::rpc::SyncAccountStorageMapsRequest {
                 block_range: Some(BlockRange {
                     block_from: pagination.current_block_from().as_u32(),
-                    block_to: pagination.block_to().map_or(u32::MAX, |block| block.as_u32()),
+                    block_to: block_to.as_u32(),
                 }),
                 account_id: Some(account_id.into()),
             };
@@ -800,14 +810,18 @@ impl NodeRpcClient for GrpcClient {
         block_to: Option<BlockNumber>,
         account_id: AccountId,
     ) -> Result<AccountVaultInfo, RpcError> {
-        let mut pagination = BlockPagination::new(block_from, block_to);
+        let block_to = match block_to {
+            Some(block_to) => block_to,
+            None => self.resolve_chain_tip().await?,
+        };
+        let mut pagination = BlockPagination::new(block_from, Some(block_to));
         let mut updates = Vec::new();
 
         let (chain_tip, block_number) = loop {
             let request = proto::rpc::SyncAccountVaultRequest {
                 block_range: Some(BlockRange {
                     block_from: pagination.current_block_from().as_u32(),
-                    block_to: pagination.block_to().map_or(u32::MAX, |block| block.as_u32()),
+                    block_to: block_to.as_u32(),
                 }),
                 account_id: Some(account_id.into()),
             };

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -56,7 +56,7 @@ use api_client::api_client_wrapper::ApiClient;
 /// Tracks the pagination state for block-driven endpoints.
 struct BlockPagination {
     current_block_from: BlockNumber,
-    block_to: Option<BlockNumber>,
+    block_to: BlockNumber,
     iterations: u32,
 }
 
@@ -75,7 +75,7 @@ impl BlockPagination {
     /// trigger an infinite loop.
     const MAX_ITERATIONS: u32 = 1000;
 
-    fn new(block_from: BlockNumber, block_to: Option<BlockNumber>) -> Self {
+    fn new(block_from: BlockNumber, block_to: BlockNumber) -> Self {
         Self {
             current_block_from: block_from,
             block_to,
@@ -87,7 +87,7 @@ impl BlockPagination {
         self.current_block_from
     }
 
-    fn block_to(&self) -> Option<BlockNumber> {
+    fn block_to(&self) -> BlockNumber {
         self.block_to
     }
 
@@ -109,7 +109,7 @@ impl BlockPagination {
             ));
         }
 
-        let target_block = self.block_to.map_or(chain_tip, |to| to.min(chain_tip));
+        let target_block = self.block_to.min(chain_tip);
 
         if block_num >= target_block {
             return Ok(PaginationResult::Done { chain_tip, block_num });
@@ -304,12 +304,6 @@ impl GrpcClient {
             .map_err(|status| self.rpc_error_from_status(RpcEndpoint::Status, status))
             .map(tonic::Response::into_inner)
             .and_then(RpcStatusInfo::try_from)
-    }
-
-    /// Fetches the latest block header and returns its block number.
-    async fn resolve_chain_tip(&self) -> Result<BlockNumber, RpcError> {
-        let (header, _) = self.get_block_header_by_number(None, false).await?;
-        Ok(header.block_num())
     }
 }
 
@@ -597,7 +591,7 @@ impl NodeRpcClient for GrpcClient {
 
         for chunk in tags.chunks(limits.note_tags_limit as usize) {
             let proto_tags: Vec<u32> = chunk.iter().map(|&t| t.into()).collect();
-            let mut pagination = BlockPagination::new(block_from, Some(block_to));
+            let mut pagination = BlockPagination::new(block_from, block_to);
 
             loop {
                 let request = proto::rpc::SyncNotesRequest {
@@ -657,7 +651,7 @@ impl NodeRpcClient for GrpcClient {
         // violating the RPC limit.
         for chunk in prefixes.chunks(limits.nullifiers_limit as usize) {
             let proto_prefixes: Vec<u32> = chunk.iter().map(|&x| u32::from(x)).collect();
-            let mut pagination = BlockPagination::new(block_from, Some(block_to));
+            let mut pagination = BlockPagination::new(block_from, block_to);
 
             loop {
                 let request = proto::rpc::SyncNullifiersRequest {
@@ -665,10 +659,7 @@ impl NodeRpcClient for GrpcClient {
                     prefix_len: 16,
                     block_range: Some(BlockRange {
                         block_from: pagination.current_block_from().as_u32(),
-                        block_to: pagination
-                            .block_to()
-                            .map(|b| b.as_u32())
-                            .expect("sync_nullifiers is paginated with a bounded block_to"),
+                        block_to: pagination.block_to().as_u32(),
                     }),
                 };
 
@@ -755,14 +746,10 @@ impl NodeRpcClient for GrpcClient {
     async fn sync_storage_maps(
         &self,
         block_from: BlockNumber,
-        block_to: Option<BlockNumber>,
+        block_to: BlockNumber,
         account_id: AccountId,
     ) -> Result<StorageMapInfo, RpcError> {
-        let block_to = match block_to {
-            Some(block_to) => block_to,
-            None => self.resolve_chain_tip().await?,
-        };
-        let mut pagination = BlockPagination::new(block_from, Some(block_to));
+        let mut pagination = BlockPagination::new(block_from, block_to);
         let mut updates = Vec::new();
 
         let (chain_tip, block_number) = loop {
@@ -807,14 +794,10 @@ impl NodeRpcClient for GrpcClient {
     async fn sync_account_vault(
         &self,
         block_from: BlockNumber,
-        block_to: Option<BlockNumber>,
+        block_to: BlockNumber,
         account_id: AccountId,
     ) -> Result<AccountVaultInfo, RpcError> {
-        let block_to = match block_to {
-            Some(block_to) => block_to,
-            None => self.resolve_chain_tip().await?,
-        };
-        let mut pagination = BlockPagination::new(block_from, Some(block_to));
+        let mut pagination = BlockPagination::new(block_from, block_to);
         let mut updates = Vec::new();
 
         let (chain_tip, block_number) = loop {
@@ -876,7 +859,7 @@ impl NodeRpcClient for GrpcClient {
 
         for chunk in account_ids.chunks(limits.account_ids_limit as usize) {
             let proto_account_ids: Vec<_> = chunk.iter().map(|acc_id| (*acc_id).into()).collect();
-            let mut pagination = BlockPagination::new(block_from, Some(block_to));
+            let mut pagination = BlockPagination::new(block_from, block_to);
 
             loop {
                 let request = proto::rpc::SyncTransactionsRequest {
@@ -1025,7 +1008,7 @@ mod tests {
 
     #[test]
     fn block_pagination_errors_when_block_num_goes_backwards() {
-        let mut pagination = BlockPagination::new(10_u32.into(), None);
+        let mut pagination = BlockPagination::new(10_u32.into(), 20_u32.into());
 
         let res = pagination.advance(9_u32.into(), 20_u32.into());
         assert!(matches!(res, Err(RpcError::PaginationError(_))));
@@ -1033,7 +1016,7 @@ mod tests {
 
     #[test]
     fn block_pagination_errors_after_max_iterations() {
-        let mut pagination = BlockPagination::new(0_u32.into(), None);
+        let mut pagination = BlockPagination::new(0_u32.into(), 10_000_u32.into());
         let chain_tip: BlockNumber = 10_000_u32.into();
 
         for _ in 0..BlockPagination::MAX_ITERATIONS {
@@ -1051,7 +1034,7 @@ mod tests {
     #[test]
     fn block_pagination_stops_at_min_of_block_to_and_chain_tip() {
         // block_to is beyond chain tip, so target should be chain_tip.
-        let mut pagination = BlockPagination::new(0_u32.into(), Some(50_u32.into()));
+        let mut pagination = BlockPagination::new(0_u32.into(), 50_u32.into());
 
         let res = pagination
             .advance(30_u32.into(), 30_u32.into())
@@ -1068,7 +1051,7 @@ mod tests {
 
     #[test]
     fn block_pagination_advances_cursor_by_one() {
-        let mut pagination = BlockPagination::new(5_u32.into(), None);
+        let mut pagination = BlockPagination::new(5_u32.into(), 100_u32.into());
 
         let res = pagination
             .advance(5_u32.into(), 100_u32.into())

--- a/crates/rust-client/src/sync/state_sync.rs
+++ b/crates/rust-client/src/sync/state_sync.rs
@@ -649,12 +649,12 @@ impl StateSync {
         // the block whose state we already have.
         let map_info = self
             .rpc_api
-            .sync_storage_maps(block_from + 1, Some(block_to), account_id)
+            .sync_storage_maps(block_from + 1, block_to, account_id)
             .await
             .map_err(ClientError::RpcError)?;
         let vault_info = self
             .rpc_api
-            .sync_account_vault(block_from + 1, Some(block_to), account_id)
+            .sync_account_vault(block_from + 1, block_to, account_id)
             .await
             .map_err(ClientError::RpcError)?;
 

--- a/crates/rust-client/src/test_utils/mock.rs
+++ b/crates/rust-client/src/test_utils/mock.rs
@@ -141,11 +141,11 @@ impl MockRpcApi {
     fn get_sync_account_vault_request(
         &self,
         block_from: BlockNumber,
-        block_to: Option<BlockNumber>,
+        block_to: BlockNumber,
         account_id: AccountId,
     ) -> AccountVaultInfo {
         let chain_tip = self.get_chain_tip_block_num();
-        let target_block = block_to.unwrap_or(chain_tip).min(chain_tip);
+        let target_block = block_to.min(chain_tip);
 
         let page_end_block: BlockNumber = (block_from.as_u32() + Self::PAGINATION_BLOCK_LIMIT)
             .min(target_block.as_u32())
@@ -228,11 +228,11 @@ impl MockRpcApi {
     fn get_sync_storage_maps_request(
         &self,
         block_from: BlockNumber,
-        block_to: Option<BlockNumber>,
+        block_to: BlockNumber,
         account_id: AccountId,
     ) -> StorageMapInfo {
         let chain_tip = self.get_chain_tip_block_num();
-        let target_block = block_to.unwrap_or(chain_tip).min(chain_tip);
+        let target_block = block_to.min(chain_tip);
 
         let page_end_block: BlockNumber = (block_from.as_u32() + Self::PAGINATION_BLOCK_LIMIT)
             .min(target_block.as_u32())
@@ -627,13 +627,13 @@ impl NodeRpcClient for MockRpcApi {
     async fn sync_storage_maps(
         &self,
         block_from: BlockNumber,
-        block_to: Option<BlockNumber>,
+        block_to: BlockNumber,
         account_id: AccountId,
     ) -> Result<StorageMapInfo, RpcError> {
         let mut all_updates = Vec::new();
         let mut current_block_from = block_from;
         let chain_tip = self.get_chain_tip_block_num();
-        let target_block = block_to.unwrap_or(chain_tip).min(chain_tip);
+        let target_block = block_to.min(chain_tip);
 
         loop {
             let response =
@@ -655,13 +655,13 @@ impl NodeRpcClient for MockRpcApi {
     async fn sync_account_vault(
         &self,
         block_from: BlockNumber,
-        block_to: Option<BlockNumber>,
+        block_to: BlockNumber,
         account_id: AccountId,
     ) -> Result<AccountVaultInfo, RpcError> {
         let mut all_updates = Vec::new();
         let mut current_block_from = block_from;
         let chain_tip = self.get_chain_tip_block_num();
-        let target_block = block_to.unwrap_or(chain_tip).min(chain_tip);
+        let target_block = block_to.min(chain_tip);
 
         loop {
             let response =

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -162,6 +162,7 @@ pub use miden_protocol::transaction::{
     TransactionInputs,
     TransactionKernel,
     TransactionScript,
+    TransactionScriptRoot,
     TransactionSummary,
 };
 pub use miden_protocol::vm::{AdviceInputs, AdviceMap};

--- a/crates/testing/miden-client-tests/src/tests.rs
+++ b/crates/testing/miden-client-tests/src/tests.rs
@@ -3391,7 +3391,7 @@ async fn sync_storage_maps_pagination() {
     assert!(chain_tip.as_u32() >= 12);
 
     let account_id = AccountId::try_from(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE).unwrap();
-    let result = rpc_api.sync_storage_maps(0.into(), None, account_id).await.unwrap();
+    let result = rpc_api.sync_storage_maps(0.into(), chain_tip, account_id).await.unwrap();
 
     // Verify we got a response covering the full range
     assert_eq!(result.chain_tip, chain_tip);
@@ -3419,7 +3419,7 @@ async fn sync_account_vault_pagination() {
 
     // Sync from block 0 to chain tip - this should require multiple pagination calls internally
     let account_id = AccountId::try_from(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE).unwrap();
-    let result = rpc_api.sync_account_vault(0.into(), None, account_id).await.unwrap();
+    let result = rpc_api.sync_account_vault(0.into(), chain_tip, account_id).await.unwrap();
 
     // Verify we got a response covering the full range
     assert_eq!(result.chain_tip, chain_tip);
@@ -3442,7 +3442,7 @@ async fn sync_storage_maps_pagination_with_block_to() {
     let rpc_api = MockRpcApi::new(mock_chain);
 
     let account_id = AccountId::try_from(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE).unwrap();
-    let result = rpc_api.sync_storage_maps(0.into(), Some(10.into()), account_id).await.unwrap();
+    let result = rpc_api.sync_storage_maps(0.into(), 10.into(), account_id).await.unwrap();
 
     // Verifies we stopped at block 10, not chain tip
     assert_eq!(result.block_number.as_u32(), 10);
@@ -3464,7 +3464,7 @@ async fn sync_account_vault_pagination_with_block_to() {
     let rpc_api = MockRpcApi::new(mock_chain);
 
     let account_id = AccountId::try_from(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE).unwrap();
-    let result = rpc_api.sync_account_vault(0.into(), Some(10.into()), account_id).await.unwrap();
+    let result = rpc_api.sync_account_vault(0.into(), 10.into(), account_id).await.unwrap();
 
     // Verify we stopped at block 10, not chain tip
     assert_eq!(result.block_number.as_u32(), 10);
@@ -3488,7 +3488,7 @@ async fn sync_storage_maps_pagination_from_middle() {
     let chain_tip = rpc_api.get_chain_tip_block_num();
 
     let account_id = AccountId::try_from(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE).unwrap();
-    let result = rpc_api.sync_storage_maps(7.into(), None, account_id).await.unwrap();
+    let result = rpc_api.sync_storage_maps(7.into(), chain_tip, account_id).await.unwrap();
 
     assert_eq!(result.chain_tip, chain_tip);
     assert_eq!(result.block_number, chain_tip);

--- a/crates/testing/node-builder/src/lib.rs
+++ b/crates/testing/node-builder/src/lib.rs
@@ -11,11 +11,18 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use ::rand::{Rng, random};
 use anyhow::{Context, Result};
 use miden_node_block_producer::{
-    BlockProducerApi, DEFAULT_MAX_BATCHES_PER_BLOCK, DEFAULT_MAX_CONCURRENT_PROOFS,
-    DEFAULT_MAX_TXS_PER_BATCH, DEFAULT_MEMPOOL_TX_CAPACITY, Sequencer,
+    BlockProducerApi,
+    DEFAULT_MAX_BATCHES_PER_BLOCK,
+    DEFAULT_MAX_CONCURRENT_PROOFS,
+    DEFAULT_MAX_TXS_PER_BATCH,
+    DEFAULT_MEMPOOL_TX_CAPACITY,
+    Sequencer,
 };
 use miden_node_proto::clients::{
-    Builder as GrpcClientBuilder, GrpcClient, NtxBuilderClient, ValidatorClient,
+    Builder as GrpcClientBuilder,
+    GrpcClient,
+    NtxBuilderClient,
+    ValidatorClient,
 };
 use miden_node_rpc::{Rpc, RpcMode};
 use miden_node_store::state::State;
@@ -25,8 +32,14 @@ use miden_node_utils::crypto::get_random_coin;
 use miden_ntx_builder::NtxBuilderConfig;
 use miden_protocol::account::auth::{AuthScheme, AuthSecretKey};
 use miden_protocol::account::{
-    Account, AccountBuilder, AccountComponent, AccountComponentMetadata, AccountFile, AccountType,
-    StorageMap, StorageMapKey,
+    Account,
+    AccountBuilder,
+    AccountComponent,
+    AccountComponentMetadata,
+    AccountFile,
+    AccountType,
+    StorageMap,
+    StorageMapKey,
 };
 use miden_protocol::asset::{Asset, AssetAmount, FungibleAsset, TokenSymbol};
 use miden_protocol::block::FeeParameters;
@@ -39,7 +52,10 @@ use miden_standards::account::access::AccessControl;
 use miden_standards::account::auth::AuthSingleSig;
 use miden_standards::account::faucets::{FungibleFaucet, TokenName, create_fungible_faucet};
 use miden_standards::account::policies::{
-    BurnPolicyConfig, MintPolicyConfig, PolicyRegistration, TokenPolicyManager,
+    BurnPolicyConfig,
+    MintPolicyConfig,
+    PolicyRegistration,
+    TokenPolicyManager,
 };
 use miden_standards::account::wallets::BasicWallet;
 use miden_validator::{Validator, ValidatorSigner};

--- a/crates/testing/node-builder/src/lib.rs
+++ b/crates/testing/node-builder/src/lib.rs
@@ -11,18 +11,11 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use ::rand::{Rng, random};
 use anyhow::{Context, Result};
 use miden_node_block_producer::{
-    BlockProducerApi,
-    DEFAULT_MAX_BATCHES_PER_BLOCK,
-    DEFAULT_MAX_CONCURRENT_PROOFS,
-    DEFAULT_MAX_TXS_PER_BATCH,
-    DEFAULT_MEMPOOL_TX_CAPACITY,
-    Sequencer,
+    BlockProducerApi, DEFAULT_MAX_BATCHES_PER_BLOCK, DEFAULT_MAX_CONCURRENT_PROOFS,
+    DEFAULT_MAX_TXS_PER_BATCH, DEFAULT_MEMPOOL_TX_CAPACITY, Sequencer,
 };
 use miden_node_proto::clients::{
-    Builder as GrpcClientBuilder,
-    GrpcClient,
-    NtxBuilderClient,
-    ValidatorClient,
+    Builder as GrpcClientBuilder, GrpcClient, NtxBuilderClient, ValidatorClient,
 };
 use miden_node_rpc::{Rpc, RpcMode};
 use miden_node_store::state::State;
@@ -32,14 +25,8 @@ use miden_node_utils::crypto::get_random_coin;
 use miden_ntx_builder::NtxBuilderConfig;
 use miden_protocol::account::auth::{AuthScheme, AuthSecretKey};
 use miden_protocol::account::{
-    Account,
-    AccountBuilder,
-    AccountComponent,
-    AccountComponentMetadata,
-    AccountFile,
-    AccountType,
-    StorageMap,
-    StorageMapKey,
+    Account, AccountBuilder, AccountComponent, AccountComponentMetadata, AccountFile, AccountType,
+    StorageMap, StorageMapKey,
 };
 use miden_protocol::asset::{Asset, AssetAmount, FungibleAsset, TokenSymbol};
 use miden_protocol::block::FeeParameters;
@@ -52,10 +39,7 @@ use miden_standards::account::access::AccessControl;
 use miden_standards::account::auth::AuthSingleSig;
 use miden_standards::account::faucets::{FungibleFaucet, TokenName, create_fungible_faucet};
 use miden_standards::account::policies::{
-    BurnPolicyConfig,
-    MintPolicyConfig,
-    PolicyRegistration,
-    TokenPolicyManager,
+    BurnPolicyConfig, MintPolicyConfig, PolicyRegistration, TokenPolicyManager,
 };
 use miden_standards::account::wallets::BasicWallet;
 use miden_validator::{Validator, ValidatorSigner};


### PR DESCRIPTION
Bumps miden dependencies to protocol's `0.15.3`.

No significant changes made, only that network transaction tests now need the `NTX_EXPIRATION_TX_SCRIPT_ROOT` to be explicitly allowed (`AuthNetworkAccount::with_allowed_tx_scripts`).