### PR TITLE
fix(rust-client): make transaction execution atomic to prevent orphaned note rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [FIX] Fixed `derive_account_commitments` to return the final account commitment when multiple transactions for the same account are committed in the same block ([#2164](https://github.com/0xMiden/miden-client/pull/2164)).
 * [FIX] Fixed the `sync_notes_with_details` to fetch the attachments for private notes ([#2214](https://github.com/0xMiden/miden-client/pull/2214)).
 * [rust] Expanded validation for output notes before executing a `TransactionRequest`. ([#89](https://github.com/0xMiden/wallet-adapter/issues/89))
+* [FIX][rust] `execute_transaction` no longer writes input-note tracking state to the store; input- and output-note tracking is persisted only by the atomic `apply_transaction` after the transaction is proven and submitted. This removes the half-applied-store window that could leave orphaned note rows if the process died mid-dispatch (root cause of recurring stuck "Consuming" notes). ([0xMiden/wallet#260](https://github.com/0xMiden/wallet/issues/260))
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * [FIX] Fixed `derive_account_commitments` to return the final account commitment when multiple transactions for the same account are committed in the same block ([#2164](https://github.com/0xMiden/miden-client/pull/2164)).
 * [FIX] Fixed the `sync_notes_with_details` to fetch the attachments for private notes ([#2214](https://github.com/0xMiden/miden-client/pull/2214)).
 * [rust] Expanded validation for output notes before executing a `TransactionRequest`. ([#89](https://github.com/0xMiden/wallet-adapter/issues/89))
-* [FIX][rust] `execute_transaction` no longer writes input-note tracking state to the store; input- and output-note tracking is persisted only by the atomic `apply_transaction` after the transaction is proven and submitted. This removes the half-applied-store window that could leave orphaned note rows if the process died mid-dispatch (root cause of recurring stuck "Consuming" notes). ([0xMiden/wallet#260](https://github.com/0xMiden/wallet/issues/260))
+* [FIX][rust] `execute_transaction` no longer writes input-note tracking state to the store; note tracking is persisted only by the atomic `apply_transaction` after the transaction is proven and submitted. This removes the half-applied-store window that could leave orphaned note rows if the process died mid-dispatch (root cause of recurring stuck "Consuming" notes). ([0xMiden/wallet#260](https://github.com/0xMiden/wallet/issues/260))
 
 ### Changes
 

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -314,6 +314,9 @@ where
 
         let mut notes = prep.notes;
         if prep.ignore_invalid_notes {
+            // Notes dropped here are never consumed, so by the no-orphan-rows invariant they get no
+            // tracking row: execution persists nothing, and only the notes actually consumed by the
+            // executed transaction are recorded at apply time.
             notes = self.get_valid_input_notes(&account, notes, prep.tx_args.clone()).await?;
         }
 
@@ -899,42 +902,53 @@ where
 
         // Locally consumed notes.
         //
-        // Notes already tracked in the store are updated in place. Notes supplied directly in the
-        // request (e.g. unauthenticated private notes) have no store row, because execution does
-        // not persist tracking state; their record is built from the executed transaction's inputs
-        // and inserted already in the consumed state, so the consume lands atomically in the apply.
+        // Each consumed note is tracked exactly once, atomically, in the apply. A note already in
+        // the store is consumed in place from its authoritative prior state, which preserves its
+        // authenticated/unauthenticated variant and consuming-transaction linkage (and surfaces a
+        // genuine conflict, e.g. re-consuming a note already in flight, by propagating the error).
+        //
+        // Two cases instead rebuild the record from the executed transaction's input:
+        //   - a note with no store row at all (e.g. an unauthenticated private note supplied
+        //     directly in the request — because execution no longer pre-persists request notes,
+        //     this rebuild is what records them); and
+        //   - a stored `Invalid` row, whose synced inclusion proof failed verification and is
+        //     therefore stale: it is rebuilt and `INSERT OR REPLACE`d (this resets the note's
+        //     creation timestamp, which is acceptable for a note now transitioning to consumed).
+        //
+        // Other stored states (`Processing*`, `Consumed*`) must NOT be rebuilt: doing so would
+        // overwrite an authoritative in-flight/consumed row and downgrade its variant.
+        let now = self.store.get_current_timestamp();
         let consumed_input_notes = executed_tx.tx_inputs().input_notes();
         let consumed_note_ids: Vec<NoteId> =
             consumed_input_notes.iter().map(InputNote::id).collect();
 
-        let stored_consumed_notes =
-            self.store.get_input_notes(NoteFilter::List(consumed_note_ids)).await?;
-        let stored_consumed_ids: BTreeSet<NoteId> =
-            stored_consumed_notes.iter().filter_map(InputNoteRecord::id).collect();
+        let mut stored_consumed: BTreeMap<NoteId, InputNoteRecord> = self
+            .store
+            .get_input_notes(NoteFilter::List(consumed_note_ids))
+            .await?
+            .into_iter()
+            .filter_map(|record| record.id().map(|id| (id, record)))
+            .collect();
 
         let mut updated_input_notes = vec![];
 
-        for mut input_note_record in stored_consumed_notes {
-            if input_note_record.consumed_locally(
-                executed_tx.account_id(),
-                executed_tx.id(),
-                self.store.get_current_timestamp(),
-            )? {
-                updated_input_notes.push(input_note_record);
-            }
-        }
-
         for input_note in consumed_input_notes.iter() {
-            if stored_consumed_ids.contains(&input_note.id()) {
+            // Consume an existing, non-`Invalid` store record in place; its prior state is
+            // authoritative.
+            if let Some(mut record) = stored_consumed
+                .remove(&input_note.id())
+                .filter(|record| !matches!(record.state(), InputNoteState::Invalid(_)))
+            {
+                if record.consumed_locally(executed_tx.account_id(), executed_tx.id(), now)? {
+                    updated_input_notes.push(record);
+                }
                 continue;
             }
 
+            // No usable store row (absent, or a stale `Invalid` row): rebuild from the executed
+            // input and insert it in the consumed state.
             let mut record = InputNoteRecord::from(input_note.clone());
-            if record.consumed_locally(
-                executed_tx.account_id(),
-                executed_tx.id(),
-                self.store.get_current_timestamp(),
-            )? {
+            if record.consumed_locally(executed_tx.account_id(), executed_tx.id(), now)? {
                 new_input_notes.push(record);
             }
         }

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -282,8 +282,12 @@ where
         Ok(tx_id)
     }
 
-    /// Creates and executes a transaction specified by the request against the specified account,
-    /// but doesn't change the local database.
+    /// Creates and executes a transaction specified by the request against the specified account.
+    ///
+    /// This does not persist any transaction tracking state: the account, input notes, and output
+    /// notes are only written to the store later, atomically, by [`Client::apply_transaction`]
+    /// after the transaction is proven and submitted. Execution may populate the content-addressed
+    /// note-script cache (keyed by script root), which is idempotent and safe to leave behind.
     ///
     /// # Errors
     ///
@@ -361,23 +365,11 @@ where
         // Only keep authenticated input notes from the store.
         stored_note_records.retain(InputNoteRecord::is_authenticated);
 
-        let authenticated_note_ids =
-            stored_note_records.iter().filter_map(InputNoteRecord::id).collect::<Vec<_>>();
-
-        // Upsert request notes missing from the store so they can be tracked and updated.
-        // NOTE: Unauthenticated notes may be stored locally in an unverified/invalid state at
-        // this point. The upsert will replace the state to an InputNoteState::Expected (with
-        // metadata included).
-        let unauthenticated_input_notes = transaction_request
-            .input_notes()
-            .iter()
-            .filter(|n| !authenticated_note_ids.contains(&n.id()))
-            .cloned()
-            .map(Into::into)
-            .collect::<Vec<_>>();
-
-        self.store.upsert_input_notes(&unauthenticated_input_notes).await?;
-
+        // Transaction execution must not persist input-note tracking state: a process death between
+        // here and the atomic `apply_transaction` would otherwise leave orphaned note rows with no
+        // transaction record. Unauthenticated request notes are fed to the executor directly by
+        // `build_input_notes`; their tracking rows are persisted atomically in the apply, sourced
+        // from the executed transaction's inputs (see `get_note_updates`).
         let notes = transaction_request.build_input_notes(stored_note_records)?;
 
         let output_recipients =
@@ -905,22 +897,45 @@ where
             )
         }));
 
-        // Locally consumed notes
-        let consumed_note_ids =
-            executed_tx.tx_inputs().input_notes().iter().map(InputNote::id).collect();
+        // Locally consumed notes.
+        //
+        // Notes already tracked in the store are updated in place. Notes supplied directly in the
+        // request (e.g. unauthenticated private notes) have no store row, because execution does
+        // not persist tracking state; their record is built from the executed transaction's inputs
+        // and inserted already in the consumed state, so the consume lands atomically in the apply.
+        let consumed_input_notes = executed_tx.tx_inputs().input_notes();
+        let consumed_note_ids: Vec<NoteId> =
+            consumed_input_notes.iter().map(InputNote::id).collect();
 
-        let consumed_notes =
+        let stored_consumed_notes =
             self.store.get_input_notes(NoteFilter::List(consumed_note_ids)).await?;
+        let stored_consumed_ids: BTreeSet<NoteId> =
+            stored_consumed_notes.iter().filter_map(InputNoteRecord::id).collect();
 
         let mut updated_input_notes = vec![];
 
-        for mut input_note_record in consumed_notes {
+        for mut input_note_record in stored_consumed_notes {
             if input_note_record.consumed_locally(
                 executed_tx.account_id(),
                 executed_tx.id(),
                 self.store.get_current_timestamp(),
             )? {
                 updated_input_notes.push(input_note_record);
+            }
+        }
+
+        for input_note in consumed_input_notes.iter() {
+            if stored_consumed_ids.contains(&input_note.id()) {
+                continue;
+            }
+
+            let mut record = InputNoteRecord::from(input_note.clone());
+            if record.consumed_locally(
+                executed_tx.account_id(),
+                executed_tx.id(),
+                self.store.get_current_timestamp(),
+            )? {
+                new_input_notes.push(record);
             }
         }
 

--- a/crates/testing/miden-client-tests/src/tests.rs
+++ b/crates/testing/miden-client-tests/src/tests.rs
@@ -1003,6 +1003,73 @@ async fn import_processing_note_returns_error() {
     ));
 }
 
+/// `execute_transaction` must not persist any input-note tracking state. The note rows are written
+/// only by the atomic `apply_transaction`, which runs after the transaction is proven and
+/// submitted.
+///
+/// This guards the crash-safety invariant behind <https://github.com/0xMiden/wallet/issues/260>: a
+/// process death anywhere during execute/prove/submit must leave the store with no half-applied
+/// note rows, so a retry always starts from a clean substrate.
+#[tokio::test]
+async fn execute_transaction_does_not_persist_input_notes() {
+    let (mut client, _rpc_api, keystore) = Box::pin(create_test_client()).await;
+    client.sync_state().await.unwrap();
+
+    let account = insert_new_wallet(&mut client, AccountType::Private, &keystore).await.unwrap();
+    let faucet = insert_new_fungible_faucet(&mut client, AccountType::Private, &keystore)
+        .await
+        .unwrap();
+
+    // Mint a note to the wallet so it has an asset to consume.
+    let (_tx_id, note) = mint_note(&mut client, account.id(), faucet.id(), NoteType::Private).await;
+
+    // Snapshot the tracked input notes before executing the consume transaction.
+    let notes_before = client.get_input_notes(NoteFilter::All).await.unwrap();
+    let states_before: BTreeMap<_, _> = notes_before
+        .iter()
+        .filter_map(|n| n.id().map(|id| (id, n.state().discriminant())))
+        .collect();
+
+    // Build a consume request that passes the note directly as an unauthenticated input note, then
+    // execute it WITHOUT proving/submitting/applying.
+    let consume_request = TransactionRequestBuilder::new()
+        .input_notes([(note.clone(), None)])
+        .build()
+        .unwrap();
+    Box::pin(client.execute_transaction(account.id(), consume_request))
+        .await
+        .unwrap();
+
+    // The store must be untouched: no rows inserted, no note advanced into a processing/consumed
+    // state by execution alone.
+    let notes_after = client.get_input_notes(NoteFilter::All).await.unwrap();
+    let states_after: BTreeMap<_, _> = notes_after
+        .iter()
+        .filter_map(|n| n.id().map(|id| (id, n.state().discriminant())))
+        .collect();
+
+    assert_eq!(
+        states_before, states_after,
+        "execute_transaction must not insert input-note rows or change their state"
+    );
+    assert!(
+        client.get_input_notes(NoteFilter::Processing).await.unwrap().is_empty(),
+        "execute_transaction must not advance a note into the processing state"
+    );
+
+    // The full pipeline (execute + prove + submit + apply) must still track the consume: after
+    // submitting, the note moves into the processing state via the atomic apply.
+    let consume_request =
+        TransactionRequestBuilder::new().input_notes([(note, None)]).build().unwrap();
+    Box::pin(client.submit_new_transaction(account.id(), consume_request))
+        .await
+        .unwrap();
+    assert!(
+        !client.get_input_notes(NoteFilter::Processing).await.unwrap().is_empty(),
+        "submitting the consume transaction must track the note as processing"
+    );
+}
+
 #[tokio::test]
 async fn note_without_asset() {
     let (mut client, _rpc_api, keystore) = Box::pin(create_test_client()).await;

--- a/crates/testing/miden-client-tests/src/tests.rs
+++ b/crates/testing/miden-client-tests/src/tests.rs
@@ -1056,6 +1056,10 @@ async fn execute_transaction_does_not_persist_input_notes() {
         client.get_input_notes(NoteFilter::Processing).await.unwrap().is_empty(),
         "execute_transaction must not advance a note into the processing state"
     );
+    assert!(
+        client.get_input_notes(NoteFilter::Consumed).await.unwrap().is_empty(),
+        "execute_transaction must not advance a note into the consumed state"
+    );
 
     // The full pipeline (execute + prove + submit + apply) must still track the consume: after
     // submitting, the note moves into the processing state via the atomic apply.


### PR DESCRIPTION
Superseded by #2222 (igamigo, approved). Relates: #2221, 0xMiden/wallet#260
Related: 0xMiden/wallet#260

---

## Problem

`Client::execute_transaction` is documented as *"executes a transaction… but doesn't change the local database"*, but `prepare_transaction` wrote unauthenticated input-note tracking rows to the store (`transaction/mod.rs`) **before** the transaction was proven, submitted, and applied. The real persistence happens later in `store.apply_transaction`, which the SQLite backend wraps in a single atomic transaction — the early upsert sat **outside** that boundary.

A process death (e.g. an MV3 service-worker shutdown) between that write and the atomic apply left orphaned `Expected` input-note rows with no transaction record. This is the half-applied substrate behind the recurring stuck "Consuming" notes in [0xMiden/wallet#260](https://github.com/0xMiden/wallet/issues/260): on relaunch the orphan-resume path re-entered execution against the half-applied rows and re-wedged.

This PR addresses the **substrate/atomicity** layer (the issue's "Phase 2"). The wallet-side live-wedge recovery (Phase 1) is out of scope for this repo.

## Fix

Establishes the invariant: **`execute_transaction` performs no mutable transaction-state writes.** The only permitted execute-time write is population of the idempotent, content-addressed `notes_scripts` cache (keyed by script root). All input-note tracking is persisted exactly once, atomically, inside `apply_transaction`, only after prove + submit succeed.

- **Removed** the premature `upsert_input_notes` in `prepare_transaction`. Unauthenticated request notes still reach the executor directly via `build_input_notes` (unchanged execution).
- **Re-plumbed `get_note_updates`**: consumed notes with no existing store row (unauthenticated/private notes supplied via the request) are built from the executed transaction's inputs and inserted — with their script — inside the atomic apply. Notes already in the store keep the in-place `Update` path.
- **Kept** the note-script cache write (crash-safe by construction) and corrected the `execute_transaction` contract doc.
- The batch path shares both functions, so it inherits the fix with no separate change.

Result: a crash anywhere during execute/prove/submit leaves the store in exactly its pre-transaction state — no orphaned rows — so retries always start from a clean substrate. No new tables, no new `Store` trait methods.

## Testing

- New `execute_transaction_does_not_persist_input_notes` test: asserts execution writes no input-note rows / advances no state, and that the full submit pipeline still tracks the consume.
- Full unit suite: **87/87 passing** (release).
- `cargo +nightly fmt --check`, workspace `clippy`, and `typos` all clean.

A design doc is included under `docs/superpowers/specs/`.