### PR TITLE
feat(rust-client): propagate NTL after_block_num delivery hint (#2108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+* [FIX][rust] Private notes delivered via the Note Transport Layer are no longer silently lost when their on-chain commitment lands more than the 20-block lookback window before the NTL delivers the note. `Client::send_private_note` now relays the note's submission height as the NTL `after_block_num` hint (a lower bound on the commitment block that the creating transaction cannot precede), and the receiver scans from `min(after_block_num, sync_height - lookback)` rather than a fixed lookback window — so the scanned range is always a superset of the lookback and a precise hint covers the exact commitment block. Each sync also re-scans still-`Expected` notes from their stored floor, recovering a note whose commitment a one-shot import scan missed (e.g. an incomplete `sync_notes` response). Consumes the `after_block_num` field added in `0xMiden/note-transport-service#81` and bumps `miden-note-transport-proto-build` to `0.4.1` ([#2108](https://github.com/0xMiden/miden-client/issues/2108)).
+
+### Changes
+
+* [BREAKING][param][rust] `NoteTransportClient::send_note` takes an additional `after_block_num: Option<BlockNumber>` argument — the sender-provided lower bound on the note's commitment block, relayed as the NTL `after_block_num` wire field — and the `NoteInfo` struct carries a matching `after_block_num` field ([#2108](https://github.com/0xMiden/miden-client/issues/2108)).
+
 ## 0.15.1 (2026-06-16)
 
 ### Enhancements

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2492,9 +2492,9 @@ dependencies = [
 
 [[package]]
 name = "miden-note-transport-proto-build"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb0d4c7cc5f8d94624bab25c43a71039d44abb4f441acdbb34d9a284dc2e2cc1"
+checksum = "7399c2999453c781601f16d82f328ecc695f9375e2415a05147449990f32f71f"
 dependencies = [
  "fs-err",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ miden-tx-batch-prover = { default-features = false, version = "0.15.3" }
 
 # Miden node dependencies
 miden-node-proto-build           = { default-features = false, version = "0.15.0" }
-miden-note-transport-proto-build = { default-features = false, version = "0.4" }
+miden-note-transport-proto-build = { default-features = false, version = "0.4.1" }
 miden-remote-prover-client       = { default-features = false, features = ["tx-prover"], version = "0.15.0" }
 
 # Miden debug dependency

--- a/crates/rust-client/src/note/import.rs
+++ b/crates/rust-client/src/note/import.rs
@@ -51,26 +51,40 @@ where
     /// indefinitely. Re-importing reuses [`Client::import_notes`], so a note that is found
     /// transitions to `Committed` and one that is not is left untouched.
     ///
-    /// Cheap in the steady state: `Expected` notes are transient (they commit within a few
-    /// blocks) and the rescan issues no RPC when there are none.
+    /// The rescan floor is bounded to [`RESCAN_LOOKBACK_BLOCKS`] behind the sync height: a note
+    /// that never commits (e.g. its creating transaction was dropped) would otherwise keep its
+    /// original floor forever and grow the scanned range without limit as the chain advances. The
+    /// import scan already covered each note's full floor→import-height window once; a transient
+    /// incomplete-response miss commits near the import height, so a bounded recent window
+    /// recovers it. Issues no RPC when there are no `Expected` notes, the steady-state case.
     pub(crate) async fn rescan_expected_notes(&mut self) -> Result<(), ClientError> {
+        /// Cap on how far behind the sync height the rescan scans, bounding the per-sync cost.
+        const RESCAN_LOOKBACK_BLOCKS: u32 = 256;
+
         let expected_notes = self.store.get_input_notes(NoteFilter::Expected).await?;
+        if expected_notes.is_empty() {
+            return Ok(());
+        }
+
+        let floor_bound =
+            self.get_sync_height().await?.as_u32().saturating_sub(RESCAN_LOOKBACK_BLOCKS);
 
         let mut note_files = Vec::new();
         for record in expected_notes {
             // Only notes that still carry a tag can be matched on-chain, by reconstructing their
             // id from the committed metadata (see `check_expected_notes`).
             let InputNoteState::Expected(ExpectedNoteState {
-                after_block_num,
-                tag: Some(tag),
-                ..
+                after_block_num, tag: Some(tag), ..
             }) = record.state()
             else {
                 continue;
             };
             note_files.push(NoteFile::NoteDetails {
                 details: record.details().clone(),
-                after_block_num: *after_block_num,
+                // Never scan further back than the bounded window, even when the note's stored
+                // floor is older. This only sets the scan floor; the stored record keeps its
+                // original `after_block_num` (the re-import reuses it via `previous_note`).
+                after_block_num: BlockNumber::from(after_block_num.as_u32().max(floor_bound)),
                 tag: Some(*tag),
             });
         }

--- a/crates/rust-client/src/note/import.rs
+++ b/crates/rust-client/src/note/import.rs
@@ -41,6 +41,47 @@ where
     // INPUT NOTE CREATION
     // --------------------------------------------------------------------------------------------
 
+    /// Re-scans still-`Expected` notes against the chain, committing any whose on-chain
+    /// commitment the one-shot import scan missed — for example because the node returned an
+    /// incomplete (but successful) `sync_notes` response when the note was imported.
+    ///
+    /// This is the only path that recovers such a note: the import scan runs once, and forward
+    /// chain sync only revisits blocks ahead of the last sync height, so a note committed at or
+    /// below the import height that the import scan didn't return would otherwise stay `Expected`
+    /// indefinitely. Re-importing reuses [`Client::import_notes`], so a note that is found
+    /// transitions to `Committed` and one that is not is left untouched.
+    ///
+    /// Cheap in the steady state: `Expected` notes are transient (they commit within a few
+    /// blocks) and the rescan issues no RPC when there are none.
+    pub(crate) async fn rescan_expected_notes(&mut self) -> Result<(), ClientError> {
+        let expected_notes = self.store.get_input_notes(NoteFilter::Expected).await?;
+
+        let mut note_files = Vec::new();
+        for record in expected_notes {
+            // Only notes that still carry a tag can be matched on-chain, by reconstructing their
+            // id from the committed metadata (see `check_expected_notes`).
+            let InputNoteState::Expected(ExpectedNoteState {
+                after_block_num,
+                tag: Some(tag),
+                ..
+            }) = record.state()
+            else {
+                continue;
+            };
+            note_files.push(NoteFile::NoteDetails {
+                details: record.details().clone(),
+                after_block_num: *after_block_num,
+                tag: Some(*tag),
+            });
+        }
+
+        if !note_files.is_empty() {
+            self.import_notes(&note_files).await?;
+        }
+
+        Ok(())
+    }
+
     /// Imports a batch of new input notes into the client's store. The information stored depends
     /// on the type of note files provided. If the notes existed previously, it will be updated
     /// with the new information. The tags specified by the `NoteFile`s will start being

--- a/crates/rust-client/src/note/import.rs
+++ b/crates/rust-client/src/note/import.rs
@@ -57,6 +57,12 @@ where
     /// import scan already covered each note's full floor→import-height window once; a transient
     /// incomplete-response miss commits near the import height, so a bounded recent window
     /// recovers it. Issues no RPC when there are no `Expected` notes, the steady-state case.
+    ///
+    /// This recovers only near-import-height misses; it is not a general safety net. A note
+    /// committed below its stored floor — e.g. delivered with no `after_block_num` hint and
+    /// committed more than the lookback window before import — is unreachable from that floor and
+    /// is not recovered here. The sender-provided hint, applied at import, is the fix for that
+    /// case.
     pub(crate) async fn rescan_expected_notes(&mut self) -> Result<(), ClientError> {
         /// Cap on how far behind the sync height the rescan scans, bounding the per-sync cost.
         const RESCAN_LOOKBACK_BLOCKS: u32 = 256;

--- a/crates/rust-client/src/note/import.rs
+++ b/crates/rust-client/src/note/import.rs
@@ -51,7 +51,7 @@ where
     /// indefinitely. Re-importing reuses [`Client::import_notes`], so a note that is found
     /// transitions to `Committed` and one that is not is left untouched.
     ///
-    /// The rescan floor is bounded to [`RESCAN_LOOKBACK_BLOCKS`] behind the sync height: a note
+    /// The rescan floor is bounded to `RESCAN_LOOKBACK_BLOCKS` behind the sync height: a note
     /// that never commits (e.g. its creating transaction was dropped) would otherwise keep its
     /// original floor forever and grow the scanned range without limit as the chain advances. The
     /// import scan already covered each note's full floor→import-height window once; a transient

--- a/crates/rust-client/src/note_transport/grpc.rs
+++ b/crates/rust-client/src/note_transport/grpc.rs
@@ -10,6 +10,7 @@ use core::pin::Pin;
 use core::task::{Context, Poll};
 
 use futures::Stream;
+use miden_protocol::block::BlockNumber;
 use miden_protocol::note::{NoteHeader, NoteTag};
 use miden_protocol::utils::serde::{Deserializable, Serializable};
 use miden_tx::utils::sync::RwLock;
@@ -130,9 +131,14 @@ impl GrpcNoteTransportClient {
         &self,
         header: NoteHeader,
         details: Vec<u8>,
+        after_block_num: Option<BlockNumber>,
     ) -> Result<(), NoteTransportError> {
         let request = SendNoteRequest {
-            note: Some(TransportNote { header: header.to_bytes(), details }),
+            note: Some(TransportNote {
+                header: header.to_bytes(),
+                details,
+                after_block_num: after_block_num.map(|block| block.as_u32()),
+            }),
         };
 
         self.api()
@@ -170,7 +176,11 @@ impl GrpcNoteTransportClient {
         for pnote in response.notes {
             let header = NoteHeader::read_from_bytes(&pnote.header)?;
 
-            notes.push(NoteInfo { header, details_bytes: pnote.details });
+            notes.push(NoteInfo {
+                header,
+                details_bytes: pnote.details,
+                after_block_num: pnote.after_block_num.map(BlockNumber::from),
+            });
         }
 
         Ok((notes, response.cursor.into()))
@@ -234,8 +244,9 @@ impl super::NoteTransportClient for GrpcNoteTransportClient {
         &self,
         header: NoteHeader,
         details: Vec<u8>,
+        after_block_num: Option<BlockNumber>,
     ) -> Result<(), NoteTransportError> {
-        self.send_note(header, details).await
+        self.send_note(header, details, after_block_num).await
     }
 
     async fn fetch_notes(
@@ -279,7 +290,11 @@ impl Stream for NoteStreamAdapter {
                 for pnote in update.notes {
                     let header = NoteHeader::read_from_bytes(&pnote.header)?;
 
-                    notes.push(NoteInfo { header, details_bytes: pnote.details });
+                    notes.push(NoteInfo {
+                        header,
+                        details_bytes: pnote.details,
+                        after_block_num: pnote.after_block_num.map(BlockNumber::from),
+                    });
                 }
                 Poll::Ready(Some(Ok(notes)))
             },

--- a/crates/rust-client/src/note_transport/mod.rs
+++ b/crates/rust-client/src/note_transport/mod.rs
@@ -32,6 +32,7 @@ use miden_tx::utils::serde::{
 };
 
 pub use self::errors::NoteTransportError;
+use crate::store::NoteFilter;
 use crate::{Client, ClientError};
 
 pub const NOTE_TRANSPORT_TESTNET_ENDPOINT: &str = "https://transport.miden.io";
@@ -88,12 +89,26 @@ impl<AUTH> Client<AUTH> {
         // e2ee impl hint:
         // address.key().encrypt(details_bytes)
 
+        // The note's creating transaction cannot commit before the block at which it was
+        // submitted, so the output note's `expected_height` (the submission height) is a safe
+        // lower bound on the note's on-chain commitment block: relaying it lets the recipient
+        // scan from exactly there rather than guess with a lookback window. `None` when the note
+        // isn't tracked as an output note here, in which case the recipient falls back to its own
+        // lookback heuristic.
+        let after_block_num = self
+            .store
+            .get_output_notes(NoteFilter::List(Vec::from([note_id])))
+            .await?
+            .first()
+            .map(|record| record.expected_height());
+
         // Persist the payload before the network call so a failed or
         // interrupted `send_note` leaves a recoverable record rather than
         // losing the only copy with the call frame.
         let entry = NoteInfo {
             header,
             details_bytes: details_bytes.clone(),
+            after_block_num,
         };
         let mut outbox = self.load_relay_outbox().await?;
         // Replace any existing entry for this note id so the latest payload
@@ -102,7 +117,7 @@ impl<AUTH> Client<AUTH> {
         outbox.push(entry);
         self.save_relay_outbox(outbox).await?;
 
-        api.send_note(header, details_bytes).await?;
+        api.send_note(header, details_bytes, after_block_num).await?;
 
         // Relay succeeded — drop the entry. A failed store write here is
         // tolerable: the next flush re-sends and the receiver dedupes by note
@@ -138,7 +153,8 @@ impl<AUTH> Client<AUTH> {
         let mut last_err: Option<NoteTransportError> = None;
 
         for entry in entries {
-            match api.send_note(entry.header, entry.details_bytes.clone()).await {
+            match api.send_note(entry.header, entry.details_bytes.clone(), entry.after_block_num).await
+            {
                 Ok(()) => {},
                 Err(err) => {
                     tracing::warn!(?err, "relay-outbox entry retry failed; will retry next sync");
@@ -371,10 +387,14 @@ impl From<u64> for NoteTransportCursor {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 pub trait NoteTransportClient: Send + Sync {
     /// Send a note with optionally encrypted details
+    ///
+    /// `after_block_num` is a sender-provided lower bound on the block at which the note's
+    /// on-chain commitment landed; it is relayed verbatim so the recipient can scan from it.
     async fn send_note(
         &self,
         header: NoteHeader,
         details: Vec<u8>,
+        after_block_num: Option<BlockNumber>,
     ) -> Result<(), NoteTransportError>;
 
     /// Fetch notes for given tags
@@ -408,6 +428,11 @@ pub struct NoteInfo {
     pub header: NoteHeader,
     /// Note details, can be encrypted
     pub details_bytes: Vec<u8>,
+    /// Sender-provided lower bound on the block at which the note's on-chain commitment landed
+    /// (the NTL `after_block_num` wire field). The receiver scans from this block forward when
+    /// committing the note. `None` when the sender did not set it, in which case the receiver
+    /// falls back to its own lookback heuristic.
+    pub after_block_num: Option<BlockNumber>,
 }
 
 // SERIALIZATION
@@ -417,6 +442,7 @@ impl Serializable for NoteInfo {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         self.header.write_into(target);
         self.details_bytes.write_into(target);
+        self.after_block_num.write_into(target);
     }
 }
 
@@ -424,7 +450,8 @@ impl Deserializable for NoteInfo {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let header = NoteHeader::read_from(source)?;
         let details_bytes = Vec::<u8>::read_from(source)?;
-        Ok(NoteInfo { header, details_bytes })
+        let after_block_num = Option::<BlockNumber>::read_from(source)?;
+        Ok(NoteInfo { header, details_bytes, after_block_num })
     }
 }
 

--- a/crates/rust-client/src/note_transport/mod.rs
+++ b/crates/rust-client/src/note_transport/mod.rs
@@ -32,7 +32,7 @@ use miden_tx::utils::serde::{
 };
 
 pub use self::errors::NoteTransportError;
-use crate::store::NoteFilter;
+use crate::store::{NoteFilter, OutputNoteRecord};
 use crate::{Client, ClientError};
 
 pub const NOTE_TRANSPORT_TESTNET_ENDPOINT: &str = "https://transport.miden.io";
@@ -100,7 +100,7 @@ impl<AUTH> Client<AUTH> {
             .get_output_notes(NoteFilter::List(Vec::from([note_id])))
             .await?
             .first()
-            .map(|record| record.expected_height());
+            .map(OutputNoteRecord::expected_height);
 
         // Persist the payload before the network call so a failed or
         // interrupted `send_note` leaves a recoverable record rather than
@@ -153,7 +153,9 @@ impl<AUTH> Client<AUTH> {
         let mut last_err: Option<NoteTransportError> = None;
 
         for entry in entries {
-            match api.send_note(entry.header, entry.details_bytes.clone(), entry.after_block_num).await
+            match api
+                .send_note(entry.header, entry.details_bytes.clone(), entry.after_block_num)
+                .await
             {
                 Ok(()) => {},
                 Err(err) => {
@@ -190,6 +192,13 @@ impl<AUTH> Client<AUTH> {
         match Vec::<NoteInfo>::read_from_bytes(&bytes) {
             Ok(entries) => Ok(entries),
             Err(err) => {
+                // A relay-outbox blob written before `after_block_num` was added to `NoteInfo`
+                // lacks the trailing field, so the current decoder rejects it. Read it with the
+                // legacy layout (defaulting the hint to `None`) so a still-pending relay survives
+                // a client upgrade instead of being dropped as unreadable.
+                if let Ok(legacy) = Vec::<LegacyNoteInfo>::read_from_bytes(&bytes) {
+                    return Ok(legacy.into_iter().map(NoteInfo::from).collect());
+                }
                 tracing::warn!(?err, "dropping unreadable relay outbox; resetting to empty");
                 self.store
                     .remove_setting(String::from(NOTE_TRANSPORT_OUTBOX_KEY))
@@ -308,6 +317,12 @@ where
 
         let (note_infos, rcursor) =
             self.get_note_transport_api()?.fetch_notes(tags, cursor).await?;
+
+        // Steady-state polling fetches empty batches; skip the rest (including the sync-height
+        // read) so an empty tick does no extra store work.
+        if note_infos.is_empty() {
+            return Ok((Vec::new(), rcursor));
+        }
 
         let sync_height = self.get_sync_height().await?;
         // Always scan back at least NOTE_LOOKBACK_BLOCKS from the sync height. This handles the
@@ -463,6 +478,32 @@ impl Deserializable for NoteInfo {
     }
 }
 
+/// The pre-`after_block_num` on-disk layout of [`NoteInfo`] (header + details only). Used only to
+/// read relay-outbox blobs written by an earlier client version so a pending relay survives an
+/// upgrade; see [`Client::load_relay_outbox`].
+struct LegacyNoteInfo {
+    header: NoteHeader,
+    details_bytes: Vec<u8>,
+}
+
+impl Deserializable for LegacyNoteInfo {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let header = NoteHeader::read_from(source)?;
+        let details_bytes = Vec::<u8>::read_from(source)?;
+        Ok(LegacyNoteInfo { header, details_bytes })
+    }
+}
+
+impl From<LegacyNoteInfo> for NoteInfo {
+    fn from(legacy: LegacyNoteInfo) -> Self {
+        NoteInfo {
+            header: legacy.header,
+            details_bytes: legacy.details_bytes,
+            after_block_num: None,
+        }
+    }
+}
+
 impl Serializable for NoteTransportCursor {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         self.0.write_into(target);
@@ -488,4 +529,50 @@ fn rejoin_note(header: &NoteHeader, details_bytes: &[u8]) -> Result<Note, Deseri
         partial_metadata,
         details.recipient().clone(),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use miden_protocol::Felt;
+    use miden_protocol::crypto::rand::RandomCoin;
+    use miden_protocol::note::NoteType;
+    use miden_protocol::testing::account_id::ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE;
+    use miden_protocol::utils::serde::Deserializable;
+    use miden_standards::testing::note::NoteBuilder;
+
+    use super::*;
+
+    /// A relay-outbox blob written before `after_block_num` was added (header + details only) must
+    /// still be readable so a pending relay survives a client upgrade instead of being dropped.
+    #[test]
+    fn legacy_outbox_blob_is_recovered_with_no_hint() {
+        let account_id = ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE.try_into().unwrap();
+        let note = NoteBuilder::new(
+            account_id,
+            RandomCoin::new([1, 2, 3, 4].map(Felt::new_unchecked).into()),
+        )
+        .note_type(NoteType::Private)
+        .build()
+        .unwrap();
+        let header = *note.header();
+        let details_bytes = NoteDetails::from(note).to_bytes();
+
+        // The pre-`after_block_num` layout is header + details with the same `Vec` framing, which a
+        // `(NoteHeader, Vec<u8>)` tuple reproduces byte for byte.
+        let old_bytes = vec![(header, details_bytes.clone())].to_bytes();
+
+        // The current decoder rejects the missing trailing field...
+        assert!(Vec::<NoteInfo>::read_from_bytes(&old_bytes).is_err());
+
+        // ...but the legacy fallback reads it, defaulting the hint to `None`.
+        let recovered: Vec<NoteInfo> = Vec::<LegacyNoteInfo>::read_from_bytes(&old_bytes)
+            .unwrap()
+            .into_iter()
+            .map(NoteInfo::from)
+            .collect();
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].header.id(), header.id());
+        assert_eq!(recovered[0].details_bytes, details_bytes);
+        assert_eq!(recovered[0].after_block_num, None);
+    }
 }

--- a/crates/rust-client/src/note_transport/mod.rs
+++ b/crates/rust-client/src/note_transport/mod.rs
@@ -303,32 +303,40 @@ where
         cursor: NoteTransportCursor,
         tags: &[NoteTag],
     ) -> Result<(Vec<NoteId>, NoteTransportCursor), ClientError> {
-        // Number of blocks to look back from sync height when scanning for committed notes.
-        // Handles the race where a note is committed on-chain just before the NTL delivers
-        // its data — without this, check_expected_notes would scan from sync_height forward
-        // and miss the already-committed note.
+        // Number of blocks to look back from the sync height when scanning for committed notes.
         const NOTE_LOOKBACK_BLOCKS: u32 = 20;
 
-        let mut notes = Vec::new();
         let (note_infos, rcursor) =
             self.get_note_transport_api()?.fetch_notes(tags, cursor).await?;
+
+        let sync_height = self.get_sync_height().await?;
+        // Always scan back at least NOTE_LOOKBACK_BLOCKS from the sync height. This handles the
+        // race where a note is committed on-chain just before the NTL delivers its data —
+        // without it, the import scan would start at the sync height and miss the already-
+        // committed note. A sender-provided `after_block_num` can only lower this floor further
+        // (a note committed longer ago than the window), so the scanned range is always a
+        // superset of the lookback window: the hint extends coverage but never shrinks it.
+        let lookback_floor = sync_height.as_u32().saturating_sub(NOTE_LOOKBACK_BLOCKS);
+
+        let mut notes_with_floor = Vec::with_capacity(note_infos.len());
         for note_info in &note_infos {
             // e2ee impl hint:
             // for key in self.store.decryption_keys() try
             // key.decrypt(details_bytes_encrypted)
             let note = rejoin_note(&note_info.header, &note_info.details_bytes)?;
-            notes.push(note);
+            let after_block_num = note_info
+                .after_block_num
+                .map_or(lookback_floor, |hint| hint.as_u32().min(lookback_floor));
+            notes_with_floor.push((note, BlockNumber::from(after_block_num)));
         }
 
-        let sync_height = self.get_sync_height().await?;
-        let after_block_num =
-            BlockNumber::from(sync_height.as_u32().saturating_sub(NOTE_LOOKBACK_BLOCKS));
+        let id_by_commitment: BTreeMap<NoteDetailsCommitment, NoteId> = notes_with_floor
+            .iter()
+            .map(|(note, _)| (note.details_commitment(), note.id()))
+            .collect();
 
-        let id_by_commitment: BTreeMap<NoteDetailsCommitment, NoteId> =
-            notes.iter().map(|note| (note.details_commitment(), note.id())).collect();
-
-        let mut note_requests = Vec::with_capacity(notes.len());
-        for note in notes {
+        let mut note_requests = Vec::with_capacity(notes_with_floor.len());
+        for (note, after_block_num) in notes_with_floor {
             let tag = note.metadata().tag();
             let note_file = NoteFile::NoteDetails {
                 details: note.into(),

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -171,6 +171,14 @@ where
             tracing::warn!(?err, "relay outbox flush failed during sync; entries retained");
         }
 
+        // Re-scan still-`Expected` notes from a prior import in case the one-shot import scan
+        // missed their on-chain commitment (e.g. an incomplete `sync_notes` response). Like the
+        // relay flush, a failure here is logged rather than propagated: the recovery is
+        // best-effort and the next sync retries it, so it must not block the sync.
+        if let Err(err) = self.rescan_expected_notes().await {
+            tracing::warn!(?err, "expected-note rescan failed during sync; will retry next sync");
+        }
+
         let cursor = self.store.get_note_transport_cursor().await?;
         let note_tags: Vec<_> = self.store.get_unique_note_tags().await?.into_iter().collect();
         let (ids, new_cursor) = self.fetch_transport_notes(cursor, &note_tags).await?;

--- a/crates/rust-client/src/test_utils/mock.rs
+++ b/crates/rust-client/src/test_utils/mock.rs
@@ -59,6 +59,11 @@ pub struct MockRpcApi {
     /// notes without their attachment content (only metadata), so tests that need
     /// `get_notes_by_id` to return private-note attachments register them here.
     private_note_attachments: Arc<RwLock<BTreeMap<NoteId, NoteAttachments>>>,
+    /// Number of upcoming `sync_notes` calls to answer with an empty (but successful) response,
+    /// simulating a node that returns an incomplete scan result. Only `sync_notes` is affected
+    /// (used by `check_expected_notes`); `sync_notes_with_details` used by forward chain sync is
+    /// left intact.
+    sync_notes_drops: Arc<RwLock<usize>>,
 }
 
 impl Default for MockRpcApi {
@@ -79,7 +84,14 @@ impl MockRpcApi {
             oversize_threshold: 1000,
             erased_notes: Arc::new(RwLock::new(Vec::new())),
             private_note_attachments: Arc::new(RwLock::new(BTreeMap::new())),
+            sync_notes_drops: Arc::new(RwLock::new(0)),
         }
+    }
+
+    /// Makes the next `n` `sync_notes` calls return an empty (successful) response, simulating a
+    /// node that returns an incomplete scan result. Used to exercise the expected-note rescan.
+    pub fn drop_next_sync_notes(&self, n: usize) {
+        *self.sync_notes_drops.write() = n;
     }
 
     /// Registers the attachment content for a private note so that subsequent `get_notes_by_id`
@@ -329,6 +341,15 @@ impl NodeRpcClient for MockRpcApi {
         block_to: BlockNumber,
         note_tags: &BTreeSet<NoteTag>,
     ) -> Result<Vec<NoteSyncBlock>, RpcError> {
+        // Simulate an incomplete (but successful) scan response when configured to.
+        {
+            let mut drops = self.sync_notes_drops.write();
+            if *drops > 0 {
+                *drops -= 1;
+                return Ok(Vec::new());
+            }
+        }
+
         let mut blocks_with_notes: BTreeMap<BlockNumber, BTreeMap<NoteId, CommittedNote>> =
             BTreeMap::new();
         for note in self.mock_chain.read().committed_notes().values() {

--- a/crates/rust-client/src/test_utils/mock.rs
+++ b/crates/rust-client/src/test_utils/mock.rs
@@ -60,9 +60,10 @@ pub struct MockRpcApi {
     /// `get_notes_by_id` to return private-note attachments register them here.
     private_note_attachments: Arc<RwLock<BTreeMap<NoteId, NoteAttachments>>>,
     /// Number of upcoming `sync_notes` calls to answer with an empty (but successful) response,
-    /// simulating a node that returns an incomplete scan result. Only `sync_notes` is affected
-    /// (used by `check_expected_notes`); `sync_notes_with_details` used by forward chain sync is
-    /// left intact.
+    /// simulating a node that returns an incomplete scan result. The drop applies to the next `n`
+    /// `sync_notes` calls in execution order, regardless of caller — forward chain sync's
+    /// `sync_notes_with_details` also routes through `sync_notes`. A test must order its scenario
+    /// so the intended call (e.g. the import scan in `check_expected_notes`) is the first to run.
     sync_notes_drops: Arc<RwLock<usize>>,
 }
 
@@ -90,6 +91,8 @@ impl MockRpcApi {
 
     /// Makes the next `n` `sync_notes` calls return an empty (successful) response, simulating a
     /// node that returns an incomplete scan result. Used to exercise the expected-note rescan.
+    /// The count applies to `sync_notes` calls in execution order from any caller (including
+    /// forward chain sync via `sync_notes_with_details`); see the field docs.
     pub fn drop_next_sync_notes(&self, n: usize) {
         *self.sync_notes_drops.write() = n;
     }

--- a/crates/rust-client/src/test_utils/note_transport.rs
+++ b/crates/rust-client/src/test_utils/note_transport.rs
@@ -9,6 +9,7 @@ use core::task::{Context, Poll};
 
 use chrono::Utc;
 use futures::Stream;
+use miden_protocol::block::BlockNumber;
 use miden_protocol::note::{NoteHeader, NoteTag};
 use miden_tx::utils::serde::{
     ByteReader,
@@ -55,9 +56,14 @@ impl MockNoteTransportNode {
         }
     }
 
-    pub fn add_note(&mut self, header: NoteHeader, details_bytes: Vec<u8>) {
+    pub fn add_note(
+        &mut self,
+        header: NoteHeader,
+        details_bytes: Vec<u8>,
+        after_block_num: Option<BlockNumber>,
+    ) {
         let tag = header.metadata().tag();
-        let info = NoteInfo { header, details_bytes };
+        let info = NoteInfo { header, details_bytes, after_block_num };
         let cursor = u64::try_from(Utc::now().timestamp_micros()).unwrap();
         self.notes.entry(tag).or_default().push((info, cursor.into()));
     }
@@ -126,8 +132,13 @@ impl MockNoteTransportApi {
 }
 
 impl MockNoteTransportApi {
-    pub fn send_note(&self, header: NoteHeader, details_bytes: Vec<u8>) {
-        self.mock_node.write().add_note(header, details_bytes);
+    pub fn send_note(
+        &self,
+        header: NoteHeader,
+        details_bytes: Vec<u8>,
+        after_block_num: Option<BlockNumber>,
+    ) {
+        self.mock_node.write().add_note(header, details_bytes, after_block_num);
     }
 
     pub fn fetch_notes(
@@ -156,8 +167,9 @@ impl NoteTransportClient for MockNoteTransportApi {
         &self,
         header: NoteHeader,
         details: Vec<u8>,
+        after_block_num: Option<BlockNumber>,
     ) -> Result<(), NoteTransportError> {
-        self.send_note(header, details);
+        self.send_note(header, details, after_block_num);
         Ok(())
     }
 
@@ -230,6 +242,7 @@ impl NoteTransportClient for FaultyNoteTransportApi {
         &self,
         header: NoteHeader,
         details: Vec<u8>,
+        after_block_num: Option<BlockNumber>,
     ) -> Result<(), NoteTransportError> {
         self.send_attempts.fetch_add(1, Ordering::SeqCst);
         let should_fail = self
@@ -241,7 +254,7 @@ impl NoteTransportClient for FaultyNoteTransportApi {
                 "FaultyNoteTransportApi: simulated send_note failure".to_string(),
             ));
         }
-        self.inner.send_note(header, details);
+        self.inner.send_note(header, details, after_block_num);
         Ok(())
     }
 

--- a/crates/testing/miden-client-tests/src/tests/transport.rs
+++ b/crates/testing/miden-client-tests/src/tests/transport.rs
@@ -383,10 +383,10 @@ async fn commit_private_note_then_advance(extra_blocks: usize) -> (MockChain, No
     (mock_chain, private_note)
 }
 
-/// Builds a client over `mock_chain` + `mock_transport_node`, syncs it to the chain tip, and
+/// Builds a client over `rpc_api` + `mock_transport_node`, syncs it to the chain tip, and
 /// registers tag 0 so chain sync sees the note's block. The NTL is not drained here.
 async fn build_synced_ntl_client(
-    mock_chain: MockChain,
+    rpc_api: Arc<MockRpcApi>,
     mock_transport_node: Arc<RwLock<MockNoteTransportNode>>,
 ) -> MockClient<FilesystemKeyStore> {
     let transport_client = MockNoteTransportApi::new(mock_transport_node);
@@ -398,7 +398,7 @@ async fn build_synced_ntl_client(
     let keystore = FilesystemKeyStore::new(temp_dir()).unwrap();
 
     let builder: ClientBuilder<FilesystemKeyStore> = ClientBuilder::new()
-        .rpc(Arc::new(MockRpcApi::new(mock_chain)))
+        .rpc(rpc_api)
         .rng(Box::new(rng))
         .sqlite_store(create_test_store_path())
         .authenticator(Arc::new(keystore))
@@ -421,7 +421,9 @@ async fn build_synced_ntl_client(
 async fn after_block_num_hint_commits_note_beyond_lookback() {
     let (mock_chain, private_note) = commit_private_note_then_advance(30).await;
     let mock_transport_node = Arc::new(RwLock::new(MockNoteTransportNode::new()));
-    let mut client = build_synced_ntl_client(mock_chain, mock_transport_node.clone()).await;
+    let mut client =
+        build_synced_ntl_client(Arc::new(MockRpcApi::new(mock_chain)), mock_transport_node.clone())
+            .await;
 
     let sync_height = client.get_sync_height().await.unwrap();
     assert!(
@@ -454,7 +456,9 @@ async fn after_block_num_hint_commits_note_beyond_lookback() {
 async fn without_hint_note_beyond_lookback_stays_expected() {
     let (mock_chain, private_note) = commit_private_note_then_advance(30).await;
     let mock_transport_node = Arc::new(RwLock::new(MockNoteTransportNode::new()));
-    let mut client = build_synced_ntl_client(mock_chain, mock_transport_node.clone()).await;
+    let mut client =
+        build_synced_ntl_client(Arc::new(MockRpcApi::new(mock_chain)), mock_transport_node.clone())
+            .await;
 
     let details_bytes = NoteDetails::from(private_note.clone()).to_bytes();
     mock_transport_node.write().add_note(*private_note.header(), details_bytes, None);
@@ -472,6 +476,45 @@ async fn without_hint_note_beyond_lookback_stays_expected() {
     assert!(
         expected.iter().any(|n| n.details_commitment() == note_details_commitment),
         "the note should remain Expected (imported but not yet observed on-chain)"
+    );
+}
+
+/// The one-shot import scan can miss a note's on-chain commitment when the node returns an
+/// incomplete (but successful) `sync_notes` response. Forward chain sync only revisits blocks
+/// ahead of the last sync height, so without a retry the note would stay `Expected` forever. A
+/// subsequent sync re-scans still-`Expected` notes from their stored floor and recovers it.
+#[tokio::test]
+async fn expected_note_rescan_recovers_from_incomplete_import_scan() {
+    // The note is committed within the lookback window, so the only thing keeping it from
+    // committing on import is the dropped scan — not the scan floor.
+    let (mock_chain, private_note) = commit_private_note_then_advance(3).await;
+    let mock_transport_node = Arc::new(RwLock::new(MockNoteTransportNode::new()));
+    let rpc_api = Arc::new(MockRpcApi::new(mock_chain));
+    let mut client = build_synced_ntl_client(rpc_api.clone(), mock_transport_node.clone()).await;
+
+    // The import-time scan (check_expected_notes -> sync_notes) returns an incomplete response.
+    rpc_api.drop_next_sync_notes(1);
+
+    let details_bytes = NoteDetails::from(private_note.clone()).to_bytes();
+    mock_transport_node.write().add_note(*private_note.header(), details_bytes, None);
+
+    let note_details_commitment = NoteDetails::from(private_note.clone()).commitment();
+
+    // First sync imports the note, but the dropped scan leaves it Expected.
+    client.sync_state().await.unwrap();
+    let committed = client.get_input_notes(NoteFilter::Committed).await.unwrap();
+    assert!(
+        !committed.iter().any(|n| n.details_commitment() == note_details_commitment),
+        "an incomplete import scan should leave the note Expected"
+    );
+
+    // Second sync: the rescan re-checks the still-Expected note, and the now-complete scan
+    // commits it.
+    client.sync_state().await.unwrap();
+    let committed = client.get_input_notes(NoteFilter::Committed).await.unwrap();
+    assert!(
+        committed.iter().any(|n| n.details_commitment() == note_details_commitment),
+        "a subsequent sync should rescan the Expected note and commit it"
     );
 }
 

--- a/crates/testing/miden-client-tests/src/tests/transport.rs
+++ b/crates/testing/miden-client-tests/src/tests/transport.rs
@@ -8,7 +8,11 @@ use miden_client::auth::RPO_FALCON_SCHEME_ID;
 use miden_client::builder::ClientBuilder;
 use miden_client::keystore::FilesystemKeyStore;
 use miden_client::note::{Note, NoteAttachments, NoteDetails, NoteTag, NoteType};
-use miden_client::note_transport::{NoteTransportClient, NoteTransportCursor};
+use miden_client::note_transport::{
+    NOTE_TRANSPORT_OUTBOX_KEY,
+    NoteTransportClient,
+    NoteTransportCursor,
+};
 use miden_client::store::NoteFilter;
 use miden_client::testing::common::create_test_store_path;
 use miden_client::testing::mock::{MockClient, MockRpcApi};
@@ -25,6 +29,7 @@ use miden_protocol::asset::FungibleAsset;
 use miden_protocol::block::BlockNumber;
 use miden_protocol::crypto::rand::RandomCoin;
 use miden_protocol::note::NoteType as ProtocolNoteType;
+use miden_protocol::testing::account_id::ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE;
 use miden_protocol::transaction::RawOutputNote;
 use miden_protocol::utils::serde::Serializable;
 use miden_standards::note::P2idNote;
@@ -499,7 +504,9 @@ async fn expected_note_rescan_recovers_from_incomplete_import_scan() {
     let rpc_api = Arc::new(MockRpcApi::new(mock_chain));
     let mut client = build_synced_ntl_client(rpc_api.clone(), mock_transport_node.clone()).await;
 
-    // The import-time scan (check_expected_notes -> sync_notes) returns an incomplete response.
+    // Drop the next sync_notes call. On the first sync, rescan_expected_notes finds no Expected
+    // notes yet and early-returns without scanning, so the import scan (check_expected_notes ->
+    // sync_notes) is the first sync_notes call and gets the incomplete (empty) response.
     rpc_api.drop_next_sync_notes(1);
 
     let details_bytes = NoteDetails::from(private_note.clone()).to_bytes();
@@ -575,6 +582,44 @@ async fn send_private_note_relays_output_note_expected_height() {
         entry.after_block_num,
         Some(expected_height),
         "sender should relay the output note's expected_height as the after_block_num hint"
+    );
+}
+
+/// A relay-outbox blob written by a pre-`after_block_num` client (header + details only) is read
+/// via the legacy decoder and re-sent on the next flush, rather than dropped as unreadable — so a
+/// pending relay survives a client upgrade. Drives the `load_relay_outbox` migration path end to
+/// end (the unit test only covers the decoders in isolation).
+#[tokio::test]
+async fn legacy_relay_outbox_blob_survives_upgrade() {
+    let mock_node = Arc::new(RwLock::new(MockNoteTransportNode::new()));
+    let (mut client, _keystore) = create_test_client_transport(mock_node.clone()).await;
+
+    // Persist an outbox entry in the pre-`after_block_num` layout: header + details with the same
+    // Vec framing, which a (NoteHeader, Vec<u8>) tuple reproduces byte for byte.
+    let account_id = ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE.try_into().unwrap();
+    let note =
+        NoteBuilder::new(account_id, RandomCoin::new([9, 9, 9, 9].map(Felt::new_unchecked).into()))
+            .note_type(ProtocolNoteType::Private)
+            .build()
+            .unwrap();
+    let header = *note.header();
+    let details_bytes = NoteDetails::from(note).to_bytes();
+    let legacy_bytes = vec![(header, details_bytes)].to_bytes();
+    client
+        .test_store()
+        .set_setting(NOTE_TRANSPORT_OUTBOX_KEY.to_string(), legacy_bytes)
+        .await
+        .unwrap();
+
+    // Flushing must read the legacy entry and re-send it to the NTL, not drop it.
+    client.flush_relay_outbox().await.unwrap();
+
+    let (relayed, _) = mock_node
+        .read()
+        .get_notes(&[header.metadata().tag()], NoteTransportCursor::init());
+    assert!(
+        relayed.iter().any(|info| info.header.id() == header.id()),
+        "a legacy outbox entry must be loaded and re-sent, not dropped as unreadable"
     );
 }
 

--- a/crates/testing/miden-client-tests/src/tests/transport.rs
+++ b/crates/testing/miden-client-tests/src/tests/transport.rs
@@ -4,10 +4,11 @@ use std::sync::Arc;
 use miden_client::DebugMode;
 use miden_client::account::{Account, AccountType};
 use miden_client::address::{Address, AddressInterface, RoutingParameters};
+use miden_client::auth::RPO_FALCON_SCHEME_ID;
 use miden_client::builder::ClientBuilder;
 use miden_client::keystore::FilesystemKeyStore;
 use miden_client::note::{Note, NoteAttachments, NoteDetails, NoteTag, NoteType};
-use miden_client::note_transport::NoteTransportClient;
+use miden_client::note_transport::{NoteTransportClient, NoteTransportCursor};
 use miden_client::store::NoteFilter;
 use miden_client::testing::common::create_test_store_path;
 use miden_client::testing::mock::{MockClient, MockRpcApi};
@@ -16,9 +17,11 @@ use miden_client::testing::note_transport::{
     MockNoteTransportApi,
     MockNoteTransportNode,
 };
+use miden_client::transaction::TransactionRequestBuilder;
 use miden_client::utils::RwLock;
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use miden_protocol::Felt;
+use miden_protocol::asset::FungibleAsset;
 use miden_protocol::block::BlockNumber;
 use miden_protocol::crypto::rand::RandomCoin;
 use miden_protocol::note::NoteType as ProtocolNoteType;
@@ -29,7 +32,7 @@ use miden_standards::testing::note::NoteBuilder;
 use miden_testing::{MockChain, MockChainBuilder, TxContextInput};
 use rand::Rng;
 
-use crate::tests::{create_test_client_builder, insert_new_wallet};
+use crate::tests::{create_test_client_builder, insert_new_wallet, setup_wallet_and_faucet};
 
 #[tokio::test]
 async fn transport_basic() {
@@ -320,7 +323,9 @@ async fn fetch_private_notes_finds_note_committed_at_sync_height() {
     let details = NoteDetails::from(private_note.clone());
     let details_bytes = details.to_bytes();
     // No after_block_num hint, so the receiver must fall back to its lookback window.
-    mock_transport_node.write().add_note(*private_note.header(), details_bytes, None);
+    mock_transport_node
+        .write()
+        .add_note(*private_note.header(), details_bytes, None);
 
     // 6. Second sync_state: fetch_transport_notes imports the note, then chain sync runs.
     // Without the fix, after_block_num = sync_height, scan misses the note at block 1.
@@ -461,7 +466,9 @@ async fn without_hint_note_beyond_lookback_stays_expected() {
             .await;
 
     let details_bytes = NoteDetails::from(private_note.clone()).to_bytes();
-    mock_transport_node.write().add_note(*private_note.header(), details_bytes, None);
+    mock_transport_node
+        .write()
+        .add_note(*private_note.header(), details_bytes, None);
 
     client.sync_state().await.unwrap();
 
@@ -496,7 +503,9 @@ async fn expected_note_rescan_recovers_from_incomplete_import_scan() {
     rpc_api.drop_next_sync_notes(1);
 
     let details_bytes = NoteDetails::from(private_note.clone()).to_bytes();
-    mock_transport_node.write().add_note(*private_note.header(), details_bytes, None);
+    mock_transport_node
+        .write()
+        .add_note(*private_note.header(), details_bytes, None);
 
     let note_details_commitment = NoteDetails::from(private_note.clone()).commitment();
 
@@ -515,6 +524,57 @@ async fn expected_note_rescan_recovers_from_incomplete_import_scan() {
     assert!(
         committed.iter().any(|n| n.details_commitment() == note_details_commitment),
         "a subsequent sync should rescan the Expected note and commit it"
+    );
+}
+
+/// Exercises the real sender path: a note created by the client's own transaction is relayed via
+/// `send_private_note`, and the relayed `after_block_num` equals the note's stored
+/// `expected_height` (a safe lower bound on its commitment block). Guards against the sender
+/// silently relaying no hint, which would reintroduce the lost-note bug for notes committed more
+/// than the lookback window before delivery.
+#[tokio::test]
+async fn send_private_note_relays_output_note_expected_height() {
+    let mock_node = Arc::new(RwLock::new(MockNoteTransportNode::new()));
+    let (mut client, keystore) = create_test_client_transport(mock_node.clone()).await;
+    let (wallet, faucet) =
+        setup_wallet_and_faucet(&mut client, AccountType::Private, &keystore, RPO_FALCON_SCHEME_ID)
+            .await
+            .unwrap();
+
+    // Mint a private note from the faucet to the wallet. This records an output note with
+    // expected_height = the transaction's submission height.
+    let asset = FungibleAsset::new(faucet.id(), 100).unwrap();
+    let tx_request = TransactionRequestBuilder::new()
+        .build_mint_fungible_asset(asset, wallet.id(), NoteType::Private, client.rng())
+        .unwrap();
+    let note = tx_request.expected_output_own_notes().first().unwrap().clone();
+    Box::pin(client.submit_new_transaction(faucet.id(), tx_request)).await.unwrap();
+
+    let expected_height = client
+        .get_output_notes(NoteFilter::List(vec![note.id()]))
+        .await
+        .unwrap()
+        .first()
+        .unwrap()
+        .expected_height();
+
+    // Relay the note. The recipient address is irrelevant to the hint.
+    let address = Address::new(wallet.id())
+        .with_routing_parameters(RoutingParameters::new(AddressInterface::BasicWallet));
+    client.send_private_note(note.clone(), &address).await.unwrap();
+
+    // The NTL should have stored the note with after_block_num = the note's expected_height.
+    let (relayed, _) = mock_node
+        .read()
+        .get_notes(&[note.metadata().tag()], NoteTransportCursor::init());
+    let entry = relayed
+        .iter()
+        .find(|info| info.header.id() == note.id())
+        .expect("relayed note should be present in the NTL");
+    assert_eq!(
+        entry.after_block_num,
+        Some(expected_height),
+        "sender should relay the output note's expected_height as the after_block_num hint"
     );
 }
 

--- a/crates/testing/miden-client-tests/src/tests/transport.rs
+++ b/crates/testing/miden-client-tests/src/tests/transport.rs
@@ -6,7 +6,7 @@ use miden_client::account::{Account, AccountType};
 use miden_client::address::{Address, AddressInterface, RoutingParameters};
 use miden_client::builder::ClientBuilder;
 use miden_client::keystore::FilesystemKeyStore;
-use miden_client::note::{NoteAttachments, NoteDetails, NoteTag, NoteType};
+use miden_client::note::{Note, NoteAttachments, NoteDetails, NoteTag, NoteType};
 use miden_client::note_transport::NoteTransportClient;
 use miden_client::store::NoteFilter;
 use miden_client::testing::common::create_test_store_path;
@@ -19,13 +19,14 @@ use miden_client::testing::note_transport::{
 use miden_client::utils::RwLock;
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use miden_protocol::Felt;
+use miden_protocol::block::BlockNumber;
 use miden_protocol::crypto::rand::RandomCoin;
 use miden_protocol::note::NoteType as ProtocolNoteType;
 use miden_protocol::transaction::RawOutputNote;
 use miden_protocol::utils::serde::Serializable;
 use miden_standards::note::P2idNote;
 use miden_standards::testing::note::NoteBuilder;
-use miden_testing::{MockChainBuilder, TxContextInput};
+use miden_testing::{MockChain, MockChainBuilder, TxContextInput};
 use rand::Rng;
 
 use crate::tests::{create_test_client_builder, insert_new_wallet};
@@ -335,6 +336,142 @@ async fn fetch_private_notes_finds_note_committed_at_sync_height() {
     assert!(
         committed_notes.iter().any(|n| n.id() == Some(private_note.id())),
         "note committed before sync_height should be found via lookback during NTL import"
+    );
+}
+
+/// Builds a mock chain that commits a private note (tag 0) near genesis, then proves
+/// `extra_blocks` further blocks so the note's commitment sits that far behind the chain tip.
+/// Returns the built chain and the committed note.
+async fn commit_private_note_then_advance(extra_blocks: usize) -> (MockChain, Note) {
+    let mut mock_chain_builder = MockChainBuilder::new();
+    let mock_account = mock_chain_builder
+        .add_existing_mock_account(miden_testing::Auth::IncrNonce)
+        .unwrap();
+
+    let private_note = NoteBuilder::new(
+        mock_account.id(),
+        RandomCoin::new([1, 2, 3, 4].map(Felt::new_unchecked).into()),
+    )
+    .note_type(ProtocolNoteType::Private)
+    .tag(NoteTag::new(0).into())
+    .build()
+    .unwrap();
+
+    let spawn_note =
+        mock_chain_builder.add_spawn_note(std::slice::from_ref(&private_note)).unwrap();
+    let mut mock_chain = mock_chain_builder.build().unwrap();
+
+    // Commit the private note.
+    let tx = Box::pin(
+        mock_chain
+            .build_tx_context(TxContextInput::AccountId(mock_account.id()), &[], &[spawn_note])
+            .unwrap()
+            .extend_expected_output_notes(vec![RawOutputNote::Full(private_note.clone())])
+            .build()
+            .unwrap()
+            .execute(),
+    )
+    .await
+    .unwrap();
+    mock_chain.add_pending_executed_transaction(&tx).unwrap();
+    mock_chain.prove_next_block().unwrap();
+
+    for _ in 0..extra_blocks {
+        mock_chain.prove_next_block().unwrap();
+    }
+
+    (mock_chain, private_note)
+}
+
+/// Builds a client over `mock_chain` + `mock_transport_node`, syncs it to the chain tip, and
+/// registers tag 0 so chain sync sees the note's block. The NTL is not drained here.
+async fn build_synced_ntl_client(
+    mock_chain: MockChain,
+    mock_transport_node: Arc<RwLock<MockNoteTransportNode>>,
+) -> MockClient<FilesystemKeyStore> {
+    let transport_client = MockNoteTransportApi::new(mock_transport_node);
+
+    let mut rng = rand::rng();
+    let coin_seed: [u64; 4] = rng.random();
+    let rng = RandomCoin::new(coin_seed.map(|v| Felt::new_unchecked(v >> 1)).into());
+
+    let keystore = FilesystemKeyStore::new(temp_dir()).unwrap();
+
+    let builder: ClientBuilder<FilesystemKeyStore> = ClientBuilder::new()
+        .rpc(Arc::new(MockRpcApi::new(mock_chain)))
+        .rng(Box::new(rng))
+        .sqlite_store(create_test_store_path())
+        .authenticator(Arc::new(keystore))
+        .in_debug_mode(DebugMode::Enabled)
+        .tx_discard_delta(None)
+        .note_transport(Arc::new(transport_client));
+
+    let mut client = builder.build().await.unwrap();
+    client.ensure_genesis_in_place().await.unwrap();
+    client.add_note_tag(NoteTag::new(0)).await.unwrap();
+    client.sync_state().await.unwrap();
+    client
+}
+
+/// A note whose commitment sits more than the lookback window (20 blocks) behind the
+/// recipient's sync height is missed by the lookback alone. The sender-provided
+/// `after_block_num` hint lowers the scan floor to (at or below) the commitment block so the
+/// note still commits on import.
+#[tokio::test]
+async fn after_block_num_hint_commits_note_beyond_lookback() {
+    let (mock_chain, private_note) = commit_private_note_then_advance(30).await;
+    let mock_transport_node = Arc::new(RwLock::new(MockNoteTransportNode::new()));
+    let mut client = build_synced_ntl_client(mock_chain, mock_transport_node.clone()).await;
+
+    let sync_height = client.get_sync_height().await.unwrap();
+    assert!(
+        sync_height.as_u32() > 21,
+        "note must sit more than the lookback window behind the tip"
+    );
+
+    // Deliver the note with a hint at genesis — a valid lower bound on its commitment block.
+    let details_bytes = NoteDetails::from(private_note.clone()).to_bytes();
+    mock_transport_node.write().add_note(
+        *private_note.header(),
+        details_bytes,
+        Some(BlockNumber::from(0)),
+    );
+
+    client.sync_state().await.unwrap();
+
+    let note_details_commitment = NoteDetails::from(private_note.clone()).commitment();
+    let committed = client.get_input_notes(NoteFilter::Committed).await.unwrap();
+    assert!(
+        committed.iter().any(|n| n.details_commitment() == note_details_commitment),
+        "the after_block_num hint should lower the scan floor so a note beyond the lookback \
+         window still commits on import"
+    );
+}
+
+/// Control for [`after_block_num_hint_commits_note_beyond_lookback`]: without the hint the same
+/// note stays `Expected`, proving the hint — not the lookback — is what commits it.
+#[tokio::test]
+async fn without_hint_note_beyond_lookback_stays_expected() {
+    let (mock_chain, private_note) = commit_private_note_then_advance(30).await;
+    let mock_transport_node = Arc::new(RwLock::new(MockNoteTransportNode::new()));
+    let mut client = build_synced_ntl_client(mock_chain, mock_transport_node.clone()).await;
+
+    let details_bytes = NoteDetails::from(private_note.clone()).to_bytes();
+    mock_transport_node.write().add_note(*private_note.header(), details_bytes, None);
+
+    client.sync_state().await.unwrap();
+
+    // Expected notes carry no metadata and thus no NoteId, so match by details commitment.
+    let note_details_commitment = NoteDetails::from(private_note.clone()).commitment();
+    let committed = client.get_input_notes(NoteFilter::Committed).await.unwrap();
+    assert!(
+        !committed.iter().any(|n| n.details_commitment() == note_details_commitment),
+        "without a hint, a note beyond the lookback window must not commit on import"
+    );
+    let expected = client.get_input_notes(NoteFilter::Expected).await.unwrap();
+    assert!(
+        expected.iter().any(|n| n.details_commitment() == note_details_commitment),
+        "the note should remain Expected (imported but not yet observed on-chain)"
     );
 }
 

--- a/crates/testing/miden-client-tests/src/tests/transport.rs
+++ b/crates/testing/miden-client-tests/src/tests/transport.rs
@@ -318,7 +318,8 @@ async fn fetch_private_notes_finds_note_committed_at_sync_height() {
     // 5. Now the NTL delivers the note (simulates late delivery after the first sync).
     let details = NoteDetails::from(private_note.clone());
     let details_bytes = details.to_bytes();
-    mock_transport_node.write().add_note(*private_note.header(), details_bytes);
+    // No after_block_num hint, so the receiver must fall back to its lookback window.
+    mock_transport_node.write().add_note(*private_note.header(), details_bytes, None);
 
     // 6. Second sync_state: fetch_transport_notes imports the note, then chain sync runs.
     // Without the fix, after_block_num = sync_height, scan misses the note at block 1.


### PR DESCRIPTION
## Problem

A private note delivered via the Note Transport Layer (NTL) is silently lost when its on-chain commitment lands more than the 20-block lookback window before the NTL delivers the note. The import scan runs once over `[sync_height − 20, sync_height]`, and regular chain sync only scans *forward*, so a note committed further back is never found and stays `Expected` forever.

This is the client-side companion to `0xMiden/note-transport-service#81`, which added `optional uint32 after_block_num = 3` to the `TransportNote` proto — a sender-provided lower bound on the block at which the note's commitment landed. Closes #2108.

## Solution

- **Proto** — bump `miden-note-transport-proto-build` 0.4 → **0.4.1** (the published crate that carries `after_block_num`). No note-transport-service change required.
- **Plumbing** — thread `after_block_num: Option<BlockNumber>` through `NoteInfo`, `NoteTransportClient::send_note`, the gRPC client, and the mock transports.
- **Sender** — `send_private_note` populates the hint from the note's output-record `expected_height` (the transaction's submission height). The creating transaction cannot commit before it was submitted, so this is a **guaranteed lower bound ≤ the commitment block** — a too-high hint can never make delivery worse.
- **Receiver** — the import scan floor becomes `min(after_block_num, sync_height − 20)`. This is always a **superset** of today's lookback window, so it never scans *less*; a precise hint covers the exact commitment block.
- **Retry** — `sync_note_transport` re-scans still-`Expected` notes from their stored floor each sync (bounded to 256 blocks behind the tip), recovering a note whose commitment a one-shot import scan missed because the node returned an incomplete `sync_notes` response.

## Breaking

- `NoteTransportClient::send_note` takes an additional `after_block_num: Option<BlockNumber>` argument, and `NoteInfo` carries a matching field. Relay-outbox blobs written by an earlier version are read via a legacy decoder (hint defaulted to `None`), so a pending relay survives the upgrade instead of being dropped.

## Testing

- TDD for each behavioral change. New tests: receiver clamp commits a note >20 blocks behind the tip (+ control that it stays `Expected` without the hint), the rescan recovers a note dropped by an incomplete import scan (via a new `MockRpcApi` `sync_notes`-drop fault), the real sender mint→relay path relays `expected_height`, and a pre-`after_block_num` outbox blob is recovered.
- Verified locally: `make format`, clippy, wasm32 no_std build, taplo, typos, rustdoc `-D warnings`, and the transport / note_transport / sync test modules.

## Reviews

Reviewed by an internal reviewer agent and an independent Codex pass before opening; all actionable findings applied (notably: graceful legacy-outbox decoding to avoid dropping pending relays, and bounding the rescan range so a never-committing `Expected` note can't grow the scan unbounded).
