### PR TITLE
feat: add `NoteTagSouce::Subscription`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Changes
 
+* [BREAKING][rust] Made `NoteTagSource` `#[non_exhaustive]` and added a `Subscription(Word)` variant. ([#XXXX](https://github.com/0xMiden/miden-client/pull/XXXX))
+* [rust] Added `Store::apply_settings_mutations` for batched `settings` writes. ([#XXXX](https://github.com/0xMiden/miden-client/pull/XXXX))
 * [BREAKING][param][rust] `NodeRpcClient::get_block_by_number()` now takes an `include_proof: bool` parameter to control whether the block proof is included in the response. ([#1991](https://github.com/0xMiden/miden-client/pull/1991))
 * [BREAKING][param][rust] `NodeRpcClient::sync_chain_mmr()` replaced `block_to: Option<BlockNumber>` with `upper_bound: SyncTarget` to match the RPC definition. Use `SyncTarget::CommittedChainTip` for previous default behavior (`None`), or `SyncTarget::BlockNumber(num)` for a specific block number. ([#1991](https://github.com/0xMiden/miden-client/pull/1991))
 * [BREAKING][rust] Added `submit_proven_batch` to `NodeRpcClient` trait. ([#2075](https://github.com/0xMiden/miden-client/pull/2075))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@
 
 ### Changes
 
-* [BREAKING][rust] Made `NoteTagSource` `#[non_exhaustive]` and added a `Subscription(Word)` variant. ([#XXXX](https://github.com/0xMiden/miden-client/pull/XXXX))
-* [rust] Added `Store::apply_settings_mutations` for batched `settings` writes. ([#XXXX](https://github.com/0xMiden/miden-client/pull/XXXX))
+* [BREAKING][rust] Added a `Subscription(Word)` variant to `NoteTagSource`. ([#2248](https://github.com/0xMiden/miden-client/pull/2248))
+* [rust] Added `Store::apply_settings_mutations` for batched `settings` writes. ([#2248](https://github.com/0xMiden/miden-client/pull/2248))
 * [BREAKING][param][rust] `NodeRpcClient::get_block_by_number()` now takes an `include_proof: bool` parameter to control whether the block proof is included in the response. ([#1991](https://github.com/0xMiden/miden-client/pull/1991))
 * [BREAKING][param][rust] `NodeRpcClient::sync_chain_mmr()` replaced `block_to: Option<BlockNumber>` with `upper_bound: SyncTarget` to match the RPC definition. Use `SyncTarget::CommittedChainTip` for previous default behavior (`None`), or `SyncTarget::BlockNumber(num)` for a specific block number. ([#1991](https://github.com/0xMiden/miden-client/pull/1991))
 * [BREAKING][rust] Added `submit_proven_batch` to `NodeRpcClient` trait. ([#2075](https://github.com/0xMiden/miden-client/pull/2075))

--- a/bin/miden-cli/src/commands/tags.rs
+++ b/bin/miden-cli/src/commands/tags.rs
@@ -54,6 +54,11 @@ async fn list_tags<AUTH>(client: Client<AUTH>) -> Result<(), CliError> {
                 format!("Note({})", details_commitment.to_hex())
             },
             miden_client::sync::NoteTagSource::User => "User".to_string(),
+            miden_client::sync::NoteTagSource::Subscription(key) => {
+                format!("Subscription({})", key.to_hex())
+            },
+            // `NoteTagSource` is `#[non_exhaustive]`; render any future source generically.
+            other => format!("{other:?}"),
         };
 
         table.add_row(vec![tag.tag.to_string(), source]);

--- a/bin/miden-cli/src/commands/tags.rs
+++ b/bin/miden-cli/src/commands/tags.rs
@@ -57,8 +57,6 @@ async fn list_tags<AUTH>(client: Client<AUTH>) -> Result<(), CliError> {
             miden_client::sync::NoteTagSource::Subscription(key) => {
                 format!("Subscription({})", key.to_hex())
             },
-            // `NoteTagSource` is `#[non_exhaustive]`; render any future source generically.
-            other => format!("{other:?}"),
         };
 
         table.add_row(vec![tag.tag.to_string(), source]);

--- a/crates/rust-client/src/store/mod.rs
+++ b/crates/rust-client/src/store/mod.rs
@@ -88,6 +88,19 @@ pub use note_record::{
     input_note_states,
 };
 
+// SETTING MUTATION
+// ================================================================================================
+
+/// A single mutation against the `settings` KV store, applied as part of an atomic batch via
+/// [`Store::apply_settings_mutations`].
+#[derive(Debug, Clone)]
+pub enum SettingMutation {
+    /// Insert or overwrite `key` with `value`.
+    Set { key: String, value: Vec<u8> },
+    /// Delete `key`.
+    Remove { key: String },
+}
+
 // STORE TRAIT
 // ================================================================================================
 
@@ -423,6 +436,25 @@ pub trait Store: Send + Sync {
 
     /// Returns all the keys from the `settings` table.
     async fn list_setting_keys(&self) -> Result<Vec<String>, StoreError>;
+
+    /// Applies a batch of [`SettingMutation`]s. Use this when several `settings` entries must stay
+    /// mutually consistent (e.g. a record and its secondary index).
+    ///
+    /// The default implementation applies the mutations sequentially and is **not** atomic — a
+    /// failure partway through leaves earlier mutations committed. Backends that can apply the
+    /// batch atomically (all-or-nothing) should override this; `SqliteStore` does.
+    async fn apply_settings_mutations(
+        &self,
+        mutations: Vec<SettingMutation>,
+    ) -> Result<(), StoreError> {
+        for mutation in mutations {
+            match mutation {
+                SettingMutation::Set { key, value } => self.set_setting(key, value).await?,
+                SettingMutation::Remove { key } => self.remove_setting(key).await?,
+            }
+        }
+        Ok(())
+    }
 
     // SYNC
     // --------------------------------------------------------------------------------------------

--- a/crates/rust-client/src/store/mod.rs
+++ b/crates/rust-client/src/store/mod.rs
@@ -439,22 +439,10 @@ pub trait Store: Send + Sync {
 
     /// Applies a batch of [`SettingMutation`]s. Use this when several `settings` entries must stay
     /// mutually consistent (e.g. a record and its secondary index).
-    ///
-    /// The default implementation applies the mutations sequentially and is **not** atomic — a
-    /// failure partway through leaves earlier mutations committed. Backends that can apply the
-    /// batch atomically (all-or-nothing) should override this; `SqliteStore` does.
     async fn apply_settings_mutations(
         &self,
         mutations: Vec<SettingMutation>,
-    ) -> Result<(), StoreError> {
-        for mutation in mutations {
-            match mutation {
-                SettingMutation::Set { key, value } => self.set_setting(key, value).await?,
-                SettingMutation::Remove { key } => self.remove_setting(key).await?,
-            }
-        }
-        Ok(())
-    }
+    ) -> Result<(), StoreError>;
 
     // SYNC
     // --------------------------------------------------------------------------------------------

--- a/crates/rust-client/src/sync/tag.rs
+++ b/crates/rust-client/src/sync/tag.rs
@@ -1,6 +1,7 @@
 use alloc::string::ToString;
 use alloc::vec::Vec;
 
+use miden_protocol::Word;
 use miden_protocol::account::{Account, AccountId};
 use miden_protocol::note::{NoteDetailsCommitment, NoteTag};
 use miden_tx::utils::serde::{
@@ -70,7 +71,11 @@ pub struct NoteTagRecord {
 
 /// Represents the source of the tag. This is used to differentiate between tags that are added by
 /// the user and tags that are added automatically by the client to track notes .
+///
+/// Marked `#[non_exhaustive]`: downstream code matching on this enum must include a wildcard arm,
+/// so future variants can be added without breaking it.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[non_exhaustive]
 pub enum NoteTagSource {
     /// Tag for notes directed to a tracked account.
     Account(AccountId),
@@ -78,6 +83,11 @@ pub enum NoteTagSource {
     Note(NoteDetailsCommitment),
     /// Tag manually added by the user.
     User,
+    /// Tag for a long-lived subscription, anchored to an opaque 4-felt key that identifies its
+    /// origin (e.g. the id of the note that registered it). Distinct subscriptions may share the
+    /// same [`NoteTag`]; the key keeps them as separate rows so each is tracked and removed
+    /// independently.
+    Subscription(Word),
 }
 
 impl NoteTagRecord {
@@ -123,6 +133,11 @@ impl Serializable for NoteTagSource {
                 details_commitment.write_into(target);
             },
             NoteTagSource::User => target.write_u8(2),
+            NoteTagSource::Subscription(key) => {
+                // Discriminant 3 must stay stable so rows survive deserialization.
+                target.write_u8(3);
+                key.write_into(target);
+            },
         }
     }
 }
@@ -133,6 +148,7 @@ impl Deserializable for NoteTagSource {
             0 => Ok(NoteTagSource::Account(AccountId::read_from(source)?)),
             1 => Ok(NoteTagSource::Note(NoteDetailsCommitment::read_from(source)?)),
             2 => Ok(NoteTagSource::User),
+            3 => Ok(NoteTagSource::Subscription(Word::read_from(source)?)),
             val => Err(DeserializationError::InvalidValue(format!("Invalid tag source: {val}"))),
         }
     }
@@ -162,5 +178,25 @@ impl TryInto<NoteTagRecord> for &InputNoteRecord {
                 "Input Note Record does not contain tag".to_string(),
             )),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use miden_protocol::{Felt, Word};
+    use miden_tx::utils::serde::{Deserializable, Serializable};
+
+    use super::NoteTagSource;
+
+    #[test]
+    fn subscription_note_tag_source_round_trips_with_stable_discriminant() {
+        let key: Word =
+            [Felt::from(1u32), Felt::from(2u32), Felt::from(3u32), Felt::from(4u32)].into();
+        let source = NoteTagSource::Subscription(key);
+
+        let bytes = source.to_bytes();
+        // Discriminant byte must stay 3 so persisted rows keep deserializing across releases.
+        assert_eq!(bytes[0], 3, "Subscription discriminant must remain 3");
+        assert_eq!(NoteTagSource::read_from_bytes(&bytes).unwrap(), source);
     }
 }

--- a/crates/rust-client/src/sync/tag.rs
+++ b/crates/rust-client/src/sync/tag.rs
@@ -71,11 +71,7 @@ pub struct NoteTagRecord {
 
 /// Represents the source of the tag. This is used to differentiate between tags that are added by
 /// the user and tags that are added automatically by the client to track notes .
-///
-/// Marked `#[non_exhaustive]`: downstream code matching on this enum must include a wildcard arm,
-/// so future variants can be added without breaking it.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[non_exhaustive]
 pub enum NoteTagSource {
     /// Tag for notes directed to a tracked account.
     Account(AccountId),

--- a/crates/sqlite-store/src/lib.rs
+++ b/crates/sqlite-store/src/lib.rs
@@ -45,6 +45,7 @@ use miden_client::store::{
     NoteFilter,
     OutputNoteRecord,
     PartialBlockchainFilter,
+    SettingMutation,
     Store,
     StoreError,
     TransactionFilter,
@@ -469,6 +470,26 @@ impl Store for SqliteStore {
 
     async fn list_setting_keys(&self) -> Result<Vec<String>, StoreError> {
         self.interact_with_connection(move |conn| list_setting_keys(conn)).await
+    }
+
+    async fn apply_settings_mutations(
+        &self,
+        mutations: Vec<SettingMutation>,
+    ) -> Result<(), StoreError> {
+        self.interact_with_connection(move |conn| {
+            let tx = conn.transaction().into_store_error()?;
+            for mutation in &mutations {
+                match mutation {
+                    SettingMutation::Set { key, value } => {
+                        set_setting(&tx, key, value).into_store_error()?;
+                    },
+                    SettingMutation::Remove { key } => remove_setting(&tx, key)?,
+                }
+            }
+            tx.commit().into_store_error()?;
+            Ok(())
+        })
+        .await
     }
 
     async fn get_unspent_input_note_nullifiers(&self) -> Result<Vec<Nullifier>, StoreError> {


### PR DESCRIPTION
Extracts the last breaking change from https://github.com/0xMiden/miden-client/pull/2231, basically a note tag source for opaque key-based subscriptions.
Also adds the store method with a blanket implementation to reduce the diff.