### PR TITLE
refactor(store): cleaner SQL types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
-* [BREAKING][store] The SQLite store now stores account IDs as serialized `BLOB` columns instead of hex `TEXT` ([#2309](https://github.com/0xMiden/rust-sdk/pull/2309/changes#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed)).
+* [BREAKING][store] The SQLite store now stores account IDs as serialized `BLOB` columns instead of hex `TEXT` ([#2309](https://github.com/0xMiden/rust-sdk/pull/2309)).
 * [BREAKING][param][store] `Store::insert_block_header` now takes a `nodes` argument and persists the header with its MMR authentication nodes in a single transaction; the standalone `Store::insert_partial_blockchain_nodes` is removed. Header-only inserts (e.g. genesis) pass an empty slice ([#2294](https://github.com/0xMiden/rust-sdk/pull/2294)).
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 
+* [BREAKING][behavior][store] The SQLite store now stores account IDs as serialized `BLOB` columns instead of hex `TEXT`. (#XXXX)
 * [BREAKING][param][store] `Store::insert_block_header` now takes a `nodes` argument and persists the header with its MMR authentication nodes in a single transaction; the standalone `Store::insert_partial_blockchain_nodes` is removed. Header-only inserts (e.g. genesis) pass an empty slice ([#2294](https://github.com/0xMiden/rust-sdk/pull/2294)).
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
-* [BREAKING][behavior][store] The SQLite store now stores account IDs as serialized `BLOB` columns instead of hex `TEXT`. (#XXXX)
+* [BREAKING][store] The SQLite store now stores account IDs as serialized `BLOB` columns instead of hex `TEXT` ([#2309](https://github.com/0xMiden/rust-sdk/pull/2309/changes#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed)).
 * [BREAKING][param][store] `Store::insert_block_header` now takes a `nodes` argument and persists the header with its MMR authentication nodes in a single transaction; the standalone `Store::insert_partial_blockchain_nodes` is removed. Header-only inserts (e.g. genesis) pass an empty slice ([#2294](https://github.com/0xMiden/rust-sdk/pull/2294)).
 
 ### Fixes

--- a/crates/sqlite-store/src/account/accounts.rs
+++ b/crates/sqlite-store/src/account/accounts.rs
@@ -65,8 +65,8 @@ impl SqliteStore {
             .query_map([], |row| row.get(0))
             .expect("no binding parameters used in query")
             .map(|result| {
-                let id: String = result.map_err(|e| StoreError::ParsingError(e.to_string()))?;
-                Ok(AccountId::from_hex(&id).expect("account id is valid"))
+                let id: Vec<u8> = result.map_err(|e| StoreError::ParsingError(e.to_string()))?;
+                Ok(AccountId::read_from_bytes(&id).expect("account id is valid"))
             })
             .collect::<Result<Vec<AccountId>, StoreError>>()
     }
@@ -84,7 +84,7 @@ impl SqliteStore {
         conn: &Connection,
         account_id: AccountId,
     ) -> Result<Option<(AccountHeader, AccountStatus)>, StoreError> {
-        Ok(query_latest_account_headers(conn, "id = ?", params![account_id.to_hex()])?
+        Ok(query_latest_account_headers(conn, "id = ?", params![account_id.to_bytes()])?
             .pop()
             .map(|(header, status, _)| (header, status)))
     }
@@ -109,7 +109,7 @@ impl SqliteStore {
         account_id: AccountId,
     ) -> Result<Option<AccountRecord>, StoreError> {
         let Some((header, status, client_account_type)) =
-            query_latest_account_headers(conn, "id = ?", params![account_id.to_hex()])?.pop()
+            query_latest_account_headers(conn, "id = ?", params![account_id.to_bytes()])?.pop()
         else {
             return Ok(None);
         };
@@ -146,7 +146,7 @@ impl SqliteStore {
         account_id: AccountId,
     ) -> Result<Option<AccountRecord>, StoreError> {
         let Some((header, status, client_account_type)) =
-            query_latest_account_headers(conn, "id = ?", params![account_id.to_hex()])?.pop()
+            query_latest_account_headers(conn, "id = ?", params![account_id.to_bytes()])?.pop()
         else {
             return Ok(None);
         };
@@ -196,7 +196,7 @@ impl SqliteStore {
         account_ids: Vec<AccountId>,
     ) -> Result<BTreeMap<AccountId, AccountCode>, StoreError> {
         let params: Vec<Value> =
-            account_ids.into_iter().map(|id| Value::from(id.to_hex())).collect();
+            account_ids.into_iter().map(|id| Value::Blob(id.to_bytes())).collect();
         const QUERY: &str = "
             SELECT account_id, code
             FROM foreign_account_code JOIN account_code ON foreign_account_code.code_commitment = account_code.commitment
@@ -208,13 +208,10 @@ impl SqliteStore {
             .expect("no binding parameters used in query")
             .map(|result| {
                 result.map_err(|err| StoreError::ParsingError(err.to_string())).and_then(
-                    |(id, code): (String, Vec<u8>)| {
+                    |(id, code): (Vec<u8>, Vec<u8>)| {
                         Ok((
-                            AccountId::from_hex(&id).map_err(|err| {
-                                StoreError::AccountError(
-                                    AccountError::FinalAccountHeaderIdParsingFailed(err),
-                                )
-                            })?,
+                            AccountId::read_from_bytes(&id)
+                                .map_err(StoreError::DataDeserializationError)?,
                             AccountCode::read_from_bytes(&code)
                                 .map_err(StoreError::DataDeserializationError)?,
                         ))
@@ -310,7 +307,7 @@ impl SqliteStore {
         account_id: AccountId,
     ) -> Result<Option<AccountCode>, StoreError> {
         let Some((header, ..)) =
-            query_latest_account_headers(conn, "id = ?", params![account_id.to_hex()])?
+            query_latest_account_headers(conn, "id = ?", params![account_id.to_bytes()])?
                 .into_iter()
                 .next()
         else {
@@ -358,16 +355,13 @@ impl SqliteStore {
         if conn
             .prepare(QUERY)
             .into_store_error()?
-            .query_map(params![new_account_state.id().to_hex()], |row| row.get(0))
+            .query_map(params![new_account_state.id().to_bytes()], |row| row.get(0))
             .into_store_error()?
             .map(|result| {
                 result.map_err(|err| StoreError::ParsingError(err.to_string())).and_then(
-                    |id: String| {
-                        AccountId::from_hex(&id).map_err(|err| {
-                            StoreError::AccountError(
-                                AccountError::FinalAccountHeaderIdParsingFailed(err),
-                            )
-                        })
+                    |id: Vec<u8>| {
+                        AccountId::read_from_bytes(&id)
+                            .map_err(StoreError::DataDeserializationError)
                     },
                 )
             })
@@ -394,7 +388,7 @@ impl SqliteStore {
         const QUERY: &str =
             insert_sql!(foreign_account_code { account_id, code_commitment } | REPLACE);
 
-        tx.execute(QUERY, params![account_id.to_hex(), code.commitment().to_string()])
+        tx.execute(QUERY, params![account_id.to_bytes(), code.commitment().to_string()])
             .into_store_error()?;
 
         Self::insert_account_code(&tx, code)?;
@@ -408,7 +402,7 @@ impl SqliteStore {
     ) -> Result<(), StoreError> {
         const QUERY: &str = insert_sql!(addresses { address, account_id } | REPLACE);
         let serialized_address = address.to_bytes();
-        tx.execute(QUERY, params![serialized_address, account_id.to_hex(),])
+        tx.execute(QUERY, params![serialized_address, account_id.to_bytes(),])
             .into_store_error()?;
 
         Ok(())
@@ -527,7 +521,7 @@ impl SqliteStore {
 
         // Step 1: Resolve (account_id, nonce) pairs from both latest and historical headers.
         // The most recent discarded state is in latest, older ones are in historical.
-        let mut id_nonce_pairs: Vec<(String, u64)> = Vec::new();
+        let mut id_nonce_pairs: Vec<(Vec<u8>, u64)> = Vec::new();
         for query in [
             "SELECT id, nonce FROM latest_account_headers WHERE account_commitment IN rarray(?)",
             "SELECT id, nonce FROM historical_account_headers WHERE account_commitment IN rarray(?)",
@@ -536,7 +530,7 @@ impl SqliteStore {
                 tx.prepare(query)
                     .into_store_error()?
                     .query_map(params![commitment_params.clone()], |row| {
-                        let id: String = row.get(0)?;
+                        let id: Vec<u8> = row.get(0)?;
                         let nonce: u64 = column_value_as_u64(row, 1)?;
                         Ok((id, nonce))
                     })
@@ -549,7 +543,7 @@ impl SqliteStore {
         // Descending order is needed because each nonce's old value is the state before
         // that nonce — processing most recent first lets earlier nonces overwrite with
         // the correct final value.
-        let mut nonces_by_account: BTreeMap<String, Vec<u64>> = BTreeMap::new();
+        let mut nonces_by_account: BTreeMap<Vec<u8>, Vec<u64>> = BTreeMap::new();
         for (id, nonce) in &id_nonce_pairs {
             nonces_by_account.entry(id.clone()).or_default().push(*nonce);
         }
@@ -560,8 +554,8 @@ impl SqliteStore {
         }
 
         // Steps 3-5
-        for (account_id_hex, nonces) in &nonces_by_account {
-            Self::undo_account_nonces(tx, account_id_hex, nonces)?;
+        for (account_id_bytes, nonces) in &nonces_by_account {
+            Self::undo_account_nonces(tx, account_id_bytes, nonces)?;
         }
 
         // Step 6: Discard rolled-back states from the in-memory forest
@@ -576,13 +570,13 @@ impl SqliteStore {
     /// and cleans up consumed historical entries.
     fn undo_account_nonces(
         tx: &Transaction<'_>,
-        account_id_hex: &str,
+        account_id_bytes: &[u8],
         nonces: &[u64],
     ) -> Result<(), StoreError> {
         // Step 3: Undo each nonce in descending order
         for &nonce in nonces {
             let nonce_val = u64_to_value(nonce);
-            Self::restore_old_values_for_nonce(tx, account_id_hex, &nonce_val)?;
+            Self::restore_old_values_for_nonce(tx, account_id_bytes, &nonce_val)?;
         }
 
         // Step 4: Restore old header from the earliest discarded nonce
@@ -596,7 +590,7 @@ impl SqliteStore {
             .query_row(
                 "SELECT COUNT(*) FROM historical_account_headers \
                  WHERE id = ? AND replaced_at_nonce = ?",
-                params![account_id_hex, &min_nonce_val],
+                params![account_id_bytes, &min_nonce_val],
                 |row| row.get::<_, i64>(0),
             )
             .into_store_error()?
@@ -614,7 +608,7 @@ impl SqliteStore {
                         vault_root, nonce, account_seed, locked \
                  FROM historical_account_headers \
                  WHERE id = ? AND replaced_at_nonce = ?",
-                params![account_id_hex, &min_nonce_val],
+                params![account_id_bytes, &min_nonce_val],
             )
             .into_store_error()?;
         } else {
@@ -625,7 +619,7 @@ impl SqliteStore {
                 "DELETE FROM latest_storage_map_entries WHERE account_id = ?",
                 "DELETE FROM latest_account_assets WHERE account_id = ?",
             ] {
-                tx.execute(table, params![account_id_hex]).into_store_error()?;
+                tx.execute(table, params![account_id_bytes]).into_store_error()?;
             }
         }
 
@@ -640,14 +634,14 @@ impl SqliteStore {
                 &format!(
                     "DELETE FROM {table} WHERE account_id = ? AND replaced_at_nonce IN rarray(?)"
                 ),
-                params![account_id_hex, nonce_params.clone()],
+                params![account_id_bytes, nonce_params.clone()],
             )
             .into_store_error()?;
         }
         tx.execute(
             "DELETE FROM historical_account_headers \
              WHERE id = ? AND replaced_at_nonce IN rarray(?)",
-            params![account_id_hex, nonce_params],
+            params![account_id_bytes, nonce_params],
         )
         .into_store_error()?;
 
@@ -658,7 +652,7 @@ impl SqliteStore {
     /// Non-NULL old values overwrite latest, NULL old values (new entries) are deleted.
     fn restore_old_values_for_nonce(
         tx: &Transaction<'_>,
-        account_id_hex: &str,
+        account_id_bytes: &[u8],
         nonce_val: &rusqlite::types::Value,
     ) -> Result<(), StoreError> {
         // Restore storage slots with non-NULL old values
@@ -668,7 +662,7 @@ impl SqliteStore {
              SELECT account_id, slot_name, old_slot_value, slot_type \
              FROM historical_account_storage \
              WHERE account_id = ? AND replaced_at_nonce = ? AND old_slot_value IS NOT NULL",
-            params![account_id_hex, nonce_val],
+            params![account_id_bytes, nonce_val],
         )
         .into_store_error()?;
 
@@ -679,7 +673,7 @@ impl SqliteStore {
                  SELECT slot_name FROM historical_account_storage \
                  WHERE account_id = ?1 AND replaced_at_nonce = ?2 AND old_slot_value IS NULL\
              )",
-            params![account_id_hex, nonce_val],
+            params![account_id_bytes, nonce_val],
         )
         .into_store_error()?;
 
@@ -690,7 +684,7 @@ impl SqliteStore {
              SELECT account_id, slot_name, key, old_value \
              FROM historical_storage_map_entries \
              WHERE account_id = ? AND replaced_at_nonce = ? AND old_value IS NOT NULL",
-            params![account_id_hex, nonce_val],
+            params![account_id_bytes, nonce_val],
         )
         .into_store_error()?;
 
@@ -704,7 +698,7 @@ impl SqliteStore {
                    AND h.key = latest_storage_map_entries.key \
                    AND h.replaced_at_nonce = ?2 AND h.old_value IS NULL\
              )",
-            params![account_id_hex, nonce_val],
+            params![account_id_bytes, nonce_val],
         )
         .into_store_error()?;
 
@@ -715,7 +709,7 @@ impl SqliteStore {
              SELECT account_id, vault_key, old_asset \
              FROM historical_account_assets \
              WHERE account_id = ? AND replaced_at_nonce = ? AND old_asset IS NOT NULL",
-            params![account_id_hex, nonce_val],
+            params![account_id_bytes, nonce_val],
         )
         .into_store_error()?;
 
@@ -726,7 +720,7 @@ impl SqliteStore {
                  SELECT vault_key FROM historical_account_assets \
                  WHERE account_id = ?1 AND replaced_at_nonce = ?2 AND old_asset IS NULL\
              )",
-            params![account_id_hex, nonce_val],
+            params![account_id_bytes, nonce_val],
         )
         .into_store_error()?;
 
@@ -743,11 +737,11 @@ impl SqliteStore {
         new_account_state: &Account,
     ) -> Result<(), StoreError> {
         let account_id = new_account_state.id();
-        let account_id_hex = account_id.to_hex();
+        let account_id_bytes = account_id.to_bytes();
 
         // Read old header before mutating the SMT snapshot or database rows. Sync filters stale
         // full-account snapshots; if one still reaches storage, reject it before mutating.
-        let old_header = query_latest_account_headers(tx, "id = ?", params![&account_id_hex])?
+        let old_header = query_latest_account_headers(tx, "id = ?", params![&account_id_bytes])?
             .into_iter()
             .next()
             .map(|(header, ..)| header)
@@ -777,7 +771,7 @@ impl SqliteStore {
              (account_id, replaced_at_nonce, slot_name, old_slot_value, slot_type) \
              SELECT account_id, ?, slot_name, slot_value, slot_type \
              FROM latest_account_storage WHERE account_id = ?",
-            params![&nonce_val, &account_id_hex],
+            params![&nonce_val, &account_id_bytes],
         )
         .into_store_error()?;
         tx.execute(
@@ -785,7 +779,7 @@ impl SqliteStore {
              (account_id, replaced_at_nonce, slot_name, key, old_value) \
              SELECT account_id, ?, slot_name, key, value \
              FROM latest_storage_map_entries WHERE account_id = ?",
-            params![&nonce_val, &account_id_hex],
+            params![&nonce_val, &account_id_bytes],
         )
         .into_store_error()?;
         tx.execute(
@@ -793,24 +787,24 @@ impl SqliteStore {
              (account_id, replaced_at_nonce, vault_key, old_asset) \
              SELECT account_id, ?, vault_key, asset \
              FROM latest_account_assets WHERE account_id = ?",
-            params![&nonce_val, &account_id_hex],
+            params![&nonce_val, &account_id_bytes],
         )
         .into_store_error()?;
 
         // Delete all latest entries for this account
         tx.execute(
             "DELETE FROM latest_account_storage WHERE account_id = ?",
-            params![&account_id_hex],
+            params![&account_id_bytes],
         )
         .into_store_error()?;
         tx.execute(
             "DELETE FROM latest_storage_map_entries WHERE account_id = ?",
-            params![&account_id_hex],
+            params![&account_id_bytes],
         )
         .into_store_error()?;
         tx.execute(
             "DELETE FROM latest_account_assets WHERE account_id = ?",
-            params![&account_id_hex],
+            params![&account_id_bytes],
         )
         .into_store_error()?;
 
@@ -825,7 +819,7 @@ impl SqliteStore {
              (account_id, replaced_at_nonce, slot_name, old_slot_value, slot_type) \
              SELECT account_id, ?, slot_name, NULL, slot_type \
              FROM latest_account_storage WHERE account_id = ?",
-            params![&nonce_val, &account_id_hex],
+            params![&nonce_val, &account_id_bytes],
         )
         .into_store_error()?;
         tx.execute(
@@ -833,7 +827,7 @@ impl SqliteStore {
              (account_id, replaced_at_nonce, slot_name, key, old_value) \
              SELECT account_id, ?, slot_name, key, NULL \
              FROM latest_storage_map_entries WHERE account_id = ?",
-            params![&nonce_val, &account_id_hex],
+            params![&nonce_val, &account_id_bytes],
         )
         .into_store_error()?;
         tx.execute(
@@ -841,7 +835,7 @@ impl SqliteStore {
              (account_id, replaced_at_nonce, vault_key, old_asset) \
              SELECT account_id, ?, vault_key, NULL \
              FROM latest_account_assets WHERE account_id = ?",
-            params![&nonce_val, &account_id_hex],
+            params![&nonce_val, &account_id_bytes],
         )
         .into_store_error()?;
 
@@ -861,11 +855,12 @@ impl SqliteStore {
         let account_id = new_header.id();
 
         // Read current header from the store.
-        let init_header = query_latest_account_headers(tx, "id = ?", params![account_id.to_hex()])?
-            .into_iter()
-            .next()
-            .map(|(header, ..)| header)
-            .ok_or(StoreError::AccountDataNotFound(account_id))?;
+        let init_header =
+            query_latest_account_headers(tx, "id = ?", params![account_id.to_bytes()])?
+                .into_iter()
+                .next()
+                .map(|(header, ..)| header)
+                .ok_or(StoreError::AccountDataNotFound(account_id))?;
 
         // Read the fungible assets that will be affected by the delta.
         // Transaction derefs to Connection, so we can pass it where Connection is expected.
@@ -897,10 +892,10 @@ impl SqliteStore {
         // tracked in the db and corresponds to the mismatched account, it means we
         // got a past update and shouldn't lock the account.
         const LOCK_CONDITION: &str = "WHERE id = :account_id AND NOT EXISTS (SELECT 1 FROM historical_account_headers WHERE id = :account_id AND account_commitment = :digest)";
-        let account_id_hex = account_id.to_hex();
+        let account_id_bytes = account_id.to_bytes();
         let digest_str = mismatched_digest.to_string();
         let params = named_params! {
-            ":account_id": account_id_hex,
+            ":account_id": account_id_bytes,
             ":digest": digest_str
         };
 
@@ -928,7 +923,7 @@ impl SqliteStore {
         account_seed: Option<Word>,
         watched: bool,
     ) -> Result<(), StoreError> {
-        let id = new_header.id().to_hex();
+        let id = new_header.id().to_bytes();
         let code_commitment = new_header.code_commitment().to_string();
         let storage_commitment = new_header.storage_commitment().to_string();
         let vault_root = new_header.vault_root().to_string();
@@ -995,7 +990,7 @@ impl SqliteStore {
             )));
         }
 
-        let id_hex = new_header.id().to_hex();
+        let id_bytes = new_header.id().to_bytes();
 
         // `AccountHeader` doesn't carry the seed or per-account flags, so read them from the row
         // we're about to overwrite: `account_seed`/`locked` get archived into the historical row,
@@ -1003,7 +998,7 @@ impl SqliteStore {
         let (old_seed, old_locked, old_watched): (Option<Vec<u8>>, bool, bool) = tx
             .query_row(
                 "SELECT account_seed, locked, watched FROM latest_account_headers WHERE id = ?",
-                params![&id_hex],
+                params![&id_bytes],
                 |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
             )
             .optional()
@@ -1011,7 +1006,7 @@ impl SqliteStore {
             .unwrap_or((None, false, false));
 
         // Archive the old header to historical.
-        let old_id = old_header.id().to_hex();
+        let old_id = old_header.id().to_bytes();
         let old_code_commitment = old_header.code_commitment().to_string();
         let old_storage_commitment = old_header.storage_commitment().to_string();
         let old_vault_root = old_header.vault_root().to_string();
@@ -1064,7 +1059,7 @@ impl SqliteStore {
         up_to_nonce: Felt,
     ) -> Result<usize, StoreError> {
         let tx = conn.transaction().into_store_error()?;
-        let account_id_hex = account_id.to_hex();
+        let account_id_bytes = account_id.to_bytes();
         let boundary_val = u64_to_value(up_to_nonce.as_canonical_u64());
         let mut total_deleted: usize = 0;
 
@@ -1077,7 +1072,7 @@ impl SqliteStore {
                 )
                 .into_store_error()?;
             let rows = stmt
-                .query_map(params![&account_id_hex, &boundary_val], |row| row.get(0))
+                .query_map(params![&account_id_bytes, &boundary_val], |row| row.get(0))
                 .into_store_error()?;
             rows.collect::<Result<Vec<String>, _>>().into_store_error()?
         };
@@ -1087,7 +1082,7 @@ impl SqliteStore {
             .execute(
                 "DELETE FROM historical_account_headers \
                  WHERE id = ? AND replaced_at_nonce <= ?",
-                params![&account_id_hex, &boundary_val],
+                params![&account_id_bytes, &boundary_val],
             )
             .into_store_error()?;
 
@@ -1095,7 +1090,7 @@ impl SqliteStore {
             .execute(
                 "DELETE FROM historical_account_storage \
                  WHERE account_id = ? AND replaced_at_nonce <= ?",
-                params![&account_id_hex, &boundary_val],
+                params![&account_id_bytes, &boundary_val],
             )
             .into_store_error()?;
 
@@ -1103,7 +1098,7 @@ impl SqliteStore {
             .execute(
                 "DELETE FROM historical_storage_map_entries \
                  WHERE account_id = ? AND replaced_at_nonce <= ?",
-                params![&account_id_hex, &boundary_val],
+                params![&account_id_bytes, &boundary_val],
             )
             .into_store_error()?;
 
@@ -1111,7 +1106,7 @@ impl SqliteStore {
             .execute(
                 "DELETE FROM historical_account_assets \
                  WHERE account_id = ? AND replaced_at_nonce <= ?",
-                params![&account_id_hex, &boundary_val],
+                params![&account_id_bytes, &boundary_val],
             )
             .into_store_error()?;
 

--- a/crates/sqlite-store/src/account/helpers.rs
+++ b/crates/sqlite-store/src/account/helpers.rs
@@ -15,14 +15,15 @@ use miden_client::account::{
 };
 use miden_client::asset::Asset;
 use miden_client::store::{AccountStatus, AccountStorageFilter, ClientAccountType, StoreError};
-use miden_client::{Deserializable, Word};
+use miden_client::{Deserializable, Serializable, Word};
+use rusqlite::types::Value;
 use rusqlite::{Connection, Params, params, params_from_iter};
 
 use crate::column_value_as_u64;
 use crate::sql_error::SqlResultExt;
 
 pub(crate) struct SerializedHeaderData {
-    pub id: String,
+    pub id: Vec<u8>,
     pub nonce: u64,
     pub vault_root: String,
     pub storage_commitment: String,
@@ -55,7 +56,8 @@ pub(crate) fn parse_accounts(
     let nonce = miden_client::Felt::new(nonce).expect("stored nonce must be a valid Felt");
     Ok((
         AccountHeader::new(
-            AccountId::from_hex(&id).expect("Conversion from stored AccountID should not panic"),
+            AccountId::read_from_bytes(&id)
+                .expect("Conversion from stored AccountID should not panic"),
             nonce,
             Word::try_from(&vault_root)?,
             Word::try_from(&storage_commitment)?,
@@ -80,7 +82,7 @@ pub(crate) fn query_latest_account_headers(
     conn.prepare(&query)
         .into_store_error()?
         .query_map(params, |row| {
-            let id: String = row.get(0)?;
+            let id: Vec<u8> = row.get(0)?;
             let nonce: u64 = column_value_as_u64(row, 1)?;
             let vault_root: String = row.get(2)?;
             let storage_commitment: String = row.get(3)?;
@@ -128,7 +130,7 @@ pub(crate) fn query_historical_account_headers(
     conn.prepare(&query)
         .into_store_error()?
         .query_map(params, |row| {
-            let id: String = row.get(0)?;
+            let id: Vec<u8> = row.get(0)?;
             let nonce: u64 = column_value_as_u64(row, 1)?;
             let vault_root: String = row.get(2)?;
             let storage_commitment: String = row.get(3)?;
@@ -182,7 +184,7 @@ pub(crate) fn query_account_addresses(
 
     conn.prepare_cached(ADDRESS_QUERY)
         .into_store_error()?
-        .query_map(params![account_id.to_hex()], |row| {
+        .query_map(params![account_id.to_bytes()], |row| {
             let address: Vec<u8> = row.get(0)?;
             Ok(address)
         })
@@ -204,7 +206,7 @@ pub(crate) fn query_vault_assets(
 
     conn.prepare(VAULT_QUERY)
         .into_store_error()?
-        .query_map(params![account_id.to_hex()], |row| {
+        .query_map(params![account_id.to_bytes()], |row| {
             let vault_key: String = row.get(0)?;
             let asset: String = row.get(1)?;
             Ok((vault_key, asset))
@@ -224,16 +226,14 @@ pub(crate) fn query_storage_slots(
     account_id: AccountId,
     filter: &AccountStorageFilter,
 ) -> Result<BTreeMap<StorageSlotName, StorageSlot>, StoreError> {
-    let account_id_hex = account_id.to_hex();
-
     // Build storage values query with filter pushed to SQL
     let base_query =
         "SELECT slot_name, slot_value, slot_type FROM latest_account_storage WHERE account_id = ?1";
-    let mut values_params: Vec<String> = vec![account_id_hex];
+    let mut values_params: Vec<Value> = vec![Value::Blob(account_id.to_bytes())];
     let query = match filter {
         AccountStorageFilter::All => base_query.to_string(),
         AccountStorageFilter::SlotName(name) => {
-            values_params.push(name.to_string());
+            values_params.push(Value::Text(name.to_string()));
             format!("{base_query} AND slot_name = ?2")
         },
         AccountStorageFilter::SlotNames(names) => {
@@ -243,12 +243,12 @@ pub(crate) fn query_storage_slots(
             let placeholders =
                 (0..names.len()).map(|i| format!("?{}", i + 2)).collect::<Vec<_>>().join(", ");
             for name in names {
-                values_params.push(name.to_string());
+                values_params.push(Value::Text(name.to_string()));
             }
             format!("{base_query} AND slot_name IN ({placeholders})")
         },
         AccountStorageFilter::Root(root) => {
-            values_params.push(root.to_hex());
+            values_params.push(Value::Text(root.to_hex()));
             format!("{base_query} AND slot_value = ?2")
         },
     };
@@ -310,10 +310,9 @@ pub(crate) fn query_storage_maps(
     account_id: AccountId,
     slot_name_filter: Option<&[String]>,
 ) -> Result<BTreeMap<StorageSlotName, StorageMap>, StoreError> {
-    let account_id_hex = account_id.to_hex();
     let base_query =
         "SELECT slot_name, key, value FROM latest_storage_map_entries WHERE account_id = ?1";
-    let mut map_params: Vec<String> = vec![account_id_hex];
+    let mut map_params: Vec<Value> = vec![Value::Blob(account_id.to_bytes())];
     let query = match slot_name_filter {
         Some(names) => {
             if names.is_empty() {
@@ -322,7 +321,7 @@ pub(crate) fn query_storage_maps(
             let placeholders =
                 (0..names.len()).map(|i| format!("?{}", i + 2)).collect::<Vec<_>>().join(", ");
             for name in names {
-                map_params.push(name.clone());
+                map_params.push(Value::Text(name.clone()));
             }
             format!("{base_query} AND slot_name IN ({placeholders})")
         },
@@ -365,7 +364,7 @@ pub(crate) fn query_storage_values(
 
     conn.prepare(STORAGE_QUERY)
         .into_store_error()?
-        .query_map(params![account_id.to_hex()], |row| {
+        .query_map(params![account_id.to_bytes()], |row| {
             let slot_name: String = row.get(0)?;
             let value: String = row.get(1)?;
             let slot_type: u8 = row.get(2)?;

--- a/crates/sqlite-store/src/account/storage.rs
+++ b/crates/sqlite-store/src/account/storage.rs
@@ -15,7 +15,7 @@ use miden_client::account::{
     StorageSlotType,
 };
 use miden_client::store::{AccountSmtForest, StoreError};
-use miden_client::{EMPTY_WORD, Word};
+use miden_client::{EMPTY_WORD, Serializable, Word};
 use rusqlite::types::Value;
 use rusqlite::{OptionalExtension, Transaction, params};
 
@@ -51,7 +51,7 @@ impl SqliteStore {
 
         conn.prepare(QUERY)
             .into_store_error()?
-            .query_map(params![account_id.to_hex(), Rc::new(map_slot_names)], |row| {
+            .query_map(params![account_id.to_bytes(), Rc::new(map_slot_names)], |row| {
                 let name: String = row.get(0)?;
                 let value: String = row.get(1)?;
                 Ok((name, value))
@@ -90,7 +90,7 @@ impl SqliteStore {
 
         let mut latest_slot_stmt = tx.prepare_cached(LATEST_SLOT_QUERY).into_store_error()?;
         let mut latest_map_stmt = tx.prepare_cached(LATEST_MAP_ENTRY_QUERY).into_store_error()?;
-        let account_id_hex = account_id.to_hex();
+        let account_id_bytes = account_id.to_bytes();
 
         for slot in account_storage {
             let slot_name_str = slot.name().to_string();
@@ -98,14 +98,14 @@ impl SqliteStore {
             let slot_type_val = slot.slot_type() as u8;
 
             latest_slot_stmt
-                .execute(params![&account_id_hex, &slot_name_str, &slot_value_hex, slot_type_val])
+                .execute(params![&account_id_bytes, &slot_name_str, &slot_value_hex, slot_type_val])
                 .into_store_error()?;
 
             if let StorageSlotContent::Map(map) = slot.content() {
                 for (key, value) in map.entries() {
                     latest_map_stmt
                         .execute(params![
-                            &account_id_hex,
+                            &account_id_bytes,
                             &slot_name_str,
                             key.to_hex(),
                             value.to_hex(),
@@ -166,7 +166,7 @@ impl SqliteStore {
         let mut hist_slot_stmt = tx.prepare_cached(HISTORICAL_SLOT_QUERY).into_store_error()?;
         let mut latest_map_stmt = tx.prepare_cached(LATEST_MAP_ENTRY_QUERY).into_store_error()?;
         let mut hist_map_stmt = tx.prepare_cached(HISTORICAL_MAP_ENTRY_QUERY).into_store_error()?;
-        let account_id_hex = account_id.to_hex();
+        let account_id_bytes = account_id.to_bytes();
         let nonce_val = u64_to_value(nonce);
 
         // Collect the delta's changed map entries for efficient lookup
@@ -190,7 +190,7 @@ impl SqliteStore {
 
             // Read old slot value from latest (NULL if slot is new)
             let old_slot_value: Option<String> = tx
-                .query_row(READ_OLD_SLOT, params![&account_id_hex, &slot_name_str], |row| {
+                .query_row(READ_OLD_SLOT, params![&account_id_bytes, &slot_name_str], |row| {
                     row.get(0)
                 })
                 .optional()
@@ -200,7 +200,7 @@ impl SqliteStore {
             // Archive old value to historical (NULL old_slot_value = slot was new)
             hist_slot_stmt
                 .execute(params![
-                    &account_id_hex,
+                    &account_id_bytes,
                     &nonce_val,
                     &slot_name_str,
                     old_slot_value,
@@ -210,7 +210,7 @@ impl SqliteStore {
 
             // Update latest slot
             latest_slot_stmt
-                .execute(params![&account_id_hex, &slot_name_str, &slot_value_hex, slot_type_val])
+                .execute(params![&account_id_bytes, &slot_name_str, &slot_value_hex, slot_type_val])
                 .into_store_error()?;
 
             if let Some(changed_entries) = delta_map_entries.get(slot_name) {
@@ -218,7 +218,7 @@ impl SqliteStore {
                     tx,
                     &mut latest_map_stmt,
                     &mut hist_map_stmt,
-                    &account_id_hex,
+                    &account_id_bytes,
                     &nonce_val,
                     &slot_name_str,
                     changed_entries,
@@ -234,7 +234,7 @@ impl SqliteStore {
         tx: &Transaction<'_>,
         latest_map_stmt: &mut rusqlite::CachedStatement<'_>,
         hist_map_stmt: &mut rusqlite::CachedStatement<'_>,
-        account_id_hex: &str,
+        account_id_bytes: &[u8],
         nonce_val: &rusqlite::types::Value,
         slot_name_str: &str,
         changed_entries: &[(Word, Word)],
@@ -249,7 +249,7 @@ impl SqliteStore {
             let old_entry_value: Option<String> = tx
                 .query_row(
                     READ_OLD_MAP_ENTRY,
-                    params![account_id_hex, slot_name_str, &key_hex],
+                    params![account_id_bytes, slot_name_str, &key_hex],
                     |row| row.get(0),
                 )
                 .optional()
@@ -259,7 +259,7 @@ impl SqliteStore {
             // Archive old value to historical (NULL = entry was new)
             hist_map_stmt
                 .execute(params![
-                    account_id_hex,
+                    account_id_bytes,
                     nonce_val,
                     slot_name_str,
                     &key_hex,
@@ -271,12 +271,12 @@ impl SqliteStore {
             if *value == EMPTY_WORD {
                 tx.execute(
                     DELETE_LATEST_MAP_ENTRY,
-                    params![account_id_hex, slot_name_str, &key_hex],
+                    params![account_id_bytes, slot_name_str, &key_hex],
                 )
                 .into_store_error()?;
             } else {
                 latest_map_stmt
-                    .execute(params![account_id_hex, slot_name_str, &key_hex, value.to_hex(),])
+                    .execute(params![account_id_bytes, slot_name_str, &key_hex, value.to_hex(),])
                     .into_store_error()?;
             }
         }

--- a/crates/sqlite-store/src/account/tests.rs
+++ b/crates/sqlite-store/src/account/tests.rs
@@ -31,7 +31,7 @@ use miden_client::asset::{
 use miden_client::auth::{AuthSchemeId, AuthSingleSig, PublicKeyCommitment};
 use miden_client::store::{ClientAccountType, Store, StoreError};
 use miden_client::testing::common::ACCOUNT_ID_REGULAR;
-use miden_client::{EMPTY_WORD, Felt, ONE, ZERO};
+use miden_client::{EMPTY_WORD, Felt, ONE, Serializable, ZERO};
 use miden_protocol::account::AccountComponentMetadata;
 use miden_protocol::asset::AssetCallbackFlag;
 use miden_protocol::testing::account_id::{
@@ -802,7 +802,7 @@ async fn prune_account_history_removes_old_committed_states() -> anyhow::Result<
         .interact_with_connection(move |conn| {
             conn.query_row(
                 "SELECT nonce FROM historical_account_headers WHERE id = ?",
-                params![account_id.to_hex()],
+                params![account_id.to_bytes()],
                 |row| crate::column_value_as_u64(row, 0),
             )
             .into_store_error()
@@ -926,7 +926,7 @@ async fn prune_removes_orphaned_account_code() -> anyhow::Result<()> {
         .interact_with_connection(move |conn| {
             conn.query_row(
                 "SELECT code_commitment FROM historical_account_headers WHERE id = ?",
-                params![account_id.to_hex()],
+                params![account_id.to_bytes()],
                 |row| row.get(0),
             )
             .into_store_error()
@@ -944,7 +944,7 @@ async fn prune_removes_orphaned_account_code() -> anyhow::Result<()> {
             .into_store_error()?;
             conn.execute(
                 "UPDATE latest_account_headers SET code_commitment = ? WHERE id = ?",
-                params!["new_code_commitment", account_id.to_hex()],
+                params!["new_code_commitment", account_id.to_bytes()],
             )
             .into_store_error()?;
             Ok(())
@@ -1406,7 +1406,7 @@ async fn lock_account_affects_latest_and_historical() -> anyhow::Result<()> {
                 )
                 .into_store_error()?;
             let rows = stmt
-                .query_map(params![account_id.to_hex()], |row| row.get(0))
+                .query_map(params![account_id.to_bytes()], |row| row.get(0))
                 .into_store_error()?
                 .collect::<Result<Vec<bool>, _>>()
                 .into_store_error()?;
@@ -1961,7 +1961,7 @@ async fn undo_after_update_removes_genuinely_new_entries() -> anyhow::Result<()>
             conn.query_row(
                 "SELECT COUNT(*) FROM historical_storage_map_entries \
                  WHERE account_id = ? AND old_value IS NULL",
-                params![account_id.to_hex()],
+                params![account_id.to_bytes()],
                 |row| row.get(0),
             )
             .into_store_error()

--- a/crates/sqlite-store/src/account/vault.rs
+++ b/crates/sqlite-store/src/account/vault.rs
@@ -4,10 +4,10 @@ use std::collections::BTreeMap;
 use std::rc::Rc;
 use std::vec::Vec;
 
-use miden_client::Word;
 use miden_client::account::{AccountDelta, AccountHeader, AccountId};
 use miden_client::asset::{Asset, FungibleAsset, NonFungibleDeltaAction};
 use miden_client::store::{AccountSmtForest, StoreError};
+use miden_client::{Serializable, Word};
 use miden_protocol::asset::AssetVaultKey;
 use miden_protocol::crypto::merkle::MerkleError;
 use rusqlite::types::Value;
@@ -39,7 +39,7 @@ impl SqliteStore {
         Ok(conn
             .prepare(QUERY)
             .into_store_error()?
-            .query_map(params![account_id.to_hex(), Rc::new(vault_keys)], |row| {
+            .query_map(params![account_id.to_bytes(), Rc::new(vault_keys)], |row| {
                 let vault_key: String = row.get(0)?;
                 let asset: String = row.get(1)?;
                 Ok((vault_key, asset))
@@ -73,14 +73,14 @@ impl SqliteStore {
             insert_sql!(latest_account_assets { account_id, vault_key, asset } | REPLACE);
 
         let mut latest_stmt = tx.prepare_cached(LATEST_QUERY).into_store_error()?;
-        let account_id_hex = account_id.to_hex();
+        let account_id_bytes = account_id.to_bytes();
 
         for asset in assets {
             let vault_key_hex = asset.vault_key().to_string();
             let asset_hex = asset.to_value_word().to_hex();
 
             latest_stmt
-                .execute(params![&account_id_hex, &vault_key_hex, &asset_hex])
+                .execute(params![&account_id_bytes, &vault_key_hex, &asset_hex])
                 .into_store_error()?;
         }
 
@@ -102,7 +102,7 @@ impl SqliteStore {
         delta: &AccountDelta,
     ) -> Result<(), StoreError> {
         let nonce = final_account_state.nonce().as_canonical_u64();
-        let account_id_hex = account_id.to_hex();
+        let account_id_bytes = account_id.to_bytes();
         let nonce_val = u64_to_value(nonce);
 
         // Apply vault delta. This map will contain all updated assets (indexed by vault key), both
@@ -157,7 +157,7 @@ impl SqliteStore {
         let updated_assets_values: Vec<Asset> = updated_assets.values().copied().collect();
         Self::persist_vault_delta(
             tx,
-            &account_id_hex,
+            &account_id_bytes,
             &nonce_val,
             &removed_vault_keys,
             &updated_assets_values,
@@ -182,7 +182,7 @@ impl SqliteStore {
     /// then updates latest (deletes removed assets, inserts/updates changed assets).
     fn persist_vault_delta(
         tx: &Transaction<'_>,
-        account_id_hex: &str,
+        account_id_bytes: &[u8],
         nonce_val: &rusqlite::types::Value,
         removed_vault_keys: &[AssetVaultKey],
         updated_assets: &[Asset],
@@ -209,7 +209,7 @@ impl SqliteStore {
 
             // Read old asset value from latest (should exist since we're removing it)
             let old_asset: Option<String> = tx
-                .query_row(READ_OLD_ASSET, params![account_id_hex, &vault_key_hex], |row| {
+                .query_row(READ_OLD_ASSET, params![account_id_bytes, &vault_key_hex], |row| {
                     row.get(0)
                 })
                 .optional()
@@ -218,7 +218,7 @@ impl SqliteStore {
 
             // Archive old value to historical
             hist_stmt
-                .execute(params![account_id_hex, nonce_val, &vault_key_hex, old_asset,])
+                .execute(params![account_id_bytes, nonce_val, &vault_key_hex, old_asset,])
                 .into_store_error()?;
         }
 
@@ -229,7 +229,7 @@ impl SqliteStore {
             tx.execute(
                 DELETE_LATEST_QUERY,
                 params![
-                    account_id_hex,
+                    account_id_bytes,
                     Rc::new(
                         removed_vault_keys
                             .iter()
@@ -248,7 +248,7 @@ impl SqliteStore {
 
             // Read old asset value from latest (NULL if asset is new)
             let old_asset: Option<String> = tx
-                .query_row(READ_OLD_ASSET, params![account_id_hex, &vault_key_hex], |row| {
+                .query_row(READ_OLD_ASSET, params![account_id_bytes, &vault_key_hex], |row| {
                     row.get(0)
                 })
                 .optional()
@@ -257,12 +257,12 @@ impl SqliteStore {
 
             // Archive old value to historical (NULL old_asset = asset was new)
             hist_stmt
-                .execute(params![account_id_hex, nonce_val, &vault_key_hex, old_asset,])
+                .execute(params![account_id_bytes, nonce_val, &vault_key_hex, old_asset,])
                 .into_store_error()?;
 
             // Insert/update in latest
             latest_stmt
-                .execute(params![account_id_hex, &vault_key_hex, &asset_hex])
+                .execute(params![account_id_bytes, &vault_key_hex, &asset_hex])
                 .into_store_error()?;
         }
 

--- a/crates/sqlite-store/src/note/filters.rs
+++ b/crates/sqlite-store/src/note/filters.rs
@@ -3,8 +3,10 @@
 
 use std::rc::Rc;
 
+use miden_client::account::AccountId;
 use miden_client::note::BlockNumber;
 use miden_client::store::{InputNoteState, NoteFilter, OutputNoteState};
+use miden_client::utils::Serializable;
 use rusqlite::types::Value;
 
 type NoteQueryParams = Vec<Rc<Vec<Value>>>;
@@ -130,7 +132,7 @@ pub(super) fn note_filter_to_query_input_notes(filter: &NoteFilter) -> (String, 
 /// restricted to a consumer account and optionally to a block range.
 pub(super) fn note_filter_to_query_input_note_by_offset(
     filter: &NoteFilter,
-    consumer: &str,
+    consumer: AccountId,
     block_start: Option<BlockNumber>,
     block_end: Option<BlockNumber>,
     offset: u32,
@@ -138,7 +140,7 @@ pub(super) fn note_filter_to_query_input_note_by_offset(
     use core::fmt::Write;
     let (mut condition, mut params) = note_filter_input_notes_condition(filter);
 
-    params.push(Rc::new(vec![Value::Text(consumer.to_string())]));
+    params.push(Rc::new(vec![Value::Blob(consumer.to_bytes())]));
     condition.push_str(" AND note.consumer_account_id IN rarray(?)");
     condition.push_str(" AND note.consumed_tx_order IS NOT NULL");
 

--- a/crates/sqlite-store/src/note/mod.rs
+++ b/crates/sqlite-store/src/note/mod.rs
@@ -71,7 +71,7 @@ struct SerializedInputNoteData {
     pub created_at: u64,
     pub consumed_block_height: Option<u32>,
     pub consumed_tx_order: Option<u32>,
-    pub consumer_account_id: Option<String>,
+    pub consumer_account_id: Option<Vec<u8>>,
 }
 
 /// Represents an `OutputNoteRecord` serialized to be stored in the database.
@@ -116,7 +116,7 @@ struct SerializedInputNoteStateUpdate {
     pub state: Vec<u8>,
     pub consumed_block_height: Option<u32>,
     pub consumed_tx_order: Option<u32>,
-    pub consumer_account_id: Option<String>,
+    pub consumer_account_id: Option<Vec<u8>>,
 }
 
 /// Represents the fields needed to update an existing output note's state.
@@ -178,10 +178,9 @@ impl SqliteStore {
         block_end: Option<BlockNumber>,
         offset: u32,
     ) -> Result<Option<InputNoteRecord>, StoreError> {
-        let consumer_hex = consumer.to_hex();
         let (query, params) = filters::note_filter_to_query_input_note_by_offset(
             filter,
-            &consumer_hex,
+            consumer,
             block_start,
             block_end,
             offset,
@@ -226,9 +225,9 @@ impl SqliteStore {
         const QUERY: &str =
             "SELECT nullifier FROM input_notes WHERE state_discriminant NOT IN rarray(?)";
         let unspent_filters = Rc::new(vec![
-            Value::from(InputNoteState::STATE_CONSUMED_AUTHENTICATED_LOCAL.to_string()),
-            Value::from(InputNoteState::STATE_CONSUMED_UNAUTHENTICATED_LOCAL.to_string()),
-            Value::from(InputNoteState::STATE_CONSUMED_EXTERNAL.to_string()),
+            Value::from(InputNoteState::STATE_CONSUMED_AUTHENTICATED_LOCAL),
+            Value::from(InputNoteState::STATE_CONSUMED_UNAUTHENTICATED_LOCAL),
+            Value::from(InputNoteState::STATE_CONSUMED_EXTERNAL),
         ]);
         conn.prepare(QUERY)
             .into_store_error()?
@@ -433,7 +432,7 @@ fn serialize_input_note(note: &InputNoteRecord) -> SerializedInputNoteData {
 
     let consumed_block_height = note.state().consumed_block_height().map(|h| h.as_u32());
     let consumed_tx_order = note.state().consumed_tx_order();
-    let consumer_account_id = note.consumer_account().map(AccountId::to_hex);
+    let consumer_account_id = note.consumer_account().map(|id| id.to_bytes());
 
     SerializedInputNoteData {
         details_commitment,
@@ -508,7 +507,7 @@ fn parse_output_note(
 fn serialize_input_note_state(note: &InputNoteRecord) -> SerializedInputNoteStateUpdate {
     let consumed_block_height = note.state().consumed_block_height().map(|h| h.as_u32());
     let consumed_tx_order = note.state().consumed_tx_order();
-    let consumer_account_id = note.consumer_account().map(AccountId::to_hex);
+    let consumer_account_id = note.consumer_account().map(|id| id.to_bytes());
 
     SerializedInputNoteStateUpdate {
         details_commitment: note.details_commitment().to_hex(),
@@ -688,7 +687,7 @@ fn batch_insert_input_notes(
                 None => param_values.push(Value::Null),
             }
             match &note.consumer_account_id {
-                Some(id) => param_values.push(Value::Text(id.clone())),
+                Some(id) => param_values.push(Value::Blob(id.clone())),
                 None => param_values.push(Value::Null),
             }
         }

--- a/crates/sqlite-store/src/store.sql
+++ b/crates/sqlite-store/src/store.sql
@@ -63,7 +63,7 @@ CREATE INDEX idx_historical_account_headers_id_replaced_at ON historical_account
 -- ── Account storage (latest + historical) ────────────────────────────────
 
 CREATE TABLE latest_account_storage (
-    account_id BLOB NOT NULL,     -- account ID
+    account_id BLOB NOT NULL,     -- serialized account ID
     slot_name TEXT NOT NULL,      -- name of the storage slot
     slot_value TEXT NULL,         -- top-level value of the slot (for maps, contains the root)
     slot_type INTEGER NOT NULL,   -- type of the slot (0 = Value, 1 = Map)
@@ -73,7 +73,7 @@ CREATE TABLE latest_account_storage (
 -- Historical account storage: stores old slot values that were replaced.
 -- NULL old_slot_value means the slot didn't exist before (was created at replaced_at_nonce).
 CREATE TABLE historical_account_storage (
-    account_id BLOB NOT NULL,           -- account ID
+    account_id BLOB NOT NULL,           -- serialized account ID
     replaced_at_nonce BIGINT NOT NULL,  -- nonce at which this old value was replaced
     slot_name TEXT NOT NULL,            -- name of the storage slot
     old_slot_value TEXT NULL,           -- old top-level value (NULL = slot was new)

--- a/crates/sqlite-store/src/store.sql
+++ b/crates/sqlite-store/src/store.sql
@@ -28,7 +28,7 @@ CREATE TABLE account_code (
 
 -- Latest account header: one row per account (current state).
 CREATE TABLE latest_account_headers (
-    id UNSIGNED BIG INT NOT NULL,            -- account ID
+    id BLOB NOT NULL,                        -- serialized account ID
     account_commitment TEXT NOT NULL UNIQUE,  -- account state commitment
     code_commitment TEXT NOT NULL,            -- commitment to the account code
     storage_commitment TEXT NOT NULL,         -- commitment to the account storage
@@ -44,7 +44,7 @@ CREATE TABLE latest_account_headers (
 -- Historical account headers: stores old headers that were replaced by newer states.
 -- Each row represents a previous account state that was superseded at replaced_at_nonce.
 CREATE TABLE historical_account_headers (
-    id UNSIGNED BIG INT NOT NULL,            -- account ID
+    id BLOB NOT NULL,                        -- serialized account ID
     account_commitment TEXT NOT NULL UNIQUE,  -- commitment of this old state
     code_commitment TEXT NOT NULL,            -- commitment to the old account code
     storage_commitment TEXT NOT NULL,         -- commitment to the old account storage
@@ -63,7 +63,7 @@ CREATE INDEX idx_historical_account_headers_id_replaced_at ON historical_account
 -- ── Account storage (latest + historical) ────────────────────────────────
 
 CREATE TABLE latest_account_storage (
-    account_id TEXT NOT NULL,     -- account ID
+    account_id BLOB NOT NULL,     -- account ID
     slot_name TEXT NOT NULL,      -- name of the storage slot
     slot_value TEXT NULL,         -- top-level value of the slot (for maps, contains the root)
     slot_type INTEGER NOT NULL,   -- type of the slot (0 = Value, 1 = Map)
@@ -73,7 +73,7 @@ CREATE TABLE latest_account_storage (
 -- Historical account storage: stores old slot values that were replaced.
 -- NULL old_slot_value means the slot didn't exist before (was created at replaced_at_nonce).
 CREATE TABLE historical_account_storage (
-    account_id TEXT NOT NULL,           -- account ID
+    account_id BLOB NOT NULL,           -- account ID
     replaced_at_nonce BIGINT NOT NULL,  -- nonce at which this old value was replaced
     slot_name TEXT NOT NULL,            -- name of the storage slot
     old_slot_value TEXT NULL,           -- old top-level value (NULL = slot was new)
@@ -84,7 +84,7 @@ CREATE TABLE historical_account_storage (
 -- ── Storage map entries (latest + historical) ────────────────────────────
 
 CREATE TABLE latest_storage_map_entries (
-    account_id TEXT NOT NULL,   -- account ID
+    account_id BLOB NOT NULL,   -- account ID
     slot_name TEXT NOT NULL,    -- name of the storage slot this entry belongs to
     key TEXT NOT NULL,          -- map entry key
     value TEXT NOT NULL,        -- map entry value
@@ -94,7 +94,7 @@ CREATE TABLE latest_storage_map_entries (
 -- Historical storage map entries: stores old map entry values that were replaced.
 -- NULL old_value means the entry didn't exist before (was created at replaced_at_nonce).
 CREATE TABLE historical_storage_map_entries (
-    account_id TEXT NOT NULL,           -- account ID
+    account_id BLOB NOT NULL,           -- account ID
     replaced_at_nonce BIGINT NOT NULL,  -- nonce at which this old entry was replaced
     slot_name TEXT NOT NULL,            -- name of the storage slot this entry belongs to
     key TEXT NOT NULL,                  -- map entry key
@@ -105,7 +105,7 @@ CREATE TABLE historical_storage_map_entries (
 -- ── Account assets (latest + historical) ─────────────────────────────────
 
 CREATE TABLE latest_account_assets (
-    account_id TEXT NOT NULL,        -- account ID
+    account_id BLOB NOT NULL,        -- account ID
     vault_key TEXT NOT NULL,         -- asset's vault key
     asset TEXT NOT NULL,             -- serialized asset value
     PRIMARY KEY (account_id, vault_key)
@@ -114,7 +114,7 @@ CREATE TABLE latest_account_assets (
 -- Historical account assets: stores old assets that were replaced.
 -- NULL old_asset means the asset didn't exist before (was created at replaced_at_nonce).
 CREATE TABLE historical_account_assets (
-    account_id TEXT NOT NULL,           -- account ID
+    account_id BLOB NOT NULL,           -- account ID
     replaced_at_nonce BIGINT NOT NULL,  -- nonce at which this old asset was replaced
     vault_key TEXT NOT NULL,            -- asset's vault key
     old_asset TEXT NULL,                -- old serialized asset value (NULL = asset was new)
@@ -124,7 +124,7 @@ CREATE TABLE historical_account_assets (
 -- ── Foreign account code ─────────────────────────────────────────────────
 
 CREATE TABLE foreign_account_code(
-    account_id TEXT NOT NULL,
+    account_id BLOB NOT NULL,
     code_commitment TEXT NOT NULL,
     PRIMARY KEY (account_id),
     FOREIGN KEY (code_commitment) REFERENCES account_code(commitment)
@@ -168,7 +168,7 @@ CREATE TABLE input_notes (
     created_at UNSIGNED BIG INT NOT NULL,                   -- timestamp of the note creation/import
     consumed_block_height INTEGER NULL,                     -- block height at which the note was consumed; NULL for non-consumed notes
     consumed_tx_order INTEGER NULL,                         -- per-account position of the consuming tx in the account's execution chain within the block; NULL for external consumption or non-consumed notes
-    consumer_account_id TEXT NULL,                          -- account ID that consumed this note; NULL for non-consumed or externally consumed notes
+    consumer_account_id BLOB NULL,                          -- serialized account ID that consumed this note; NULL for non-consumed or externally consumed notes
 
     PRIMARY KEY (details_commitment),
     FOREIGN KEY (script_root) REFERENCES notes_scripts(script_root)
@@ -245,7 +245,7 @@ CREATE TABLE partial_blockchain_nodes (
 
 CREATE TABLE addresses (
     address BLOB NOT NULL,          -- the address
-    account_id UNSIGNED BIG INT NOT NULL,   -- associated Account ID.
+    account_id BLOB NOT NULL,       -- associated serialized account ID
 
     PRIMARY KEY (address)
 ) WITHOUT ROWID;


### PR DESCRIPTION
While reviewing https://github.com/0xMiden/rust-sdk/pull/2308 I realized we were incorrectly addressing fields (`Value::from(InputNoteState::STATE_CONSUMED_AUTHENTICATED_LOCAL.to_string()),` does not need to be a string).

* Fixed `get_unspent_input_note_nullifiers` to bind note-state discriminants as integers, matching the column type
* Migrated account ID columns from hex-encoded `TEXT` to 15-byte `BLOB`s
* Migrated the remaining word-sized values. Commitments, roots, nullifiers, note and transaction IDs, vault keys, etc.: from hex-encoded `TEXT` to 32-byte `BLOB`s, removing unnecessary hex encoding and decoding on reads and writes

Originally I think the intention was to use text to ease debugging, but overall, recently there has been no need to have those and so this will save space. In terms of savings some rows will save 45-50% in tables like the storage map entries. Reads got faster as well but probably unmeasurably so.

A couple of notes:

- We could make the database `STRICT` to catch incorrectly referencing a column
- We could decide to keep only a subset of these, but there's no tradeoff here: it is strictly leaner in size, and reads/writes would be faster (even when unnoticeably so), and types are a bit cleaner/more correct now. Inspectability is not the best but also not really a blocker in any case (conversion is always trivial).