### PR TITLE
feat(cli): rename `send` subcommand to `transfer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 
+* [BREAKING][behavior][cli] Renamed the `send` subcommand to `transfer` (behavior and flags unchanged) ([#2311](https://github.com/0xMiden/rust-sdk/issues/2311)).
 * [BREAKING][param][store] `Store::insert_block_header` now takes a `nodes` argument and persists the header with its MMR authentication nodes in a single transaction; the standalone `Store::insert_partial_blockchain_nodes` is removed. Header-only inserts (e.g. genesis) pass an empty slice ([#2294](https://github.com/0xMiden/rust-sdk/pull/2294)).
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
-* [BREAKING][behavior][cli] Renamed the `send` subcommand to `transfer` (behavior and flags unchanged) ([#2311](https://github.com/0xMiden/rust-sdk/issues/2311)).
+* [BREAKING][rename][cli] Renamed the `send` subcommand to `transfer` (behavior and flags unchanged) ([#2311](https://github.com/0xMiden/rust-sdk/issues/2311)).
 * [BREAKING][param][store] `Store::insert_block_header` now takes a `nodes` argument and persists the header with its MMR authentication nodes in a single transaction; the standalone `Store::insert_partial_blockchain_nodes` is removed. Header-only inserts (e.g. genesis) pass an empty slice ([#2294](https://github.com/0xMiden/rust-sdk/pull/2294)).
 
 ### Fixes

--- a/bin/miden-cli/src/commands/new_transactions.rs
+++ b/bin/miden-cli/src/commands/new_transactions.rs
@@ -106,7 +106,7 @@ impl MintCmd {
 
 /// Create a pay-to-id transaction.
 #[derive(Debug, Parser, Clone)]
-pub struct SendCmd {
+pub struct TransferCmd {
     /// Sender account ID or its hex prefix. If none is provided, the default account's ID is used
     /// instead.
     #[arg(short = 's', long = "sender")]
@@ -141,7 +141,7 @@ pub struct SendCmd {
     delegate_proving: bool,
 }
 
-impl SendCmd {
+impl TransferCmd {
     pub async fn execute<AUTH: Keystore + Sync + 'static>(
         &self,
         mut client: Client<AUTH>,

--- a/bin/miden-cli/src/lib.rs
+++ b/bin/miden-cli/src/lib.rs
@@ -24,7 +24,7 @@ use commands::info::InfoCmd;
 use commands::init::InitCmd;
 use commands::network_note_status::NetworkNoteStatusCmd;
 use commands::new_account::{NewAccountCmd, NewWalletCmd};
-use commands::new_transactions::{ConsumeNotesCmd, MintCmd, PswapCmd, SendCmd, SwapCmd};
+use commands::new_transactions::{ConsumeNotesCmd, MintCmd, PswapCmd, SwapCmd, TransferCmd};
 use commands::notes::NotesCmd;
 use commands::sync::SyncCmd;
 use commands::tags::TagsCmd;
@@ -398,7 +398,7 @@ pub enum Command {
     #[command(name = "tx")]
     Transaction(TransactionCmd),
     Mint(MintCmd),
-    Send(SendCmd),
+    Transfer(TransferCmd),
     Pswap(PswapCmd),
     Swap(SwapCmd),
     ConsumeNotes(ConsumeNotesCmd),
@@ -471,7 +471,7 @@ impl Cli {
             Command::Call(call) => Box::pin(call.execute(client)).await,
             Command::Export(cmd) => cmd.execute(client, keystore).await,
             Command::Mint(mint) => Box::pin(mint.execute(client)).await,
-            Command::Send(send) => Box::pin(send.execute(client)).await,
+            Command::Transfer(transfer) => Box::pin(transfer.execute(client)).await,
             Command::Pswap(pswap) => Box::pin(pswap.execute(client)).await,
             Command::Swap(swap) => Box::pin(swap.execute(client)).await,
             Command::ConsumeNotes(consume_notes) => Box::pin(consume_notes.execute(client)).await,

--- a/bin/miden-cli/tests/cli.rs
+++ b/bin/miden-cli/tests/cli.rs
@@ -639,9 +639,9 @@ async fn cli_export_import_note() -> Result<()> {
     // Consume the note
     consume_note_cli(&temp_dir_2, &first_basic_account_id, &[&note_to_export_id]);
 
-    // Test send command
+    // Test transfer command
     let mock_target_id: AccountId = AccountId::try_from(ACCOUNT_ID_PRIVATE_SENDER).unwrap();
-    send_cli(
+    transfer_cli(
         &temp_dir_2,
         &first_basic_account_id,
         &mock_target_id.to_hex(),
@@ -756,8 +756,8 @@ fn cli_empty_commands() {
     let mut mint_cmd = cargo_bin_cmd!("miden-client");
     assert_command_fails_but_does_not_panic(mint_cmd.args(["mint"]).current_dir(&temp_dir));
 
-    let mut send_cmd = cargo_bin_cmd!("miden-client");
-    assert_command_fails_but_does_not_panic(send_cmd.args(["send"]).current_dir(&temp_dir));
+    let mut transfer_cmd = cargo_bin_cmd!("miden-client");
+    assert_command_fails_but_does_not_panic(transfer_cmd.args(["transfer"]).current_dir(&temp_dir));
 
     let mut swam_cmd = cargo_bin_cmd!("miden-client");
     assert_command_fails_but_does_not_panic(swam_cmd.args(["swap"]).current_dir(&temp_dir));
@@ -1375,12 +1375,12 @@ fn show_note_cli(cli_path: &Path, note_id: &str, should_fail: bool) {
     }
 }
 
-/// Sends 25 units of the corresponding faucet and checks that the command runs successfully given
-/// account using the CLI given by `cli_path`.
-fn send_cli(cli_path: &Path, from_account_id: &str, to_account_id: &str, faucet_id: &str) {
-    let mut send_cmd = cargo_bin_cmd!("miden-client");
-    send_cmd.args([
-        "send",
+/// Transfers 25 units of the corresponding faucet and checks that the command runs successfully
+/// given account using the CLI given by `cli_path`.
+fn transfer_cli(cli_path: &Path, from_account_id: &str, to_account_id: &str, faucet_id: &str) {
+    let mut transfer_cmd = cargo_bin_cmd!("miden-client");
+    transfer_cmd.args([
+        "transfer",
         "--sender",
         from_account_id,
         "--target",
@@ -1391,7 +1391,7 @@ fn send_cli(cli_path: &Path, from_account_id: &str, to_account_id: &str, faucet_
         "private",
         "--force",
     ]);
-    send_cmd.current_dir(cli_path).assert().success();
+    transfer_cmd.current_dir(cli_path).assert().success();
 }
 
 /// Syncs until a tracked note gets committed.

--- a/docs/external/src/rust-client/cli/cli-troubleshooting.md
+++ b/docs/external/src/rust-client/cli/cli-troubleshooting.md
@@ -28,7 +28,7 @@ When enabled, the transaction executor prints the output of any `debug.*` instru
 
 ```sh
 # Enable debug output for a command
