### PR TITLE
feat(sync): Verify private account commitment before locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Fixes
 
-* [FIX][rust] State sync now re-verifies a tracked private account's commitment mismatch against the witness `get_account` returns. The witness is checked against the synced block's account root before locking the account, so a node can no longer durably lock it with a forged `sync_transactions` commitment ([#2260](https://github.com/0xMiden/miden-client/pull/2260)).
-* [FIX][rust] State sync now range-checks `sync_transactions` records to `(current, chain_tip]`, rejecting out-of-range records that could forge transaction commit heights ([#2252](https://github.com/0xMiden/miden-client/pull/2252)).
+* [FIX][rust] State sync now re-verifies a tracked private account's commitment mismatch against the witness `get_account` returns. The witness is checked against the synced block's account root before locking the account, so a node can no longer durably lock it with a forged `sync_transactions` commitment ([#2260](https://github.com/0xMiden/rust-sdk/pull/2260)).
+* [FIX][rust] State sync now range-checks `sync_transactions` records to `(current, chain_tip]`, rejecting out-of-range records that could forge transaction commit heights ([#2252](https://github.com/0xMiden/rust-sdk/pull/2252)).
 * [FIX][rust] `Endpoint` parsing now strips a trailing slash from the host of no-port endpoints such as `http://host/`, matching the cleanup already applied when a port is present ([#2268](https://github.com/0xMiden/rust-sdk/pull/2268)).
 * [FIX][rust] `NodeRpcClient::get_block_header_by_number` and `get_block_by_number` now reject responses whose block number does not match the requested one with `RpcError::InvalidResponse` ([#2270](https://github.com/0xMiden/rust-sdk/pull/2270)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* [FIX][rust] State sync now re-verifies a tracked private account's commitment mismatch against the witness `get_account` returns. The witness is checked against the synced block's account root before locking the account, so a node can no longer durably lock it with a forged `sync_transactions` commitment ([#2239](https://github.com/0xMiden/miden-client/issues/2239)).
 * [FIX][rust] State sync now range-checks `sync_transactions` records to `(current, chain_tip]`, rejecting out-of-range records that could forge transaction commit heights ([#2252](https://github.com/0xMiden/miden-client/pull/2252)).
 
 ## 0.15.0 (2026-06-12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-* [FIX][rust] State sync now re-verifies a tracked private account's commitment mismatch against the witness `get_account` returns. The witness is checked against the synced block's account root before locking the account, so a node can no longer durably lock it with a forged `sync_transactions` commitment ([#2239](https://github.com/0xMiden/miden-client/issues/2239)).
+* [FIX][rust] State sync now re-verifies a tracked private account's commitment mismatch against the witness `get_account` returns. The witness is checked against the synced block's account root before locking the account, so a node can no longer durably lock it with a forged `sync_transactions` commitment ([#2260](https://github.com/0xMiden/miden-client/pull/2260)).
 * [FIX][rust] State sync now range-checks `sync_transactions` records to `(current, chain_tip]`, rejecting out-of-range records that could forge transaction commit heights ([#2252](https://github.com/0xMiden/miden-client/pull/2252)).
 
 ## 0.15.0 (2026-06-12)

--- a/crates/rust-client/src/sync/state_sync.rs
+++ b/crates/rust-client/src/sync/state_sync.rs
@@ -1303,6 +1303,36 @@ mod tests {
     // PRIVATE ACCOUNT LOCK VERIFICATION TESTS
     // --------------------------------------------------------------------------------------------
 
+    /// Verifies that `sync_transactions` records outside the requested range `(current, chain_tip]`
+    /// are rejected with a `ChainValidationError`.
+    #[test]
+    fn validate_transaction_records_range_rejects_out_of_range_blocks() {
+        let account_id: AccountId = ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET.try_into().unwrap();
+        let current = BlockNumber::from(5u32);
+        let chain_tip = BlockNumber::from(10u32);
+
+        StateSync::validate_transaction_records_range(
+            &[make_tx_record(account_id, 7)],
+            current,
+            chain_tip,
+        )
+        .unwrap();
+
+        let result = StateSync::validate_transaction_records_range(
+            &[make_tx_record(account_id, 11)],
+            current,
+            chain_tip,
+        );
+        assert!(matches!(result, Err(ClientError::ChainValidationError(_))));
+
+        let result = StateSync::validate_transaction_records_range(
+            &[make_tx_record(account_id, 5)],
+            current,
+            chain_tip,
+        );
+        assert!(matches!(result, Err(ClientError::ChainValidationError(_))));
+    }
+
     /// A forged `sync_transactions` commitment must not lock the account when the witness proves
     /// the on-chain commitment still matches the local one.
     #[tokio::test]
@@ -2278,35 +2308,5 @@ mod tests {
             output_notes: vec![],
             erased_output_notes: vec![],
         }
-    }
-
-    /// Verifies that `sync_transactions` records outside the requested range `(current, chain_tip]`
-    /// are rejected with a `ChainValidationError`.
-    #[test]
-    fn validate_transaction_records_range_rejects_out_of_range_blocks() {
-        let account_id: AccountId = ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET.try_into().unwrap();
-        let current = BlockNumber::from(5u32);
-        let chain_tip = BlockNumber::from(10u32);
-
-        StateSync::validate_transaction_records_range(
-            &[make_tx_record(account_id, 7)],
-            current,
-            chain_tip,
-        )
-        .unwrap();
-
-        let result = StateSync::validate_transaction_records_range(
-            &[make_tx_record(account_id, 11)],
-            current,
-            chain_tip,
-        );
-        assert!(matches!(result, Err(ClientError::ChainValidationError(_))));
-
-        let result = StateSync::validate_transaction_records_range(
-            &[make_tx_record(account_id, 5)],
-            current,
-            chain_tip,
-        );
-        assert!(matches!(result, Err(ClientError::ChainValidationError(_))));
     }
 }

--- a/crates/rust-client/src/sync/state_sync.rs
+++ b/crates/rust-client/src/sync/state_sync.rs
@@ -1304,9 +1304,7 @@ mod tests {
     // --------------------------------------------------------------------------------------------
 
     /// A forged `sync_transactions` commitment must not lock the account when the witness proves
-    /// the on-chain commitment still matches the local one. The helper is
-    /// type-agnostic: it ignores account details and only verifies the witness, so a committed
-    /// mock account exercises the same path used for private accounts.
+    /// the on-chain commitment still matches the local one.
     #[tokio::test]
     async fn verify_private_account_mismatch_ignores_forged_commitment() {
         let mut builder = MockChainBuilder::new();
@@ -1327,8 +1325,8 @@ mod tests {
         );
     }
 
-    /// When the witness proves a commitment that genuinely differs from the local one, the account
-    /// is reported as mismatched with the proven (not the record's) commitment.
+    /// When the witness proves a commitment that differs from the local one, the account is
+    /// reported as mismatched with the proven commitment.
     #[tokio::test]
     async fn verify_private_account_mismatch_reports_proven_divergence() {
         let mut builder = MockChainBuilder::new();
@@ -1337,8 +1335,6 @@ mod tests {
         let chain_tip_header = rpc_api.mock_chain.read().latest_block_header();
         let on_chain_commitment = account.to_commitment();
         let state_sync = StateSync::new(Arc::new(rpc_api), Arc::new(MockScreener), None);
-
-        // Local state lags behind the proven on-chain commitment.
         let stale_local_commitment = word(0xdead_beef);
 
         let result = state_sync

--- a/crates/rust-client/src/sync/state_sync.rs
+++ b/crates/rust-client/src/sync/state_sync.rs
@@ -22,11 +22,11 @@ use super::{
 };
 use crate::ClientError;
 use crate::note::{NoteConsumption, NoteUpdateTracker};
-use crate::rpc::NodeRpcClient;
 use crate::rpc::domain::account::{AccountDetails, GetAccountRequest, StorageMapFetch, VaultFetch};
 use crate::rpc::domain::note::{CommittedNote, NoteSyncBlock, SyncedNoteDetails};
 use crate::rpc::domain::sync::{ChainMmrInfo, SyncTarget};
 use crate::rpc::domain::transaction::TransactionRecord as RpcTransactionRecord;
+use crate::rpc::{AccountStateAt, NodeRpcClient};
 use crate::store::{InputNoteRecord, OutputNoteRecord, StoreError};
 use crate::transaction::TransactionRecord;
 
@@ -242,6 +242,7 @@ impl StateSync {
                 &accounts,
                 &new_commitments,
                 block_num,
+                &sync_data.chain_tip_header,
             )
             .await?;
 
@@ -645,6 +646,7 @@ impl StateSync {
         accounts: &[AccountHeader],
         account_commitment_updates: &[(AccountId, Word)],
         block_from: BlockNumber,
+        chain_tip_header: &BlockHeader,
     ) -> Result<Vec<Word>, ClientError> {
         // "Public" here includes both Public and Network accounts, since both have
         // their state stored on-chain and follow the same sync path.
@@ -660,19 +662,81 @@ impl StateSync {
             )
             .await?;
 
-        let mismatched_private_accounts = account_commitment_updates
-            .iter()
-            .filter(|(account_id, digest)| {
-                private_accounts
-                    .iter()
-                    .any(|header| header.id() == *account_id && &header.to_commitment() != digest)
-            })
-            .copied()
-            .collect::<Vec<_>>();
+        // If a private account commitment differs between the node and local then we verify the
+        // commitment from the node before flagging the account as mismatched.
+        let mut mismatched_private_accounts = Vec::new();
+        for header in &private_accounts {
+            let account_id = header.id();
+            let local_commitment = header.to_commitment();
+            let record_diverges = account_commitment_updates
+                .iter()
+                .any(|(id, digest)| *id == account_id && *digest != local_commitment);
+            if !record_diverges {
+                continue;
+            }
+
+            if let Some(proven_commitment) = self
+                .verify_private_account_mismatch(account_id, local_commitment, chain_tip_header)
+                .await?
+            {
+                mismatched_private_accounts.push((account_id, proven_commitment));
+            }
+        }
 
         account_updates.extend(AccountUpdates::new(Vec::new(), mismatched_private_accounts));
 
         Ok(superseded_states)
+    }
+
+    /// Verifies a private account commitment against an account witness from the node.
+    ///
+    /// Assumes `local_commitment` is a private account commitment that diverges from the
+    /// `sync_transactions` records.
+    ///
+    /// Fetches the account witness via `get_account` at `chain_tip_header`'s block and checks the
+    /// root it computes against `chain_tip_header`'s account root.
+    ///
+    /// Returns `Some(proven_commitment)` only when the proven on-chain commitment differs from
+    /// `local_commitment`.
+    async fn verify_private_account_mismatch(
+        &self,
+        account_id: AccountId,
+        local_commitment: Word,
+        chain_tip_header: &BlockHeader,
+    ) -> Result<Option<Word>, ClientError> {
+        let chain_tip = chain_tip_header.block_num();
+        let (proof_block_num, proof) = self
+            .rpc_api
+            .get_account(account_id, GetAccountRequest::new().at(AccountStateAt::Block(chain_tip)))
+            .await?;
+
+        if proof_block_num != chain_tip {
+            return Err(ClientError::ChainValidationError(format!(
+                "get_account returned a proof at block {proof_block_num}, expected chain tip {chain_tip}"
+            )));
+        }
+
+        let (witness, _) = proof.into_parts();
+        let witness_id = witness.id();
+        let proven_commitment = witness.state_commitment();
+        // Verifying the witness against the chain tip's account root ties the proven commitment to
+        // the synced block.
+        if witness.into_proof().compute_root() != chain_tip_header.account_root() {
+            return Err(ClientError::ChainValidationError(format!(
+                "account witness for {account_id} does not verify against the chain tip account root"
+            )));
+        }
+
+        // Check if the witness is for a different account at this prefix, the account is absent on
+        // chain, or the proven commitment matches local.
+        if witness_id != account_id
+            || proven_commitment == Word::empty()
+            || proven_commitment == local_commitment
+        {
+            return Ok(None);
+        }
+
+        Ok(Some(proven_commitment))
     }
 
     /// Queries the node for updated public accounts and populates `account_updates`.
@@ -1234,6 +1298,101 @@ mod tests {
             vec![local_header.to_commitment()],
             "the superseded local state should be reported so its transaction is discarded"
         );
+    }
+
+    // PRIVATE ACCOUNT LOCK VERIFICATION TESTS
+    // --------------------------------------------------------------------------------------------
+
+    /// A forged `sync_transactions` commitment must not lock the account when the witness proves
+    /// the on-chain commitment still matches the local one. The helper is
+    /// type-agnostic: it ignores account details and only verifies the witness, so a committed
+    /// mock account exercises the same path used for private accounts.
+    #[tokio::test]
+    async fn verify_private_account_mismatch_ignores_forged_commitment() {
+        let mut builder = MockChainBuilder::new();
+        let account = builder.add_existing_mock_account(miden_testing::Auth::IncrNonce).unwrap();
+        let rpc_api = MockRpcApi::new(builder.build().unwrap());
+        let chain_tip_header = rpc_api.mock_chain.read().latest_block_header();
+        let on_chain_commitment = account.to_commitment();
+        let state_sync = StateSync::new(Arc::new(rpc_api), Arc::new(MockScreener), None);
+
+        let result = state_sync
+            .verify_private_account_mismatch(account.id(), on_chain_commitment, &chain_tip_header)
+            .await
+            .unwrap();
+
+        assert!(
+            result.is_none(),
+            "an unproven commitment must not lock an account whose on-chain state matches local"
+        );
+    }
+
+    /// When the witness proves a commitment that genuinely differs from the local one, the account
+    /// is reported as mismatched with the proven (not the record's) commitment.
+    #[tokio::test]
+    async fn verify_private_account_mismatch_reports_proven_divergence() {
+        let mut builder = MockChainBuilder::new();
+        let account = builder.add_existing_mock_account(miden_testing::Auth::IncrNonce).unwrap();
+        let rpc_api = MockRpcApi::new(builder.build().unwrap());
+        let chain_tip_header = rpc_api.mock_chain.read().latest_block_header();
+        let on_chain_commitment = account.to_commitment();
+        let state_sync = StateSync::new(Arc::new(rpc_api), Arc::new(MockScreener), None);
+
+        // Local state lags behind the proven on-chain commitment.
+        let stale_local_commitment = word(0xdead_beef);
+
+        let result = state_sync
+            .verify_private_account_mismatch(
+                account.id(),
+                stale_local_commitment,
+                &chain_tip_header,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result,
+            Some(on_chain_commitment),
+            "a proven divergence should return the proven commitment to lock with"
+        );
+    }
+
+    /// A witness that doesn't verify against the chain tip's account root is a misbehaving node and
+    /// must abort the sync rather than lock the account.
+    #[tokio::test]
+    async fn verify_private_account_mismatch_rejects_unverifiable_proof() {
+        let mut builder = MockChainBuilder::new();
+        let account = builder.add_existing_mock_account(miden_testing::Auth::IncrNonce).unwrap();
+        let rpc_api = MockRpcApi::new(builder.build().unwrap());
+        let real_header = rpc_api.mock_chain.read().latest_block_header();
+        let state_sync = StateSync::new(Arc::new(rpc_api), Arc::new(MockScreener), None);
+
+        // Same block number so the request resolves, but a tampered account root the witness
+        // cannot verify against.
+        let tampered_header = BlockHeader::new(
+            real_header.version(),
+            real_header.prev_block_commitment(),
+            real_header.block_num(),
+            real_header.chain_commitment(),
+            word(0xbad0_bad0),
+            real_header.nullifier_root(),
+            real_header.note_root(),
+            real_header.tx_commitment(),
+            real_header.tx_kernel_commitment(),
+            real_header.validator_key().clone(),
+            real_header.fee_parameters().clone(),
+            real_header.timestamp(),
+        );
+
+        let result = state_sync
+            .verify_private_account_mismatch(
+                account.id(),
+                account.to_commitment(),
+                &tampered_header,
+            )
+            .await;
+
+        assert!(matches!(result, Err(ClientError::ChainValidationError(_))));
     }
 
     // COMPUTE NULLIFIER TX ORDER TESTS


### PR DESCRIPTION
Adds a verification step in `sync_state` for private accounts whose commitment doesn't match the commitment from `sync_transactions` records. The account is locked only when that divergence is confirmed by an account witness verified against the synced block's account root, so a forged `sync_transactions` record alone can't trigger a lock.

This PR and #2252 close #2239.