### PR TITLE
fix(store): keep externally-consumed notes findable by their NoteId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [rust] Bumped dependencies: Miden VM crates (`miden-core`, `miden-processor`, `miden-prover`, `miden-assembly`, etc.) to `0.23.5`, and `miden-node-proto-build` and `miden-remote-prover-client` to `0.15.1` ([#2301](https://github.com/0xMiden/rust-sdk/pull/2301)).
 
+### Fixes
+
+* [FIX][store] Add metadata to ConsumedExternal notes so that they can be findable by their `NoteId`. The change is store-compatible because records written by older clients (the metadata-less layout) still decode, reading back with no metadata as before ([#XXXX](https://github.com/0xMiden/miden-client/pull/XXXX)).
+
 ## 0.15.3 (2026-07-02)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixes
 
-* [FIX][store] Add metadata to ConsumedExternal notes so that they can be findable by their `NoteId`. The change is store-compatible because records written by older clients (the metadata-less layout) still decode, reading back with no metadata as before ([#2308](https://github.com/0xMiden/miden-client/pull/2308)).
+* [FIX][store] Add metadata to ConsumedExternal notes so that they can be findable by their `NoteId`. The change is store-compatible because records written by older clients (the metadata-less layout) still decode, reading back with no metadata as before ([#2308](https://github.com/0xMiden/rust-sdk/pull/2308)).
 
 ## 0.15.3 (2026-07-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixes
 
-* [FIX][store] Add metadata to ConsumedExternal notes so that they can be findable by their `NoteId`. The change is store-compatible because records written by older clients (the metadata-less layout) still decode, reading back with no metadata as before ([#XXXX](https://github.com/0xMiden/miden-client/pull/XXXX)).
+* [FIX][store] Add metadata to ConsumedExternal notes so that they can be findable by their `NoteId`. The change is store-compatible because records written by older clients (the metadata-less layout) still decode, reading back with no metadata as before ([#2308](https://github.com/0xMiden/miden-client/pull/2308)).
 
 ## 0.15.3 (2026-07-02)
 

--- a/bin/integration-tests/src/tests/client.rs
+++ b/bin/integration-tests/src/tests/client.rs
@@ -988,7 +988,8 @@ pub async fn test_import_consumed_note_with_proof(client_config: ClientConfig) -
         )])
         .await?;
 
-    // A `ConsumedExternal` note has no metadata, so look it up by its details commitment.
+    // Look up the consumed note by its details commitment, which is stable across state
+    // transitions.
     let consumed_note = client_2
         .get_input_notes(NoteFilter::DetailsCommitments(vec![note.details_commitment()]))
         .await?
@@ -1056,7 +1057,8 @@ pub async fn test_import_consumed_note_with_id(client_config: ClientConfig) -> R
     // Import the consumed note
     client_2.import_notes(&[NoteFile::NoteId(note.id().unwrap())]).await.unwrap();
 
-    // A `ConsumedExternal` note has no metadata, so look it up by its details commitment.
+    // Look up the consumed note by its details commitment, which is stable across state
+    // transitions.
     let consumed_note = client_2
         .get_input_notes(NoteFilter::DetailsCommitments(vec![note.details_commitment()]))
         .await?
@@ -1224,7 +1226,7 @@ pub async fn test_discarded_transaction(client_config: ClientConfig) -> Result<(
     assert!(matches!(note_record.state(), InputNoteState::ConsumedAuthenticatedLocal(_)));
 
     // After sync the note in client 1 should be consumed externally and the transaction discarded.
-    // `ConsumedExternal` has no metadata, so look the note up by its details commitment.
+    // Look the note up by its details commitment, which is stable across state transitions.
     client_1.sync_state().await.unwrap();
     let note_record = client_1
         .get_input_notes(NoteFilter::DetailsCommitments(vec![note.details_commitment()]))

--- a/bin/integration-tests/src/tests/network_transaction.rs
+++ b/bin/integration-tests/src/tests/network_transaction.rs
@@ -540,9 +540,8 @@ pub async fn test_note_reader_finds_note_consumed_by_ntx(
         client.source_manager(),
         &mut client.rng(),
     )?;
-    // Captured before `network_note` is moved into the request below: once the network account
-    // consumes it the note is `ConsumedExternal` (no metadata), so `InputNoteRecord::id` is `None`
-    // and the note can only be matched by its stable details commitment.
+    // Captured before `network_note` is moved into the request below, so the consumed note can be
+    // matched later by its stable details commitment.
     let details_commitment = network_note.details_commitment();
 
     let tx_request =
@@ -612,9 +611,8 @@ pub async fn test_network_note_consumed_by_ntx(client_config: ClientConfig) -> R
         client.source_manager(),
         &mut client.rng(),
     )?;
-    // Captured before `network_note` is moved into the request below: once the network account
-    // consumes it the note is `ConsumedExternal` (no metadata), so it can only be resolved by its
-    // details commitment, not its note ID.
+    // Captured before `network_note` is moved into the request below, so the consumed note can be
+    // matched later by its stable details commitment.
     let details_commitment = network_note.details_commitment();
 
     let tx_request =

--- a/crates/rust-client/src/note/import.rs
+++ b/crates/rust-client/src/note/import.rs
@@ -171,8 +171,8 @@ where
     /// is passed via `previous_note` so it can be updated. The note information is fetched from
     /// the node and stored in the client's store.
     ///
-    /// The returned records are not keyed by [`NoteId`] because a note that the node reports as
-    /// already consumed becomes a metadata-less `ConsumedExternal` record with no `NoteId`.
+    /// The returned records are positional rather than keyed by [`NoteId`]; a `None` entry marks a
+    /// note that needs no update.
     ///
     /// # Errors:
     /// - If a note doesn't exist on the node.

--- a/crates/rust-client/src/note/note_update_tracker.rs
+++ b/crates/rust-client/src/note/note_update_tracker.rs
@@ -318,9 +318,10 @@ impl NoteUpdateTracker {
             .filter(|note| note.update_type.is_modified())
     }
 
-    /// Returns the ids of updated input notes that are now consumed, by tracking key. Consumed
-    /// states carry no metadata, so `InputNoteRecord::id` is `None`; the key (the id assigned at
-    /// commit) is used instead.
+    /// Returns the ids of updated input notes that are now consumed, by tracking key. The tracking
+    /// key (the id assigned when the record was inserted) is used rather than
+    /// `InputNoteRecord::id`, which can be `None` for a consumed record whose state carries no
+    /// metadata.
     pub fn consumed_input_note_ids(&self) -> impl Iterator<Item = NoteId> + '_ {
         self.input_notes
             .iter()

--- a/crates/rust-client/src/store/note_record/input_note_record/mod.rs
+++ b/crates/rust-client/src/store/note_record/input_note_record/mod.rs
@@ -84,9 +84,8 @@ impl InputNoteRecord {
 
     /// Returns the input note ID, computed by combining the details commitment with the
     /// note metadata. Returns `None` when the current state has no metadata (e.g. an
-    /// expected note imported from bare `NoteFile::NoteDetails`, or a note in the
-    /// `ConsumedExternal` state). Use [`Self::details_commitment`] when a stable identifier
-    /// is needed in those cases.
+    /// expected note imported from bare `NoteFile::NoteDetails`). Use
+    /// [`Self::details_commitment`] when a stable identifier is needed in those cases.
     pub fn id(&self) -> Option<NoteId> {
         let metadata = self.metadata()?;
         Some(NoteId::new(self.details.commitment(), metadata))

--- a/crates/rust-client/src/store/note_record/input_note_record/states/committed.rs
+++ b/crates/rust-client/src/store/note_record/input_note_record/states/committed.rs
@@ -51,6 +51,7 @@ impl NoteStateHandler for CommittedNoteState {
                 nullifier_block_height,
                 consumer_account,
                 consumed_tx_order: None,
+                metadata: Some(self.metadata),
             }
             .into(),
         ))

--- a/crates/rust-client/src/store/note_record/input_note_record/states/consumed_external.rs
+++ b/crates/rust-client/src/store/note_record/input_note_record/states/consumed_external.rs
@@ -4,6 +4,7 @@ use miden_protocol::account::AccountId;
 use miden_protocol::block::{BlockHeader, BlockNumber};
 use miden_protocol::note::{NoteId, NoteInclusionProof, NoteMetadata};
 use miden_protocol::transaction::TransactionId;
+use miden_tx::utils::serde::Deserializable;
 
 use super::{InputNoteState, NoteStateHandler};
 use crate::store::NoteRecordError;
@@ -21,6 +22,12 @@ pub struct ConsumedExternalNoteState {
     /// Per-account position of the consuming transaction within the account's execution chain
     /// for the block. `None` if the order has not been determined yet.
     pub consumed_tx_order: Option<u32>,
+    /// Metadata associated with the note (sender, note type, tag and other additional
+    /// information), retained through consumption so the note ID stays recoverable. `None` when
+    /// the prior state had no metadata (e.g. a note imported from bare
+    /// `NoteFile::NoteDetails`, or a record read back from the legacy on-disk layout that
+    /// predates this field).
+    pub metadata: Option<NoteMetadata>,
 }
 
 impl NoteStateHandler for ConsumedExternalNoteState {
@@ -68,7 +75,7 @@ impl NoteStateHandler for ConsumedExternalNoteState {
     }
 
     fn metadata(&self) -> Option<&NoteMetadata> {
-        None
+        self.metadata.as_ref()
     }
 
     fn inclusion_proof(&self) -> Option<&NoteInclusionProof> {
@@ -80,11 +87,31 @@ impl NoteStateHandler for ConsumedExternalNoteState {
     }
 }
 
+impl ConsumedExternalNoteState {
+    /// Deserializes the legacy layout stored under [`InputNoteState::STATE_CONSUMED_EXTERNAL`],
+    /// which predates the `metadata` field. Records written in that format carry no metadata,
+    /// so `metadata` is set to `None`.
+    pub(crate) fn read_from_legacy<R: miden_tx::utils::serde::ByteReader>(
+        source: &mut R,
+    ) -> Result<Self, miden_tx::utils::serde::DeserializationError> {
+        let nullifier_block_height = BlockNumber::read_from(source)?;
+        let consumer_account = Option::<AccountId>::read_from(source)?;
+        let consumed_tx_order = Option::<u32>::read_from(source)?;
+        Ok(ConsumedExternalNoteState {
+            nullifier_block_height,
+            consumer_account,
+            consumed_tx_order,
+            metadata: None,
+        })
+    }
+}
+
 impl miden_tx::utils::serde::Serializable for ConsumedExternalNoteState {
     fn write_into<W: miden_tx::utils::serde::ByteWriter>(&self, target: &mut W) {
         self.nullifier_block_height.write_into(target);
         self.consumer_account.write_into(target);
         self.consumed_tx_order.write_into(target);
+        self.metadata.write_into(target);
     }
 }
 
@@ -95,10 +122,12 @@ impl miden_tx::utils::serde::Deserializable for ConsumedExternalNoteState {
         let nullifier_block_height = BlockNumber::read_from(source)?;
         let consumer_account = Option::<AccountId>::read_from(source)?;
         let consumed_tx_order = Option::<u32>::read_from(source)?;
+        let metadata = Option::<NoteMetadata>::read_from(source)?;
         Ok(ConsumedExternalNoteState {
             nullifier_block_height,
             consumer_account,
             consumed_tx_order,
+            metadata,
         })
     }
 }
@@ -106,5 +135,35 @@ impl miden_tx::utils::serde::Deserializable for ConsumedExternalNoteState {
 impl From<ConsumedExternalNoteState> for InputNoteState {
     fn from(state: ConsumedExternalNoteState) -> Self {
         InputNoteState::ConsumedExternal(state)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec::Vec;
+
+    use miden_protocol::account::AccountId;
+    use miden_protocol::block::BlockNumber;
+    use miden_tx::utils::serde::{Deserializable, Serializable};
+
+    use crate::store::InputNoteState;
+
+    /// A row written by an older client uses discriminant 8 with three fields and no metadata.
+    /// Reading it back must succeed and leave `metadata` empty, so existing stores keep working
+    /// after upgrading to a client that writes the metadata-bearing layout.
+    #[test]
+    fn legacy_consumed_external_blob_decodes_without_metadata() {
+        let mut legacy_bytes = Vec::new();
+        legacy_bytes.push(InputNoteState::STATE_CONSUMED_EXTERNAL);
+        BlockNumber::from(7u32).write_into(&mut legacy_bytes);
+        None::<AccountId>.write_into(&mut legacy_bytes);
+        None::<u32>.write_into(&mut legacy_bytes);
+
+        let state = InputNoteState::read_from_bytes(&legacy_bytes).unwrap();
+        let InputNoteState::ConsumedExternal(inner) = state else {
+            panic!("expected ConsumedExternal");
+        };
+        assert_eq!(inner.nullifier_block_height, BlockNumber::from(7u32));
+        assert_eq!(inner.metadata, None);
     }
 }

--- a/crates/rust-client/src/store/note_record/input_note_record/states/expected.rs
+++ b/crates/rust-client/src/store/note_record/input_note_record/states/expected.rs
@@ -48,6 +48,7 @@ impl NoteStateHandler for ExpectedNoteState {
                 nullifier_block_height,
                 consumer_account,
                 consumed_tx_order: None,
+                metadata: self.metadata,
             }
             .into(),
         ))

--- a/crates/rust-client/src/store/note_record/input_note_record/states/invalid.rs
+++ b/crates/rust-client/src/store/note_record/input_note_record/states/invalid.rs
@@ -46,6 +46,7 @@ impl NoteStateHandler for InvalidNoteState {
                 nullifier_block_height,
                 consumer_account,
                 consumed_tx_order: None,
+                metadata: Some(self.metadata),
             }
             .into(),
         ))

--- a/crates/rust-client/src/store/note_record/input_note_record/states/mod.rs
+++ b/crates/rust-client/src/store/note_record/input_note_record/states/mod.rs
@@ -72,6 +72,7 @@ impl InputNoteState {
     pub const STATE_CONSUMED_EXTERNAL: u8 = 8;
     /// `ConsumedExternal` layout that also stores the note metadata. Discriminant 8 is the legacy
     /// metadata-less layout, kept read-only for stores written by older client versions.
+    //TODO: Remove this when merging next to main.
     pub const STATE_CONSUMED_EXTERNAL_V2: u8 = 9;
 
     /// Returns the inner state handler that implements state transitions.

--- a/crates/rust-client/src/store/note_record/input_note_record/states/mod.rs
+++ b/crates/rust-client/src/store/note_record/input_note_record/states/mod.rs
@@ -70,6 +70,9 @@ impl InputNoteState {
     pub const STATE_CONSUMED_AUTHENTICATED_LOCAL: u8 = 6;
     pub const STATE_CONSUMED_UNAUTHENTICATED_LOCAL: u8 = 7;
     pub const STATE_CONSUMED_EXTERNAL: u8 = 8;
+    /// `ConsumedExternal` layout that also stores the note metadata. Discriminant 8 is the legacy
+    /// metadata-less layout, kept read-only for stores written by older client versions.
+    pub const STATE_CONSUMED_EXTERNAL_V2: u8 = 9;
 
     /// Returns the inner state handler that implements state transitions.
     fn inner(&self) -> &dyn NoteStateHandler {
@@ -101,7 +104,7 @@ impl InputNoteState {
             InputNoteState::ConsumedUnauthenticatedLocal(_) => {
                 Self::STATE_CONSUMED_UNAUTHENTICATED_LOCAL
             },
-            InputNoteState::ConsumedExternal(_) => Self::STATE_CONSUMED_EXTERNAL,
+            InputNoteState::ConsumedExternal(_) => Self::STATE_CONSUMED_EXTERNAL_V2,
         }
     }
 
@@ -242,6 +245,9 @@ impl Deserializable for InputNoteState {
                 Ok(ConsumedUnauthenticatedLocalNoteState::read_from(source)?.into())
             },
             Self::STATE_CONSUMED_EXTERNAL => {
+                Ok(ConsumedExternalNoteState::read_from_legacy(source)?.into())
+            },
+            Self::STATE_CONSUMED_EXTERNAL_V2 => {
                 Ok(ConsumedExternalNoteState::read_from(source)?.into())
             },
             _ => Err(DeserializationError::InvalidValue(format!(

--- a/crates/rust-client/src/store/note_record/input_note_record/states/processing_authenticated.rs
+++ b/crates/rust-client/src/store/note_record/input_note_record/states/processing_authenticated.rs
@@ -53,6 +53,7 @@ impl NoteStateHandler for ProcessingAuthenticatedNoteState {
                 nullifier_block_height,
                 consumer_account,
                 consumed_tx_order: None,
+                metadata: Some(self.metadata),
             }
             .into(),
         ))

--- a/crates/rust-client/src/store/note_record/input_note_record/states/processing_unauthenticated.rs
+++ b/crates/rust-client/src/store/note_record/input_note_record/states/processing_unauthenticated.rs
@@ -45,6 +45,7 @@ impl NoteStateHandler for ProcessingUnauthenticatedNoteState {
                 nullifier_block_height,
                 consumer_account,
                 consumed_tx_order: None,
+                metadata: Some(self.metadata),
             }
             .into(),
         ))

--- a/crates/rust-client/src/store/note_record/input_note_record/states/unverified.rs
+++ b/crates/rust-client/src/store/note_record/input_note_record/states/unverified.rs
@@ -45,6 +45,7 @@ impl NoteStateHandler for UnverifiedNoteState {
                 nullifier_block_height,
                 consumer_account,
                 consumed_tx_order: None,
+                metadata: Some(self.metadata),
             }
             .into(),
         ))

--- a/crates/sqlite-store/src/note/filters.rs
+++ b/crates/sqlite-store/src/note/filters.rs
@@ -168,10 +168,11 @@ pub(super) fn note_filter_input_notes_condition(filter: &NoteFilter) -> (String,
         },
         NoteFilter::Consumed => {
             format!(
-                "(state_discriminant in ({}, {}, {}))",
+                "(state_discriminant in ({}, {}, {}, {}))",
                 InputNoteState::STATE_CONSUMED_AUTHENTICATED_LOCAL,
                 InputNoteState::STATE_CONSUMED_UNAUTHENTICATED_LOCAL,
-                InputNoteState::STATE_CONSUMED_EXTERNAL
+                InputNoteState::STATE_CONSUMED_EXTERNAL,
+                InputNoteState::STATE_CONSUMED_EXTERNAL_V2
             )
         },
         NoteFilter::Expected => {

--- a/crates/sqlite-store/src/note/mod.rs
+++ b/crates/sqlite-store/src/note/mod.rs
@@ -229,6 +229,7 @@ impl SqliteStore {
             Value::from(InputNoteState::STATE_CONSUMED_AUTHENTICATED_LOCAL.to_string()),
             Value::from(InputNoteState::STATE_CONSUMED_UNAUTHENTICATED_LOCAL.to_string()),
             Value::from(InputNoteState::STATE_CONSUMED_EXTERNAL.to_string()),
+            Value::from(InputNoteState::STATE_CONSUMED_EXTERNAL_V2.to_string()),
         ]);
         conn.prepare(QUERY)
             .into_store_error()?

--- a/crates/sqlite-store/src/note/tests.rs
+++ b/crates/sqlite-store/src/note/tests.rs
@@ -55,6 +55,7 @@ fn create_consumed_external_input_note(
         nullifier_block_height: BlockNumber::from(block_height),
         consumer_account,
         consumed_tx_order: None,
+        metadata: None,
     };
 
     InputNoteRecord::new(details, NoteAttachments::empty(), Some(0), state.into())

--- a/crates/testing/miden-client-tests/src/tests.rs
+++ b/crates/testing/miden-client-tests/src/tests.rs
@@ -186,8 +186,8 @@ async fn input_notes_round_trip() {
     let retrieved_notes = client.get_input_notes(NoteFilter::All).await.unwrap();
     assert_eq!(retrieved_notes.len(), 4);
 
-    // Compare by details commitment: notes that have been consumed are stored without metadata,
-    // so they have no `NoteId`, but their details commitment is always available.
+    // Compare by details commitment, which is always available regardless of note state (a
+    // `NoteId` needs metadata, which some records don't carry).
     let chain_notes_commitments: std::collections::HashSet<_> =
         available_notes.iter().map(|n| n.note().unwrap().details_commitment()).collect();
     // compare notes
@@ -911,8 +911,8 @@ async fn import_note_validation() {
     .pop()
     .unwrap();
 
-    // The consumed note is in `ConsumedExternal` state (no metadata), so it's retrieved by its
-    // details commitment rather than by `NoteId`.
+    // Retrieve the consumed note by its details commitment, which is stable across state
+    // transitions.
     let consumed_note = client
         .get_input_notes(NoteFilter::DetailsCommitments(vec![
             consumed_note.note().unwrap().details_commitment(),
@@ -1391,8 +1391,7 @@ async fn input_note_reader_finds_externally_consumed_notes() {
     // Sync: the client should discover the note was consumed externally by the tracked account.
     client.sync_state().await.unwrap();
 
-    // The note is in ConsumedExternal state (no metadata), so it's retrieved by its details
-    // commitment rather than by `NoteId`.
+    // Retrieve the note by its details commitment, which is stable across state transitions.
     let input_note = client
         .get_input_notes(NoteFilter::DetailsCommitments(vec![p2id_details_commitment]))
         .await
@@ -1424,6 +1423,85 @@ async fn input_note_reader_finds_externally_consumed_notes() {
     );
     assert_eq!(collected[0].details_commitment(), p2id_details_commitment);
     assert_eq!(collected[0].consumer_account(), Some(consumer_id));
+}
+
+// Regression: importing an already-consumed public note by id must leave a record that is findable
+// by its `NoteId` (not only by details commitment). The consumed record retains its metadata, so it
+// keeps a resolvable id.
+#[tokio::test]
+async fn import_by_id_already_consumed_note_is_findable_by_id() {
+    let sender_id: AccountId = ACCOUNT_ID_PRIVATE_SENDER.try_into().unwrap();
+    let faucet_id: AccountId = ACCOUNT_ID_PRIVATE_FUNGIBLE_FAUCET.try_into().unwrap();
+
+    // Build a MockChain with a consumer and a PUBLIC P2ID note from sender to consumer.
+    let mut builder = MockChainBuilder::new();
+    let consumer = builder.add_existing_mock_account(miden_testing::Auth::IncrNonce).unwrap();
+    let consumer_id = consumer.id();
+
+    let asset = Asset::Fungible(FungibleAsset::new(faucet_id, 100u64).unwrap());
+    let p2id_note = builder
+        .add_p2id_note(sender_id, consumer_id, &[asset], NoteType::Public)
+        .unwrap();
+    let note_id = p2id_note.id();
+    let details_commitment = p2id_note.details_commitment();
+
+    let mut chain = builder.build().unwrap();
+    // Block 1: makes the note consumable.
+    chain.prove_next_block().unwrap();
+
+    // Consumer consumes the note directly on the chain (bypassing any client).
+    let tx = Box::pin(
+        chain
+            .build_tx_context(
+                miden_testing::TxContextInput::Account(consumer.clone()),
+                &[],
+                core::slice::from_ref(&p2id_note),
+            )
+            .unwrap()
+            .build()
+            .unwrap()
+            .execute(),
+    )
+    .await
+    .unwrap();
+    chain.add_pending_executed_transaction(&tx).unwrap();
+    // Block 2: includes the consume transaction (note is now spent on-chain).
+    chain.prove_next_block().unwrap();
+
+    // Build a client backed by this chain. This client never saw the note before.
+    let rng =
+        RandomCoin::new(rand::random::<[u64; 4]>().map(|v| Felt::new_unchecked(v >> 1)).into());
+    let keystore = FilesystemKeyStore::new(std::env::temp_dir()).unwrap();
+    let mock_rpc = MockRpcApi::new(chain);
+
+    let mut client = ClientBuilder::new()
+        .rpc(Arc::new(mock_rpc))
+        .rng(Box::new(rng))
+        .sqlite_store(create_test_store_path())
+        .authenticator(Arc::new(keystore))
+        .in_debug_mode(DebugMode::Enabled)
+        .tx_discard_delta(None)
+        .build()
+        .await
+        .unwrap();
+    client.ensure_genesis_in_place().await.unwrap();
+
+    // Import the already-consumed public note by id.
+    let returned = client.import_notes(&[NoteFile::NoteId(note_id)]).await.unwrap();
+    assert_eq!(returned.len(), 1, "import returns the note's details commitment");
+
+    // The consumed record keeps its NoteId, so it is findable by an id-based filter.
+    let by_id = client.get_input_notes(NoteFilter::List(vec![note_id])).await.unwrap();
+    assert_eq!(by_id.len(), 1, "consumed note must be findable by NoteId");
+    assert_eq!(by_id[0].id(), Some(note_id));
+    assert!(by_id[0].is_consumed());
+
+    // It remains findable by details commitment too.
+    let by_commitment = client
+        .get_input_notes(NoteFilter::DetailsCommitments(vec![details_commitment]))
+        .await
+        .unwrap();
+    assert_eq!(by_commitment.len(), 1);
 }
 
 /// Builds a chain with two blocks relevant to a tracked account (blocks 1 and 4) and a client


### PR DESCRIPTION
Notes consumed externally weren't findable by their note id because they didn't store their metadata; now they do.