### PR TITLE
Reject empty RPC endpoint parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* [FIX][rust] RPC endpoint parsing now rejects endpoint strings that omit either the protocol or host. ([#2266](https://github.com/0xMiden/miden-client/pull/2266))
 * [FIX][rust] State sync now range-checks `sync_transactions` records to `(current, chain_tip]`, rejecting out-of-range records that could forge transaction commit heights ([#2252](https://github.com/0xMiden/rust-sdk/pull/2252)).
 * [FIX][rust] `Endpoint` parsing now strips a trailing slash from the host of no-port endpoints such as `http://host/`, matching the cleanup already applied when a port is present ([#2268](https://github.com/0xMiden/rust-sdk/pull/2268)).
 * [FIX][rust] `NodeRpcClient::get_block_header_by_number` and `get_block_by_number` now reject responses whose block number does not match the requested one with `RpcError::InvalidResponse` ([#2270](https://github.com/0xMiden/rust-sdk/pull/2270)).

--- a/crates/rust-client/src/rpc/endpoint.rs
+++ b/crates/rust-client/src/rpc/endpoint.rs
@@ -141,6 +141,14 @@ impl TryFrom<&str> for Endpoint {
 
         let hostname = hostname.trim_end_matches('/');
 
+        if protocol.is_empty() {
+            return Err("endpoint protocol cannot be empty".to_string());
+        }
+
+        if hostname.is_empty() {
+            return Err("endpoint host cannot be empty".to_string());
+        }
+
         Ok(Endpoint::new(protocol.to_string(), hostname.to_string(), port))
     }
 }
@@ -250,6 +258,18 @@ mod test {
     #[test]
     fn endpoint_parsing_should_fail_for_invalid_port() {
         let endpoint = Endpoint::try_from("some.test.domain:8000/hello");
+        assert!(endpoint.is_err());
+    }
+
+    #[test]
+    fn endpoint_parsing_should_fail_for_empty_protocol() {
+        let endpoint = Endpoint::try_from("://some.test.domain:8000");
+        assert!(endpoint.is_err());
+    }
+
+    #[test]
+    fn endpoint_parsing_should_fail_for_empty_host() {
+        let endpoint = Endpoint::try_from("https://:8000");
         assert!(endpoint.is_err());
     }
 


### PR DESCRIPTION
Endpoint parsing currently accepts empty protocol or host components, such as `://host:8000` or `https://:8000`, and builds an `Endpoint` with an empty field.

This adds explicit validation for both parts so malformed RPC endpoints fail early with a clear error.