### PR TITLE
feat(rust-client): Make gRPC response size configurable and increase default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Enhancements
 
 * [FEATURE][cli] `miden-cli call` now accepts advice map entries supplied via `--inputs-path/-i <FILE.toml>` in the same TOML format as `exec` ([#2244](https://github.com/0xMiden/miden-client/pull/2244)).
-* [FEATURE][rust] The gRPC client now accepts responses up to 15% above the node's 4 MiB payload budget by default, and `GrpcClient::with_max_decoding_message_size` lets callers raise the decode ceiling further. This prevents syncs from failing with a "decoded message length too large" error when a node response slightly exceeds the previous hard 4 MiB limit ([#2298](https://github.com/0xMiden/miden-client/issues/2298)).
+* [FEATURE][rust] The gRPC client now accepts responses up to 15% above the node's 4 MiB payload budget by default, and `GrpcClient::with_max_decoding_message_size` lets callers raise the decode ceiling further. This prevents syncs from failing with a "decoded message length too large" error when a node response slightly exceeds the previous hard 4 MiB limit ([#2298](https://github.com/0xMiden/miden-client/pull/2299)).
 
 ## 0.15.2 (2026-06-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Enhancements
 
 * [FEATURE][cli] `miden-cli call` now accepts advice map entries supplied via `--inputs-path/-i <FILE.toml>` in the same TOML format as `exec` ([#2244](https://github.com/0xMiden/miden-client/pull/2244)).
-* [FEATURE][rust] The gRPC client now accepts responses up to 15% above the node's 4 MiB payload budget by default, and `GrpcClient::with_max_decoding_message_size` lets callers raise the decode ceiling further. This prevents syncs from failing with a "decoded message length too large" error when a node response slightly exceeds the previous hard 4 MiB limit ([#2298](https://github.com/0xMiden/miden-client/pull/2299)).
+* [FEATURE][rust] The gRPC client now accepts responses up to 15% above the node's 4 MiB payload budget by default, and `GrpcClient::with_max_decoding_message_size` lets callers raise the decode ceiling further. The CLI raises its own ceiling to 6 MiB to cover large `SyncTransactions` responses. This prevents syncs from failing with a "decoded message length too large" error when a node response slightly exceeds the previous hard 4 MiB limit ([#2298](https://github.com/0xMiden/miden-client/pull/2299)).
 
 ## 0.15.2 (2026-06-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Enhancements
 
 * [FEATURE][cli] `miden-cli call` now accepts advice map entries supplied via `--inputs-path/-i <FILE.toml>` in the same TOML format as `exec` ([#2244](https://github.com/0xMiden/miden-client/pull/2244)).
-* [FEATURE][rust] The gRPC client now accepts responses up to 15% above the node's 4 MiB payload budget by default, and `GrpcClient::with_max_message_size` lets callers raise the decode ceiling further. This prevents syncs from failing with a "decoded message length too large" error when a node response slightly exceeds the previous hard 4 MiB limit ([#2298](https://github.com/0xMiden/miden-client/issues/2298)).
+* [FEATURE][rust] The gRPC client now accepts responses up to 15% above the node's 4 MiB payload budget by default, and `GrpcClient::with_max_decoding_message_size` lets callers raise the decode ceiling further. This prevents syncs from failing with a "decoded message length too large" error when a node response slightly exceeds the previous hard 4 MiB limit ([#2298](https://github.com/0xMiden/miden-client/issues/2298)).
 
 ## 0.15.2 (2026-06-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 * [FEATURE][cli] `miden-cli call` now accepts advice map entries supplied via `--inputs-path/-i <FILE.toml>` in the same TOML format as `exec` ([#2244](https://github.com/0xMiden/miden-client/pull/2244)).
+* [FEATURE][rust] The gRPC client now accepts responses up to 15% above the node's 4 MiB payload budget by default, and `GrpcClient::with_max_message_size` lets callers raise the decode ceiling further. This prevents syncs from failing with a "decoded message length too large" error when a node response slightly exceeds the previous hard 4 MiB limit ([#2298](https://github.com/0xMiden/miden-client/issues/2298)).
 
 ## 0.15.2 (2026-06-18)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-bench"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-cli"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-integration-tests"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2162,7 +2162,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-sqlite-store"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2180,7 +2180,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-unit-tests"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "miden-client",
  "miden-client-sqlite-store",
@@ -4533,7 +4533,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-node-genesis"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "miden-agglayer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ edition      = "2024"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/miden-client"
 rust-version = "1.93"
-version      = "0.15.2"
+version      = "0.15.3"
 
 [profile.dev]
 codegen-units = 16
@@ -30,8 +30,8 @@ opt-level = 1
 
 [workspace.dependencies]
 # Workspace crates
-miden-client              = { default-features = false, path = "crates/rust-client", version = "0.15.2" }
-miden-client-sqlite-store = { default-features = false, path = "crates/sqlite-store", version = "0.15.2" }
+miden-client              = { default-features = false, path = "crates/rust-client", version = "0.15.3" }
+miden-client-sqlite-store = { default-features = false, path = "crates/sqlite-store", version = "0.15.3" }
 
 # Miden protocol dependencies
 miden-agglayer        = { default-features = false, version = "0.15.3" }

--- a/bin/miden-cli/src/lib.rs
+++ b/bin/miden-cli/src/lib.rs
@@ -10,6 +10,7 @@ use miden_client::account::AccountHeader;
 use miden_client::builder::ClientBuilder;
 use miden_client::keystore::{FilesystemKeyStore, Keystore};
 use miden_client::note_transport::grpc::GrpcNoteTransportClient;
+use miden_client::rpc::GrpcClient;
 use miden_client::store::{NoteFilter as ClientNoteFilter, OutputNoteRecord};
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 
@@ -138,9 +139,14 @@ impl CliClient {
             CliKeyStore::new(config.secret_keys_directory.clone()).map_err(CliError::KeyStore)?;
 
         // Build client with the provided configuration
+        let rpc_client = Arc::new(
+            GrpcClient::new(&config.rpc.endpoint.clone().into(), config.rpc.timeout_ms)
+                .with_max_decoding_message_size(CLI_MAX_RESPONSE_SIZE_BYTES),
+        );
+
         let mut builder = ClientBuilder::new()
             .sqlite_store(config.store_filepath.clone())
-            .grpc_client(&config.rpc.endpoint.clone().into(), Some(config.rpc.timeout_ms))
+            .rpc(rpc_client)
             .authenticator(Arc::new(keystore))
             .in_debug_mode(debug_mode)
             .tx_discard_delta(Some(TX_DISCARD_DELTA));
@@ -319,6 +325,10 @@ pub fn client_binary_name() -> OsString {
 /// Number of blocks that must elapse after a transaction’s reference block before it is marked
 /// stale and discarded.
 const TX_DISCARD_DELTA: u32 = 20;
+
+/// Maximum size (in bytes) of any decoded gRPC response the CLI accepts. Sized to fit large
+/// `SyncTransactions` responses.
+const CLI_MAX_RESPONSE_SIZE_BYTES: usize = 6 * 1024 * 1024;
 
 /// Root CLI struct.
 #[derive(Parser, Debug)]

--- a/crates/rust-client/src/rpc/tonic_client/api_client.rs
+++ b/crates/rust-client/src/rpc/tonic_client/api_client.rs
@@ -29,6 +29,7 @@ pub(crate) mod api_client_wrapper {
         pub(crate) client: InnerClient,
         wasm_client: WasmClient,
         bearer_token: Option<String>,
+        max_decoding_message_size: usize,
     }
 
     impl ApiClient {
@@ -43,12 +44,19 @@ pub(crate) mod api_client_wrapper {
             _timeout_ms: u64,
             genesis_commitment: Option<Word>,
             bearer_token: Option<String>,
+            max_decoding_message_size: usize,
         ) -> Result<ApiClient, RpcError> {
             let wasm_client = WasmClient::new(endpoint);
             let interceptor =
                 accept_header_interceptor(genesis_commitment, bearer_token.as_deref())?;
-            let client = ProtoClient::with_interceptor(wasm_client.clone(), interceptor);
-            Ok(ApiClient { client, wasm_client, bearer_token })
+            let client = ProtoClient::with_interceptor(wasm_client.clone(), interceptor)
+                .max_decoding_message_size(max_decoding_message_size);
+            Ok(ApiClient {
+                client,
+                wasm_client,
+                bearer_token,
+                max_decoding_message_size,
+            })
         }
 
         /// Connects to the Miden node API without injecting an Accept header.
@@ -60,12 +68,19 @@ pub(crate) mod api_client_wrapper {
             endpoint: String,
             _timeout_ms: u64,
             bearer_token: Option<String>,
+            max_decoding_message_size: usize,
         ) -> Result<ApiClient, RpcError> {
             let wasm_client = WasmClient::new(endpoint);
             let interceptor =
                 MetadataInterceptor::default().with_bearer_token(bearer_token.as_deref())?;
-            let client = ProtoClient::with_interceptor(wasm_client.clone(), interceptor);
-            Ok(ApiClient { client, wasm_client, bearer_token })
+            let client = ProtoClient::with_interceptor(wasm_client.clone(), interceptor)
+                .max_decoding_message_size(max_decoding_message_size);
+            Ok(ApiClient {
+                client,
+                wasm_client,
+                bearer_token,
+                max_decoding_message_size,
+            })
         }
 
         /// Returns a new `ApiClient` with an updated genesis commitment.
@@ -77,7 +92,8 @@ pub(crate) mod api_client_wrapper {
             let interceptor =
                 accept_header_interceptor(Some(genesis_commitment), self.bearer_token.as_deref())
                     .expect("bearer token already validated at construction time");
-            self.client = ProtoClient::with_interceptor(self.wasm_client.clone(), interceptor);
+            self.client = ProtoClient::with_interceptor(self.wasm_client.clone(), interceptor)
+                .max_decoding_message_size(self.max_decoding_message_size);
             self
         }
     }
@@ -106,6 +122,7 @@ pub(crate) mod api_client_wrapper {
         pub(crate) client: InnerClient,
         channel: Channel,
         bearer_token: Option<String>,
+        max_decoding_message_size: usize,
     }
 
     impl ApiClient {
@@ -118,6 +135,7 @@ pub(crate) mod api_client_wrapper {
             timeout_ms: u64,
             genesis_commitment: Option<Word>,
             bearer_token: Option<String>,
+            max_decoding_message_size: usize,
         ) -> Result<ApiClient, RpcError> {
             // Build the interceptor first so an invalid bearer token fails fast,
             // before we attempt the network connection.
@@ -136,8 +154,14 @@ pub(crate) mod api_client_wrapper {
                 .map_err(|err| RpcError::ConnectionError(Box::new(err)))?;
 
             // Return the connected client.
-            let client = ProtoClient::with_interceptor(channel.clone(), interceptor);
-            Ok(ApiClient { client, channel, bearer_token })
+            let client = ProtoClient::with_interceptor(channel.clone(), interceptor)
+                .max_decoding_message_size(max_decoding_message_size);
+            Ok(ApiClient {
+                client,
+                channel,
+                bearer_token,
+                max_decoding_message_size,
+            })
         }
 
         /// Connects to the Miden node API without injecting an Accept header.
@@ -147,6 +171,7 @@ pub(crate) mod api_client_wrapper {
             endpoint: String,
             timeout_ms: u64,
             bearer_token: Option<String>,
+            max_decoding_message_size: usize,
         ) -> Result<ApiClient, RpcError> {
             // Fail fast on an invalid bearer token, before opening the channel.
             let interceptor =
@@ -163,8 +188,14 @@ pub(crate) mod api_client_wrapper {
                 .await
                 .map_err(|err| RpcError::ConnectionError(Box::new(err)))?;
 
-            let client = ProtoClient::with_interceptor(channel.clone(), interceptor);
-            Ok(ApiClient { client, channel, bearer_token })
+            let client = ProtoClient::with_interceptor(channel.clone(), interceptor)
+                .max_decoding_message_size(max_decoding_message_size);
+            Ok(ApiClient {
+                client,
+                channel,
+                bearer_token,
+                max_decoding_message_size,
+            })
         }
 
         /// Returns a new `ApiClient` with an updated genesis commitment.
@@ -176,7 +207,8 @@ pub(crate) mod api_client_wrapper {
             let interceptor =
                 accept_header_interceptor(Some(genesis_commitment), self.bearer_token.as_deref())
                     .expect("bearer token already validated at construction time");
-            self.client = ProtoClient::with_interceptor(self.channel.clone(), interceptor);
+            self.client = ProtoClient::with_interceptor(self.channel.clone(), interceptor)
+                .max_decoding_message_size(self.max_decoding_message_size);
             self
         }
     }

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -158,7 +158,7 @@ pub struct GrpcClient {
     /// authenticating gateway in front of the node.
     bearer_token: Option<String>,
     /// Maximum size (in bytes) of a decoded gRPC response the client will accept. Defaults to
-    /// [`DEFAULT_MAX_DECODING_MESSAGE_SIZE`].
+    /// [`DEFAULT_MAX_RESPONSE_SIZE_BYTES`].
     max_decoding_message_size: usize,
 }
 
@@ -175,7 +175,7 @@ impl GrpcClient {
             max_retries: retry::DEFAULT_MAX_RETRIES,
             retry_interval_ms: retry::DEFAULT_RETRY_INTERVAL_MS,
             bearer_token: None,
-            max_decoding_message_size: DEFAULT_MAX_DECODING_MESSAGE_SIZE,
+            max_decoding_message_size: DEFAULT_MAX_RESPONSE_SIZE_BYTES,
         }
     }
 
@@ -1016,7 +1016,7 @@ mod tests {
     use miden_protocol::Word;
     use miden_protocol::block::BlockNumber;
 
-    use super::{BlockPagination, DEFAULT_MAX_DECODING_MESSAGE_SIZE, GrpcClient, PaginationResult};
+    use super::{BlockPagination, DEFAULT_MAX_RESPONSE_SIZE_BYTES, GrpcClient, PaginationResult};
     use crate::alloc::string::ToString;
     use crate::rpc::{Endpoint, NodeRpcClient, RpcError};
 
@@ -1192,7 +1192,7 @@ mod tests {
 
         // A fresh client uses the default decode ceiling.
         let default_client = GrpcClient::new(endpoint, 10_000);
-        assert_eq!(default_client.max_decoding_message_size, DEFAULT_MAX_DECODING_MESSAGE_SIZE);
+        assert_eq!(default_client.max_decoding_message_size, DEFAULT_MAX_RESPONSE_SIZE_BYTES);
 
         // The knob overrides it for callers that hit responses above the default.
         let custom =

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -126,7 +126,7 @@ impl BlockPagination {
 
 /// Default maximum size (in bytes) of a decoded gRPC response the client will accept: 15% above
 /// tonic's built-in 4 MiB receive limit. See [`GrpcClient::with_max_decoding_message_size`].
-const DEFAULT_MAX_DECODING_MESSAGE_SIZE: usize = 4 * 1024 * 1024 * 115 / 100;
+const DEFAULT_MAX_RESPONSE_SIZE_BYTES: usize = 4 * 1024 * 1024 * 115 / 100;
 
 /// Client for the Node RPC API using gRPC.
 ///

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -126,10 +126,13 @@ impl BlockPagination {
 
 /// Default maximum size (in bytes) of a decoded gRPC response the client will accept.
 ///
-/// The node targets a 4 MiB budget for paginated responses but sizes them with a best-effort
-/// estimate that omits protobuf framing and some fields, so an encoded message can land a little
-/// above 4 MiB. This default adds a 15% margin over that budget to absorb the overhead. Callers
-/// that still exceed it can raise the ceiling with [`GrpcClient::with_max_decoding_message_size`].
+/// When no decode limit is set on a tonic client, the decoder falls back to tonic's built-in
+/// `DEFAULT_MAX_RECV_MESSAGE_SIZE` of 4 MiB, applied at these [`unwrap_or`
+/// fallbacks][tonic-decode]. Passing this value explicitly overrides that fallback and lifts the
+/// ceiling to 15% above 4 MiB, so responses that land slightly over 4 MiB still decode. Callers
+/// that need more can raise it further with [`GrpcClient::with_max_decoding_message_size`].
+///
+/// [tonic-decode]: https://github.com/hyperium/tonic/blob/6cb6056b5a748bc5a29bd48f4602dbc4e552bb7d/tonic/src/codec/decode.rs#L192-L218
 const DEFAULT_MAX_DECODING_MESSAGE_SIZE: usize = 4 * 1024 * 1024 * 115 / 100;
 
 /// Client for the Node RPC API using gRPC.

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -124,15 +124,8 @@ impl BlockPagination {
 // GRPC CLIENT
 // ================================================================================================
 
-/// Default maximum size (in bytes) of a decoded gRPC response the client will accept.
-///
-/// When no decode limit is set on a tonic client, the decoder falls back to tonic's built-in
-/// `DEFAULT_MAX_RECV_MESSAGE_SIZE` of 4 MiB, applied at these [`unwrap_or`
-/// fallbacks][tonic-decode]. Passing this value explicitly overrides that fallback and lifts the
-/// ceiling to 15% above 4 MiB, so responses that land slightly over 4 MiB still decode. Callers
-/// that need more can raise it further with [`GrpcClient::with_max_decoding_message_size`].
-///
-/// [tonic-decode]: https://github.com/hyperium/tonic/blob/6cb6056b5a748bc5a29bd48f4602dbc4e552bb7d/tonic/src/codec/decode.rs#L192-L218
+/// Default maximum size (in bytes) of a decoded gRPC response the client will accept: 15% above
+/// tonic's built-in 4 MiB receive limit. See [`GrpcClient::with_max_decoding_message_size`].
 const DEFAULT_MAX_DECODING_MESSAGE_SIZE: usize = 4 * 1024 * 1024 * 115 / 100;
 
 /// Client for the Node RPC API using gRPC.
@@ -204,10 +197,10 @@ impl GrpcClient {
 
     /// Sets the maximum size (in bytes) of a decoded gRPC response the client will accept.
     ///
-    /// Defaults to a 15% margin over the node's 4 MiB payload budget. Raise this when the node
-    /// returns responses larger than the default and a sync fails with a "decoded message length
-    /// too large" error. This only changes what the client is willing to receive; it does not
-    /// affect how much data the node produces.
+    /// Defaults to 15% above [tonic's built-in 4 MiB receive limit][tonic-decode], leaving headroom
+    /// for responses that land slightly over 4 MiB.
+    ///
+    /// [tonic-decode]: https://github.com/hyperium/tonic/blob/6cb6056b5a748bc5a29bd48f4602dbc4e552bb7d/tonic/src/codec/decode.rs#L192-L218
     #[must_use]
     pub fn with_max_decoding_message_size(mut self, max_decoding_message_size: usize) -> Self {
         self.max_decoding_message_size = max_decoding_message_size;

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -129,7 +129,7 @@ impl BlockPagination {
 /// The node targets a 4 MiB budget for paginated responses but sizes them with a best-effort
 /// estimate that omits protobuf framing and some fields, so an encoded message can land a little
 /// above 4 MiB. This default adds a 15% margin over that budget to absorb the overhead. Callers
-/// that still exceed it can raise the ceiling with [`GrpcClient::with_max_message_size`].
+/// that still exceed it can raise the ceiling with [`GrpcClient::with_max_decoding_message_size`].
 const DEFAULT_MAX_DECODING_MESSAGE_SIZE: usize = 4 * 1024 * 1024 * 115 / 100;
 
 /// Client for the Node RPC API using gRPC.
@@ -206,7 +206,7 @@ impl GrpcClient {
     /// too large" error. This only changes what the client is willing to receive; it does not
     /// affect how much data the node produces.
     #[must_use]
-    pub fn with_max_message_size(mut self, max_decoding_message_size: usize) -> Self {
+    pub fn with_max_decoding_message_size(mut self, max_decoding_message_size: usize) -> Self {
         self.max_decoding_message_size = max_decoding_message_size;
         self
     }
@@ -1191,7 +1191,7 @@ mod tests {
     }
 
     #[test]
-    fn with_max_message_size_overrides_default() {
+    fn with_max_decoding_message_size_overrides_default() {
         let endpoint = &Endpoint::devnet();
 
         // A fresh client uses the default decode ceiling.
@@ -1199,7 +1199,8 @@ mod tests {
         assert_eq!(default_client.max_decoding_message_size, DEFAULT_MAX_DECODING_MESSAGE_SIZE);
 
         // The knob overrides it for callers that hit responses above the default.
-        let custom = GrpcClient::new(endpoint, 10_000).with_max_message_size(8 * 1024 * 1024);
+        let custom =
+            GrpcClient::new(endpoint, 10_000).with_max_decoding_message_size(8 * 1024 * 1024);
         assert_eq!(custom.max_decoding_message_size, 8 * 1024 * 1024);
     }
 

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -124,6 +124,14 @@ impl BlockPagination {
 // GRPC CLIENT
 // ================================================================================================
 
+/// Default maximum size (in bytes) of a decoded gRPC response the client will accept.
+///
+/// The node targets a 4 MiB budget for paginated responses but sizes them with a best-effort
+/// estimate that omits protobuf framing and some fields, so an encoded message can land a little
+/// above 4 MiB. This default adds a 15% margin over that budget to absorb the overhead. Callers
+/// that still exceed it can raise the ceiling with [`GrpcClient::with_max_message_size`].
+const DEFAULT_MAX_DECODING_MESSAGE_SIZE: usize = 4 * 1024 * 1024 * 115 / 100;
+
 /// Client for the Node RPC API using gRPC.
 ///
 /// If the `tonic` feature is enabled, this client will use a `tonic::transport::Channel` to
@@ -153,6 +161,9 @@ pub struct GrpcClient {
     /// gRPC call, alongside the standard `accept` header. Used when talking to an
     /// authenticating gateway in front of the node.
     bearer_token: Option<String>,
+    /// Maximum size (in bytes) of a decoded gRPC response the client will accept. Defaults to
+    /// [`DEFAULT_MAX_DECODING_MESSAGE_SIZE`].
+    max_decoding_message_size: usize,
 }
 
 impl GrpcClient {
@@ -168,6 +179,7 @@ impl GrpcClient {
             max_retries: retry::DEFAULT_MAX_RETRIES,
             retry_interval_ms: retry::DEFAULT_RETRY_INTERVAL_MS,
             bearer_token: None,
+            max_decoding_message_size: DEFAULT_MAX_DECODING_MESSAGE_SIZE,
         }
     }
 
@@ -184,6 +196,18 @@ impl GrpcClient {
     #[must_use]
     pub fn with_retry_interval_ms(mut self, retry_interval_ms: u64) -> Self {
         self.retry_interval_ms = retry_interval_ms;
+        self
+    }
+
+    /// Sets the maximum size (in bytes) of a decoded gRPC response the client will accept.
+    ///
+    /// Defaults to a 15% margin over the node's 4 MiB payload budget. Raise this when the node
+    /// returns responses larger than the default and a sync fails with a "decoded message length
+    /// too large" error. This only changes what the client is willing to receive; it does not
+    /// affect how much data the node produces.
+    #[must_use]
+    pub fn with_max_message_size(mut self, max_decoding_message_size: usize) -> Self {
+        self.max_decoding_message_size = max_decoding_message_size;
         self
     }
 
@@ -236,6 +260,7 @@ impl GrpcClient {
             self.timeout_ms,
             genesis_commitment,
             self.bearer_token.clone(),
+            self.max_decoding_message_size,
         )
         .await?;
         let mut client = self.client.write();
@@ -296,6 +321,7 @@ impl GrpcClient {
             self.endpoint.clone(),
             self.timeout_ms,
             self.bearer_token.clone(),
+            self.max_decoding_message_size,
         )
         .await?;
         rpc_api
@@ -994,7 +1020,7 @@ mod tests {
     use miden_protocol::Word;
     use miden_protocol::block::BlockNumber;
 
-    use super::{BlockPagination, GrpcClient, PaginationResult};
+    use super::{BlockPagination, DEFAULT_MAX_DECODING_MESSAGE_SIZE, GrpcClient, PaginationResult};
     use crate::alloc::string::ToString;
     use crate::rpc::{Endpoint, NodeRpcClient, RpcError};
 
@@ -1162,6 +1188,19 @@ mod tests {
         // Rebuilding the interceptor after a genesis update must not drop the caller token.
         assert_eq!(client.bearer_token.as_deref(), Some("token"));
         assert!(client.client.read().as_ref().is_some());
+    }
+
+    #[test]
+    fn with_max_message_size_overrides_default() {
+        let endpoint = &Endpoint::devnet();
+
+        // A fresh client uses the default decode ceiling.
+        let default_client = GrpcClient::new(endpoint, 10_000);
+        assert_eq!(default_client.max_decoding_message_size, DEFAULT_MAX_DECODING_MESSAGE_SIZE);
+
+        // The knob overrides it for callers that hit responses above the default.
+        let custom = GrpcClient::new(endpoint, 10_000).with_max_message_size(8 * 1024 * 1024);
+        assert_eq!(custom.max_decoding_message_size, 8 * 1024 * 1024);
     }
 
     /// Real-network smoke test: hitting the public testnet with a caller-supplied bearer


### PR DESCRIPTION
Closes #2298.

Also bumps version to `0.15.3`.