### PR TITLE
fix(rust-client): strip trailing slash from no-port endpoint host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 * [FIX][rust] State sync now range-checks `sync_transactions` records to `(current, chain_tip]`, rejecting out-of-range records that could forge transaction commit heights ([#2252](https://github.com/0xMiden/miden-client/pull/2252)).
-* [FIX][rust] `Endpoint` parsing now strips a trailing slash from the host of no-port endpoints such as `http://host/`, matching the cleanup already applied when a port is present ([#XXXX](https://github.com/0xMiden/miden-client/pull/XXXX)).
+* [FIX][rust] `Endpoint` parsing now strips a trailing slash from the host of no-port endpoints such as `http://host/`, matching the cleanup already applied when a port is present ([#2268](https://github.com/0xMiden/miden-client/pull/2268)).
 
 ## 0.15.0 (2026-06-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 * [FIX][rust] State sync now range-checks `sync_transactions` records to `(current, chain_tip]`, rejecting out-of-range records that could forge transaction commit heights ([#2252](https://github.com/0xMiden/miden-client/pull/2252)).
+* [FIX][rust] `Endpoint` parsing now strips a trailing slash from the host of no-port endpoints such as `http://host/`, matching the cleanup already applied when a port is present ([#XXXX](https://github.com/0xMiden/miden-client/pull/XXXX)).
 
 ## 0.15.0 (2026-06-12)
 

--- a/crates/rust-client/src/rpc/endpoint.rs
+++ b/crates/rust-client/src/rpc/endpoint.rs
@@ -139,6 +139,8 @@ impl TryFrom<&str> for Endpoint {
             (None, None) => ("https", endpoint, None),
         };
 
+        let hostname = hostname.trim_end_matches('/');
+
         Ok(Endpoint::new(protocol.to_string(), hostname.to_string(), port))
     }
 }
@@ -258,6 +260,18 @@ mod test {
             protocol: "https".to_string(),
             host: "some.test.domain".to_string(),
             port: Some(8000),
+        };
+
+        assert_eq!(endpoint, expected_endpoint);
+    }
+
+    #[test]
+    fn endpoint_parsing_with_protocol_and_final_forward_slash_no_port() {
+        let endpoint = Endpoint::try_from("http://some.test.domain/").unwrap();
+        let expected_endpoint = Endpoint {
+            protocol: "http".to_string(),
+            host: "some.test.domain".to_string(),
+            port: None,
         };
 
         assert_eq!(endpoint, expected_endpoint);


### PR DESCRIPTION
Changes endpoint parsing so that Endpoint string without port number is parsed as an endpoint which host name doesn't include the final slash. For example, the parser converts `http://host/` to the host name `host` and not `host/`.