-miden-client --debug transfer --sender <SENDER> --target <TARGET> --asset 100::<FAUCET_ID>
+miden-client --debug transfer --sender <SENDER> --target <TARGET> --asset 100::<FAUCET_ID> --note-type private
 
 # Force non-interactive submission (e.g., CI)
 miden-client transfer --force ...

--- a/docs/external/src/rust-client/cli/cli-troubleshooting.md
+++ b/docs/external/src/rust-client/cli/cli-troubleshooting.md
@@ -28,10 +28,10 @@ When enabled, the transaction executor prints the output of any `debug.*` instru
 
 ```sh
 # Enable debug output for a command
-miden-client --debug send --sender <SENDER> --target <TARGET> --asset 100::<FAUCET_ID>
+miden-client --debug transfer --sender <SENDER> --target <TARGET> --asset 100::<FAUCET_ID>
 
 # Force non-interactive submission (e.g., CI)
-miden-client send --force ...
+miden-client transfer --force ...
 
 # Refresh local state
 miden-client sync

--- a/docs/external/src/rust-client/cli/index.md
+++ b/docs/external/src/rust-client/cli/index.md
@@ -300,11 +300,11 @@ Additionally, you can optionally not specify note IDs, in which case any note th
 
 Either `Expected` or `Committed` notes may be consumed by this command, changing their state to `Processing`. It's state will be updated to `Consumed` after the next sync.
 
-#### `send`
+#### `transfer`
 
-Sends assets to another account. Sender Account creates a note that a target Account ID can consume. The asset is identified by the tuple `(FAUCET ID, AMOUNT)`. The note can be configured to be recallable making the sender able to consume it after a height is reached.
+Transfers assets to another account. Sender Account creates a note that a target Account ID can consume. The asset is identified by the tuple `(FAUCET ID, AMOUNT)`. The note can be configured to be recallable making the sender able to consume it after a height is reached.
 
-Usage: `miden-client send --sender <SENDER ACCOUNT ID> --target <TARGET ACCOUNT ID> --asset <AMOUNT>::<FAUCET ID> --note-type <NOTE_TYPE> <RECALL_HEIGHT>`
+Usage: `miden-client transfer --sender <SENDER ACCOUNT ID> --target <TARGET ACCOUNT ID> --asset <AMOUNT>::<FAUCET ID> --note-type <NOTE_TYPE> <RECALL_HEIGHT>`
 
 #### `swap`
 
@@ -352,18 +352,18 @@ miden-client address remove 0x17f13f4f83a8e8100c19d2961dfda2 mlcl1qple0ejnutx8zy
 
 #### Tips
 
-For `send` and `consume-notes`, you can omit the `--sender` and `--account` flags to use the default account defined in the [config](cli-config.md). If you omit the flag but have no default account defined in the config, you'll get an error instead.
+For `transfer` and `consume-notes`, you can omit the `--sender` and `--account` flags to use the default account defined in the [config](cli-config.md). If you omit the flag but have no default account defined in the config, you'll get an error instead.
 
 For every command which needs an account ID (either wallet or faucet), you can also provide a partial ID instead of the full ID for each account. So instead of
 
 ```sh
