### PR TITLE
fix(sync): public account updates

### DIFF
--- a/crates/rust-client/src/sync/state_sync.rs
+++ b/crates/rust-client/src/sync/state_sync.rs
@@ -643,17 +643,22 @@ impl StateSync {
         current_public_accounts: &[&AccountHeader],
         block_from: BlockNumber,
     ) -> Result<(), ClientError> {
-        let local_commitments: BTreeMap<AccountId, Word> = current_public_accounts
-            .iter()
-            .map(|header| (header.id(), header.to_commitment()))
-            .collect();
+        let local_headers: BTreeMap<AccountId, &AccountHeader> =
+            current_public_accounts.iter().map(|header| (header.id(), *header)).collect();
         for (id, commitment) in commitment_updates {
-            if local_commitments.get(id).is_none_or(|local| local == commitment) {
+            let Some(local_header) = local_headers.get(id).copied() else {
+                continue;
+            };
+
+            if local_header.to_commitment() == *commitment {
                 continue;
             }
 
-            let public_update = self.sync_public_account(*id, block_from).await?;
-            account_updates.extend(AccountUpdates::new(vec![public_update], Vec::new()));
+            if let Some(public_update) =
+                self.sync_public_account(*id, local_header, block_from).await?
+            {
+                account_updates.extend(AccountUpdates::new(vec![public_update], Vec::new()));
+            }
         }
 
         Ok(())
@@ -662,7 +667,8 @@ impl StateSync {
     /// Fetches an updated snapshot for a single public account.
     ///
     /// Must only be called when the local commitment for the account is known to differ from the
-    /// network's, which guarantees the node returns updated details with a newer nonce.
+    /// network's. If the account snapshot returned by the node is not newer than the local header,
+    /// the update is ignored as stale.
     ///
     /// # Panics
     ///
@@ -671,8 +677,9 @@ impl StateSync {
     async fn sync_public_account(
         &self,
         account_id: AccountId,
+        local_header: &AccountHeader,
         block_from: BlockNumber,
-    ) -> Result<PublicAccountUpdate, ClientError> {
+    ) -> Result<Option<PublicAccountUpdate>, ClientError> {
         // A single request fetches the full snapshot: every storage map's entries plus the vault,
         // with the storage layout discovered server-side.
         let (proof_block_num, proof) = self
@@ -687,6 +694,9 @@ impl StateSync {
             .map_err(ClientError::RpcError)?;
 
         let details = proof.into_details().expect("node returned no details for a public account");
+        if details.header.nonce().as_canonical_u64() <= local_header.nonce().as_canonical_u64() {
+            return Ok(None);
+        }
 
         let vault_oversized = details.vault_details.too_many_assets;
         let any_map_oversized =
@@ -705,7 +715,7 @@ impl StateSync {
             PublicAccountUpdate::Full(account)
         };
 
-        Ok(public_update)
+        Ok(Some(public_update))
     }
 
     /// Builds a [`PublicAccountUpdate::Delta`] by fetching incremental storage map and vault
@@ -1086,6 +1096,35 @@ mod tests {
             ZERO,
         ]
         .into()
+    }
+
+    #[tokio::test]
+    async fn sync_public_accounts_ignores_non_newer_node_snapshot() {
+        let mut builder = MockChainBuilder::new();
+        let account = builder.add_existing_mock_account(miden_testing::Auth::IncrNonce).unwrap();
+        let rpc_api = MockRpcApi::new(builder.build().unwrap());
+        let state_sync = StateSync::new(Arc::new(rpc_api), Arc::new(MockScreener), None);
+
+        let local_header =
+            AccountHeader::new(account.id(), Felt::from(1u32), EMPTY_WORD, EMPTY_WORD, EMPTY_WORD);
+        let current_public_accounts = vec![&local_header];
+        let commitment_updates = vec![(account.id(), account.to_commitment())];
+        let mut account_updates = AccountUpdates::default();
+
+        state_sync
+            .sync_public_accounts(
+                &mut account_updates,
+                &commitment_updates,
+                &current_public_accounts,
+                BlockNumber::GENESIS,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            account_updates.updated_public_accounts().is_empty(),
+            "public account sync should ignore node snapshots that are not newer than local"
+        );
     }
 
     // COMPUTE NULLIFIER TX ORDER TESTS

--- a/crates/rust-client/src/sync/state_sync.rs
+++ b/crates/rust-client/src/sync/state_sync.rs
@@ -2,6 +2,7 @@ use alloc::boxed::Box;
 use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
+use core::cmp::Ordering;
 
 use async_trait::async_trait;
 use miden_protocol::Word;
@@ -31,6 +32,16 @@ use crate::transaction::TransactionRecord;
 
 // STATE UPDATE DATA
 // ================================================================================================
+
+/// How a node snapshot of a public account should be reconciled against the local state.
+enum PublicAccountSync {
+    /// Node is newer — apply its state to the store.
+    Apply(Box<PublicAccountUpdate>),
+    /// Same nonce but different state — the local transaction lost the race and must be discarded.
+    Superseded,
+    /// Node is behind the local (potentially optimistic) state — leave the local state untouched.
+    Ignore,
+}
 
 /// Data fetched from the node needed to sync the client to the chain tip.
 ///
@@ -225,13 +236,21 @@ impl StateSync {
         state_sync_update.block_num = sync_data.chain_tip_header.block_num();
 
         let new_commitments = derive_account_commitments(&sync_data.transactions);
-        self.account_state_sync(
-            &mut state_sync_update.account_updates,
-            &accounts,
-            &new_commitments,
-            block_num,
-        )
-        .await?;
+        let superseded_states = self
+            .account_state_sync(
+                &mut state_sync_update.account_updates,
+                &accounts,
+                &new_commitments,
+                block_num,
+            )
+            .await?;
+
+        // Discard the local transactions whose result lost a same-nonce race against the network.
+        for superseded_state in superseded_states {
+            state_sync_update
+                .transaction_updates
+                .apply_superseded_account_state(superseded_state);
+        }
 
         // Apply local changes: update the MMR, screen notes, and apply state transitions.
         self.apply_sync_result(sync_data, &mut state_sync_update, current_partial_mmr)
@@ -593,25 +612,29 @@ impl StateSync {
     /// * Private accounts that have been marked as mismatched because the current commitment
     ///   doesn't match the one received from the node. The client will need to handle these cases
     ///   as they could be a stale account state or a reason to lock the account.
+    ///
+    /// Returns the local states that were superseded by a same-nonce network transaction; the
+    /// caller must discard the transactions that produced them.
     async fn account_state_sync(
         &self,
         account_updates: &mut AccountUpdates,
         accounts: &[AccountHeader],
         account_commitment_updates: &[(AccountId, Word)],
         block_from: BlockNumber,
-    ) -> Result<(), ClientError> {
+    ) -> Result<Vec<Word>, ClientError> {
         // "Public" here includes both Public and Network accounts, since both have
         // their state stored on-chain and follow the same sync path.
         let (public_accounts, private_accounts): (Vec<_>, Vec<_>) =
             accounts.iter().partition(|header| !header.id().is_private());
 
-        self.sync_public_accounts(
-            account_updates,
-            account_commitment_updates,
-            &public_accounts,
-            block_from,
-        )
-        .await?;
+        let superseded_states = self
+            .sync_public_accounts(
+                account_updates,
+                account_commitment_updates,
+                &public_accounts,
+                block_from,
+            )
+            .await?;
 
         let mismatched_private_accounts = account_commitment_updates
             .iter()
@@ -625,7 +648,7 @@ impl StateSync {
 
         account_updates.extend(AccountUpdates::new(Vec::new(), mismatched_private_accounts));
 
-        Ok(())
+        Ok(superseded_states)
     }
 
     /// Queries the node for updated public accounts and populates `account_updates`.
@@ -642,9 +665,11 @@ impl StateSync {
         commitment_updates: &[(AccountId, Word)],
         current_public_accounts: &[&AccountHeader],
         block_from: BlockNumber,
-    ) -> Result<(), ClientError> {
+    ) -> Result<Vec<Word>, ClientError> {
         let local_headers: BTreeMap<AccountId, &AccountHeader> =
             current_public_accounts.iter().map(|header| (header.id(), *header)).collect();
+        // Local states that lost a same-nonce race; their transactions must be discarded.
+        let mut superseded_states = Vec::new();
         for (id, commitment) in commitment_updates {
             let Some(local_header) = local_headers.get(id).copied() else {
                 continue;
@@ -654,21 +679,28 @@ impl StateSync {
                 continue;
             }
 
-            if let Some(public_update) =
-                self.sync_public_account(*id, local_header, block_from).await?
-            {
-                account_updates.extend(AccountUpdates::new(vec![public_update], Vec::new()));
+            match self.sync_public_account(*id, local_header, block_from).await? {
+                PublicAccountSync::Apply(public_update) => {
+                    account_updates.extend(AccountUpdates::new(vec![*public_update], Vec::new()));
+                },
+                PublicAccountSync::Superseded => {
+                    superseded_states.push(local_header.to_commitment());
+                },
+                PublicAccountSync::Ignore => {},
             }
         }
 
-        Ok(())
+        Ok(superseded_states)
     }
 
-    /// Fetches an updated snapshot for a single public account.
+    // SYNC PUBLIC ACCOUNTS HELPERS
+    // --------------------------------------------------------------------------------------------
+
+    /// Fetches an updated snapshot for a single public account and decides how to reconcile it
+    /// against the local state.
     ///
     /// Must only be called when the local commitment for the account is known to differ from the
-    /// network's. If the account snapshot returned by the node is not newer than the local header,
-    /// the update is ignored as stale.
+    /// network's, so an equal nonce always means a genuine fork.
     ///
     /// # Panics
     ///
@@ -679,7 +711,7 @@ impl StateSync {
         account_id: AccountId,
         local_header: &AccountHeader,
         block_from: BlockNumber,
-    ) -> Result<Option<PublicAccountUpdate>, ClientError> {
+    ) -> Result<PublicAccountSync, ClientError> {
         // A single request fetches the full snapshot: every storage map's entries plus the vault,
         // with the storage layout discovered server-side.
         let (proof_block_num, proof) = self
@@ -694,8 +726,19 @@ impl StateSync {
             .map_err(ClientError::RpcError)?;
 
         let details = proof.into_details().expect("node returned no details for a public account");
-        if details.header.nonce().as_canonical_u64() <= local_header.nonce().as_canonical_u64() {
-            return Ok(None);
+        match details
+            .header
+            .nonce()
+            .as_canonical_u64()
+            .cmp(&local_header.nonce().as_canonical_u64())
+        {
+            // Node is behind us: our own transaction was committed yet (will expire naturally
+            // eventually).
+            Ordering::Less => return Ok(PublicAccountSync::Ignore),
+            // Same height but different state: our transaction definitively lost, drop it.
+            Ordering::Equal => return Ok(PublicAccountSync::Superseded),
+            // Node moved past us: adopt its state, built below.
+            Ordering::Greater => {},
         }
 
         let vault_oversized = details.vault_details.too_many_assets;
@@ -715,7 +758,7 @@ impl StateSync {
             PublicAccountUpdate::Full(account)
         };
 
-        Ok(Some(public_update))
+        Ok(PublicAccountSync::Apply(Box::new(public_update)))
     }
 
     /// Builds a [`PublicAccountUpdate::Delta`] by fetching incremental storage map and vault
@@ -1099,19 +1142,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sync_public_accounts_ignores_non_newer_node_snapshot() {
+    async fn sync_public_accounts_ignores_older_node_snapshot() {
         let mut builder = MockChainBuilder::new();
         let account = builder.add_existing_mock_account(miden_testing::Auth::IncrNonce).unwrap();
         let rpc_api = MockRpcApi::new(builder.build().unwrap());
         let state_sync = StateSync::new(Arc::new(rpc_api), Arc::new(MockScreener), None);
 
+        // Local state is at a higher nonce than the node's snapshot (our own tx isn't committed
+        // there yet), so the node snapshot must be ignored.
         let local_header =
-            AccountHeader::new(account.id(), Felt::from(1u32), EMPTY_WORD, EMPTY_WORD, EMPTY_WORD);
+            AccountHeader::new(account.id(), Felt::from(2u32), EMPTY_WORD, EMPTY_WORD, EMPTY_WORD);
         let current_public_accounts = vec![&local_header];
         let commitment_updates = vec![(account.id(), account.to_commitment())];
         let mut account_updates = AccountUpdates::default();
 
-        state_sync
+        let superseded = state_sync
             .sync_public_accounts(
                 &mut account_updates,
                 &commitment_updates,
@@ -1123,7 +1168,47 @@ mod tests {
 
         assert!(
             account_updates.updated_public_accounts().is_empty(),
-            "public account sync should ignore node snapshots that are not newer than local"
+            "public account sync should ignore node snapshots that are older than local"
+        );
+        assert!(
+            superseded.is_empty(),
+            "an older node snapshot must not supersede the local state"
+        );
+    }
+
+    #[tokio::test]
+    async fn sync_public_accounts_marks_same_nonce_mismatch_as_superseded() {
+        let mut builder = MockChainBuilder::new();
+        let account = builder.add_existing_mock_account(miden_testing::Auth::IncrNonce).unwrap();
+        let rpc_api = MockRpcApi::new(builder.build().unwrap());
+        let state_sync = StateSync::new(Arc::new(rpc_api), Arc::new(MockScreener), None);
+
+        // Local state is at the same nonce as the node's but with a different commitment: a fork
+        // where the local transaction lost the race and must be discarded.
+        let local_header =
+            AccountHeader::new(account.id(), account.nonce(), EMPTY_WORD, EMPTY_WORD, EMPTY_WORD);
+        let current_public_accounts = vec![&local_header];
+        let commitment_updates = vec![(account.id(), account.to_commitment())];
+        let mut account_updates = AccountUpdates::default();
+
+        let superseded = state_sync
+            .sync_public_accounts(
+                &mut account_updates,
+                &commitment_updates,
+                &current_public_accounts,
+                BlockNumber::GENESIS,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            account_updates.updated_public_accounts().is_empty(),
+            "a same-nonce fork must not overwrite the account while its tx is still pending"
+        );
+        assert_eq!(
+            superseded,
+            vec![local_header.to_commitment()],
+            "the superseded local state should be reported so its transaction is discarded"
         );
     }
 

--- a/crates/rust-client/src/sync/state_sync_update.rs
+++ b/crates/rust-client/src/sync/state_sync_update.rs
@@ -290,6 +290,14 @@ impl TransactionUpdateTracker {
         );
     }
 
+    /// Discards the local transaction that produced this now-superseded account state.
+    pub fn apply_superseded_account_state(&mut self, superseded_account_state: Word) {
+        self.discard_transaction_with_predicate(
+            |transaction| transaction.details.final_account_state == superseded_account_state,
+            DiscardCause::Superseded,
+        );
+    }
+
     /// Discards transactions that have the same initial account state as the provided one.
     pub fn apply_invalid_initial_account_state(&mut self, invalid_account_state: Word) {
         self.discard_transaction_with_predicate(

--- a/crates/rust-client/src/transaction/record.rs
+++ b/crates/rust-client/src/transaction/record.rs
@@ -147,6 +147,8 @@ pub enum DiscardCause {
     InputConsumed,
     DiscardedInitialState,
     Stale,
+    /// Another transaction reached the same account nonce first, so this one can never commit.
+    Superseded,
 }
 
 impl DiscardCause {
@@ -156,6 +158,7 @@ impl DiscardCause {
             "InputConsumed" => Ok(DiscardCause::InputConsumed),
             "DiscardedInitialState" => Ok(DiscardCause::DiscardedInitialState),
             "Stale" => Ok(DiscardCause::Stale),
+            "Superseded" => Ok(DiscardCause::Superseded),
             _ => Err(DeserializationError::InvalidValue(format!("Invalid discard cause: {cause}"))),
         }
     }
@@ -168,6 +171,7 @@ impl fmt::Display for DiscardCause {
             DiscardCause::InputConsumed => write!(f, "InputConsumed"),
             DiscardCause::DiscardedInitialState => write!(f, "DiscardedInitialState"),
             DiscardCause::Stale => write!(f, "Stale"),
+            DiscardCause::Superseded => write!(f, "Superseded"),
         }
     }
 }
@@ -179,6 +183,7 @@ impl Serializable for DiscardCause {
             DiscardCause::InputConsumed => target.write_u8(1),
             DiscardCause::DiscardedInitialState => target.write_u8(2),
             DiscardCause::Stale => target.write_u8(3),
+            DiscardCause::Superseded => target.write_u8(4),
         }
     }
 }
@@ -190,6 +195,7 @@ impl Deserializable for DiscardCause {
             1 => Ok(DiscardCause::InputConsumed),
             2 => Ok(DiscardCause::DiscardedInitialState),
             3 => Ok(DiscardCause::Stale),
+            4 => Ok(DiscardCause::Superseded),
             _ => Err(DeserializationError::InvalidValue("Invalid discard cause".to_string())),
         }
     }

--- a/crates/sqlite-store/src/account/accounts.rs
+++ b/crates/sqlite-store/src/account/accounts.rs
@@ -744,6 +744,24 @@ impl SqliteStore {
     ) -> Result<(), StoreError> {
         let account_id = new_account_state.id();
         let account_id_hex = account_id.to_hex();
+
+        // Read old header before mutating the SMT snapshot or database rows. Sync filters stale
+        // full-account snapshots; if one still reaches storage, reject it before mutating.
+        let old_header = query_latest_account_headers(tx, "id = ?", params![&account_id_hex])?
+            .into_iter()
+            .next()
+            .map(|(header, ..)| header)
+            .ok_or(StoreError::AccountDataNotFound(account_id))?;
+
+        if new_account_state.nonce().as_canonical_u64() < old_header.nonce().as_canonical_u64() {
+            return Err(StoreError::DatabaseError(format!(
+                "update_account_state: new nonce {} is less than old nonce {} for account {}",
+                new_account_state.nonce().as_canonical_u64(),
+                old_header.nonce().as_canonical_u64(),
+                account_id,
+            )));
+        }
+
         let nonce_val = u64_to_value(new_account_state.nonce().as_canonical_u64());
 
         // Insert and register account state in the SMT forest (handles old root cleanup)
@@ -752,13 +770,6 @@ impl SqliteStore {
             new_account_state.vault(),
             new_account_state.storage(),
         )?;
-
-        // Read old header before overwriting.
-        let old_header = query_latest_account_headers(tx, "id = ?", params![account_id.to_hex()])?
-            .into_iter()
-            .next()
-            .map(|(header, ..)| header)
-            .ok_or(StoreError::AccountDataNotFound(account_id))?;
 
         // Archive all old entries from latest → historical
         tx.execute(

--- a/crates/sqlite-store/src/account/tests.rs
+++ b/crates/sqlite-store/src/account/tests.rs
@@ -1626,6 +1626,60 @@ async fn undo_after_update_account_state_does_not_resurrect_removed_entries() ->
     Ok(())
 }
 
+/// Verifies that stale full-account snapshots don't roll a locally newer state back.
+#[tokio::test]
+async fn update_account_state_rejects_stale_full_snapshot_without_mutating() -> anyhow::Result<()> {
+    let store = create_test_store().await;
+    let map_slot_name = StorageSlotName::new("test::stale_update::map").expect("valid slot name");
+
+    // Insert nonce-0 account, then advance the persisted state to nonce 1.
+    let stale_account = setup_account_with_map(&store, 3, &map_slot_name).await?;
+    let account_id = stale_account.id();
+    let mut current_account = stale_account.clone();
+    apply_single_entry_update(&store, &mut current_account, &map_slot_name, 1).await?;
+    assert!(stale_account.nonce().as_canonical_u64() < current_account.nonce().as_canonical_u64());
+    assert_ne!(stale_account.to_commitment(), current_account.to_commitment());
+
+    let metrics_before_stale_update = get_storage_metrics(&store).await;
+
+    // Feed the older nonce-0 full snapshot through the same path used for public account sync.
+    let smt_forest = store.smt_forest.clone();
+    let result = store
+        .interact_with_connection(move |conn| {
+            let tx = conn.transaction().into_store_error()?;
+            let mut smt_forest = smt_forest.write().expect("smt_forest write lock not poisoned");
+            SqliteStore::update_account_state(&tx, &mut smt_forest, &stale_account)?;
+            tx.commit().into_store_error()?;
+            Ok(())
+        })
+        .await;
+    assert!(
+        matches!(&result, Err(StoreError::DatabaseError(err)) if err.contains("new nonce 0 is less than old nonce 1")),
+        "expected stale update to be rejected before mutating state, got {result:?}"
+    );
+
+    let persisted: Account = store
+        .get_account(account_id)
+        .await?
+        .context("account should exist after stale update")?
+        .try_into()?;
+    assert_eq!(persisted, current_account);
+
+    let metrics_after_stale_update = get_storage_metrics(&store).await;
+    assert_eq!(
+        metrics_after_stale_update.historical_account_headers,
+        metrics_before_stale_update.historical_account_headers,
+        "stale update must not archive the current header"
+    );
+    assert_eq!(
+        metrics_after_stale_update.historical_storage_map_entries,
+        metrics_before_stale_update.historical_storage_map_entries,
+        "stale update must not archive storage entries"
+    );
+
+    Ok(())
+}
+
 /// Verifies that `get_account_header_by_commitment` retrieves historical states by commitment.
 #[tokio::test]
 async fn get_account_header_by_commitment_returns_historical() -> anyhow::Result<()> {


### PR DESCRIPTION
Closes #2243.

This fixes the bug introduced by #2143 by not returning account updates that are stale as part of the sync process.

I think this could be refactored even more but in order to make this work right now, this should suffice and then we can look at simplifying things further.