### PR TITLE
chore: prepare 0.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.15.3 (2026-06-29)
+
 ### Fixes
 
 * [FIX][rust] RPC endpoint parsing now rejects endpoint strings that omit either the protocol or host. ([#2266](https://github.com/0xMiden/miden-client/pull/2266))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-bench"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-cli"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-integration-tests"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2162,7 +2162,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-sqlite-store"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2180,7 +2180,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-unit-tests"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "miden-client",
  "miden-client-sqlite-store",
@@ -4533,7 +4533,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-node-genesis"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "miden-agglayer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ edition      = "2024"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/rust-sdk"
 rust-version = "1.93"
-version      = "0.15.2"
+version      = "0.15.3"
 
 [profile.dev]
 codegen-units = 16
@@ -30,8 +30,8 @@ opt-level = 1
 
 [workspace.dependencies]
 # Workspace crates
-miden-client              = { default-features = false, path = "crates/rust-client", version = "0.15.2" }
-miden-client-sqlite-store = { default-features = false, path = "crates/sqlite-store", version = "0.15.2" }
+miden-client              = { default-features = false, path = "crates/rust-client", version = "0.15.3" }
+miden-client-sqlite-store = { default-features = false, path = "crates/sqlite-store", version = "0.15.3" }
 
 # Miden protocol dependencies
 miden-agglayer        = { default-features = false, version = "0.15.3" }


### PR DESCRIPTION
## What

Patch release of the Rust SDK: bumps `miden-client` / `miden-client-sqlite-store` (and the workspace) from **0.15.2 → 0.15.3**.

## Why

`gateway-fm/miden-agglayer` shipped **v0.15.1** ("Miden 0.15.x migration"), which documents the validated 0.15.x base-crate matrix (`miden-protocol`/`miden-standards`/`miden-tx`/`miden-agglayer` = `0.15.3`). `next` already carries those `0.15.3` base crates, so this just cuts the version so a published **`miden-client 0.15.3`** exists for the **web-sdk** to consume (the web-sdk bump is the follow-up PR).

It also ships the accumulated `Unreleased` fixes (RPC-response validation hardening, endpoint parsing, public/private account sync binding) under the `0.15.3` heading.

## Changes

- `Cargo.toml`: workspace `version` and the two workspace-crate `version` pins `0.15.2 → 0.15.3`
- `Cargo.lock`: all seven workspace members re-pinned to `0.15.3`
- `CHANGELOG.md`: rolled `## Unreleased` into `## 0.15.3 (2026-06-29)`

No code changes; base protocol crates unchanged (already `0.15.3`). `cargo metadata --locked` passes.