-miden-client send --sender 0x80519a1c5e3680fc --target 0x8fd4b86a6387f8d8 --asset 100::0xa99c5c8764d4e011
+miden-client transfer --sender 0x80519a1c5e3680fc --target 0x8fd4b86a6387f8d8 --asset 100::0xa99c5c8764d4e011
 ```
 
 You can do:
 
 ```sh
-miden-client send --sender 0x80519 --target 0x8fd4b --asset 100::0xa99c5c8764d4e011
+miden-client transfer --sender 0x80519 --target 0x8fd4b --asset 100::0xa99c5c8764d4e011
 ```
 
 !!! note
@@ -383,7 +383,7 @@ TX Summary:
 Continue with proving and submission? Changes will be irreversible once the proof is finalized on the network (y/N)
 ```
 
-This confirmation can be skipped in non-interactive environments by providing the `--force` flag (`miden-client send --force ...`).
+This confirmation can be skipped in non-interactive environments by providing the `--force` flag (`miden-client transfer --force ...`).
 
 #### Delegated proving
 

--- a/docs/external/src/rust-client/cli/index.md
+++ b/docs/external/src/rust-client/cli/index.md
@@ -304,7 +304,7 @@ Either `Expected` or `Committed` notes may be consumed by this command, changing
 
 Transfers assets to another account. Sender Account creates a note that a target Account ID can consume. The asset is identified by the tuple `(FAUCET ID, AMOUNT)`. The note can be configured to be recallable making the sender able to consume it after a height is reached.
 
-Usage: `miden-client transfer --sender <SENDER ACCOUNT ID> --target <TARGET ACCOUNT ID> --asset <AMOUNT>::<FAUCET ID> --note-type <NOTE_TYPE> <RECALL_HEIGHT>`
+Usage: `miden-client transfer --sender <SENDER ACCOUNT ID> --target <TARGET ACCOUNT ID> --asset <AMOUNT>::<FAUCET ID> --note-type <NOTE_TYPE> [--recall-height <RECALL_HEIGHT>]`
 
 #### `swap`
 
@@ -357,13 +357,13 @@ For `transfer` and `consume-notes`, you can omit the `--sender` and `--account` 
 For every command which needs an account ID (either wallet or faucet), you can also provide a partial ID instead of the full ID for each account. So instead of
 
 ```sh
-miden-client transfer --sender 0x80519a1c5e3680fc --target 0x8fd4b86a6387f8d8 --asset 100::0xa99c5c8764d4e011
+miden-client transfer --sender 0x80519a1c5e3680fc --target 0x8fd4b86a6387f8d8 --asset 100::0xa99c5c8764d4e011 --note-type private
 ```
 
 You can do:
 
 ```sh
-miden-client transfer --sender 0x80519 --target 0x8fd4b --asset 100::0xa99c5c8764d4e011
+miden-client transfer --sender 0x80519 --target 0x8fd4b --asset 100::0xa99c5c8764d4e011 --note-type private
 ```
 
 !!! note

--- a/docs/external/src/rust-client/get-started/p2p-private.md
+++ b/docs/external/src/rust-client/get-started/p2p-private.md
@@ -40,7 +40,7 @@ Remember to use the [Miden client documentation](https://docs.miden.xyz/builder/
    To do this, run:
 
    ```sh
-   miden-client send --sender <regular-account-id-A> --target <regular-account-id-B> --asset 50::<faucet-account-id> --note-type private
+   miden-client transfer --sender <regular-account-id-A> --target <regular-account-id-B> --asset 50::<faucet-account-id> --note-type private
    ```
 
    :::note

--- a/docs/external/src/rust-client/get-started/p2p-public.md
+++ b/docs/external/src/rust-client/get-started/p2p-public.md
@@ -49,7 +49,7 @@ To do this, we use two terminals with their own state (using their own `miden-cl
     To do this, from the first client run:
 
     ```sh
-    miden-client send --sender <basic-account-id-A> --target <basic-account-id-C> --asset 50::<faucet-account-id> --note-type public
+    miden-client transfer --sender <basic-account-id-A> --target <basic-account-id-C> --asset 50::<faucet-account-id> --note-type public
     ```
 
     :::note


### PR DESCRIPTION
While working on the rename, I noticed that the required --note-type command is missing from the documentation in docs/external/src/rust-client/cli/cli-troubleshooting.md, and --recall-height is documented incorrectly in docs/external/src/rust-client/cli/index.md, so I fixed this also.

Closes #2311