### PR TITLE
Align add-transaction error codes with node counterpart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 * [FIX][store] Add metadata to ConsumedExternal notes so that they can be findable by their `NoteId`. The change is store-compatible because records written by older clients (the metadata-less layout) still decode, reading back with no metadata as before ([#2308](https://github.com/0xMiden/rust-sdk/pull/2308)).
+* [FIX][rpc] Align `AddTransactionError` app-level codes with the node's `MempoolSubmissionError`, so submit-transaction failures report the correct cause (e.g. an account commitment mismatch is no longer misreported as "unauthenticated notes not found") and the node's message is preserved for state conflicts ([#2320](https://github.com/0xMiden/rust-sdk/issues/2320)).
 
 ## 0.15.3 (2026-07-02)
 

--- a/bin/integration-tests/src/tests/client.rs
+++ b/bin/integration-tests/src/tests/client.rs
@@ -1435,69 +1435,18 @@ pub async fn test_expired_transaction_fails(client_config: ClientConfig) -> Resu
 
     info!("Sending expired transaction to node (expecting failure)");
     let proven_transaction = client.prove_transaction(&transaction_result).await.unwrap();
-    let submitted_tx_result =
-        match client.submit_proven_transaction(proven_transaction, &transaction_result).await {
-            Ok(submission_height) => {
-                client.apply_transaction(&transaction_result, submission_height).await
-            },
-            Err(err) => Err(err),
-        };
-
-    assert!(submitted_tx_result.is_err());
-    Ok(())
-}
-
-pub async fn test_resubmitted_mint_reports_state_conflict(
-    client_config: ClientConfig,
-) -> Result<()> {
-    let (mut client, authenticator) = client_config.into_client().await?;
-    let (faucet_account, _) = insert_new_fungible_faucet(
-        &mut client,
-        AccountType::Private,
-        &authenticator,
-        RPO_FALCON_SCHEME_ID,
-    )
-    .await?;
-    let (target_account, ..) =
-        insert_new_wallet(&mut client, AccountType::Private, &authenticator, RPO_FALCON_SCHEME_ID)
-            .await?;
-
-    let faucet_account_id = faucet_account.id();
-    let target_account_id = target_account.id();
-
-    wait_for_node(&mut client).await;
-
-    let fungible_asset = FungibleAsset::new(faucet_account_id, MINT_AMOUNT).unwrap();
-    let tx_request = TransactionRequestBuilder::new().build_mint_fungible_asset(
-        fungible_asset,
-        target_account_id,
-        NoteType::Public,
-        client.rng(),
-    )?;
-
-    let transaction_result = client.execute_transaction(faucet_account_id, tx_request).await?;
-
-    let proven_transaction = client.prove_transaction(&transaction_result).await?;
-    let submission_height = client
-        .submit_proven_transaction(proven_transaction, &transaction_result)
-        .await?;
-    client.apply_transaction(&transaction_result, submission_height).await?;
-    wait_for_blocks(&mut client, 2).await;
-
-    let proven_transaction = client.prove_transaction(&transaction_result).await?;
-    let resubmit_result =
+    let submit_result =
         client.submit_proven_transaction(proven_transaction, &transaction_result).await;
 
-    let err = resubmit_result.expect_err("resubmitting a mined mint must be rejected");
+    let err = submit_result.expect_err("submitting an expired transaction must be rejected");
     let ClientError::RpcError(rpc_error) = &err else {
         panic!("expected an RPC error, got: {err:?}");
     };
     assert_matches!(
         rpc_error.endpoint_error(),
-        Some(EndpointError::AddTransaction(AddTransactionError::StateConflict { .. })),
-        "expected a StateConflict, got: {err:?}"
+        Some(EndpointError::AddTransaction(AddTransactionError::Expired)),
+        "expected an Expired error, got: {err:?}"
     );
-
     Ok(())
 }
 

--- a/bin/integration-tests/src/tests/client.rs
+++ b/bin/integration-tests/src/tests/client.rs
@@ -29,7 +29,7 @@ use miden_client::rpc::domain::account::{
     StorageMapFetch,
     VaultFetch,
 };
-use miden_client::rpc::{GrpcClient, NodeRpcClient};
+use miden_client::rpc::{AddTransactionError, EndpointError, GrpcClient, NodeRpcClient};
 use miden_client::store::{
     InputNoteRecord,
     InputNoteState,
@@ -1444,6 +1444,60 @@ pub async fn test_expired_transaction_fails(client_config: ClientConfig) -> Resu
         };
 
     assert!(submitted_tx_result.is_err());
+    Ok(())
+}
+
+pub async fn test_resubmitted_mint_reports_state_conflict(
+    client_config: ClientConfig,
+) -> Result<()> {
+    let (mut client, authenticator) = client_config.into_client().await?;
+    let (faucet_account, _) = insert_new_fungible_faucet(
+        &mut client,
+        AccountType::Private,
+        &authenticator,
+        RPO_FALCON_SCHEME_ID,
+    )
+    .await?;
+    let (target_account, ..) =
+        insert_new_wallet(&mut client, AccountType::Private, &authenticator, RPO_FALCON_SCHEME_ID)
+            .await?;
+
+    let faucet_account_id = faucet_account.id();
+    let target_account_id = target_account.id();
+
+    wait_for_node(&mut client).await;
+
+    let fungible_asset = FungibleAsset::new(faucet_account_id, MINT_AMOUNT).unwrap();
+    let tx_request = TransactionRequestBuilder::new().build_mint_fungible_asset(
+        fungible_asset,
+        target_account_id,
+        NoteType::Public,
+        client.rng(),
+    )?;
+
+    let transaction_result = client.execute_transaction(faucet_account_id, tx_request).await?;
+
+    let proven_transaction = client.prove_transaction(&transaction_result).await?;
+    let submission_height = client
+        .submit_proven_transaction(proven_transaction, &transaction_result)
+        .await?;
+    client.apply_transaction(&transaction_result, submission_height).await?;
+    wait_for_blocks(&mut client, 2).await;
+
+    let proven_transaction = client.prove_transaction(&transaction_result).await?;
+    let resubmit_result =
+        client.submit_proven_transaction(proven_transaction, &transaction_result).await;
+
+    let err = resubmit_result.expect_err("resubmitting a mined mint must be rejected");
+    let ClientError::RpcError(rpc_error) = &err else {
+        panic!("expected an RPC error, got: {err:?}");
+    };
+    assert_matches!(
+        rpc_error.endpoint_error(),
+        Some(EndpointError::AddTransaction(AddTransactionError::StateConflict { .. })),
+        "expected a StateConflict, got: {err:?}"
+    );
+
     Ok(())
 }
 

--- a/crates/rust-client/src/rpc/errors/mod.rs
+++ b/crates/rust-client/src/rpc/errors/mod.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 use super::RpcEndpoint;
 
 pub mod node;
-pub use node::EndpointError;
+pub use node::{AddTransactionError, EndpointError};
 
 // RPC ERROR
 // ================================================================================================

--- a/crates/rust-client/src/rpc/errors/node/transaction.rs
+++ b/crates/rust-client/src/rpc/errors/node/transaction.rs
@@ -2,35 +2,20 @@ use alloc::string::String;
 
 use thiserror::Error;
 
-// Error codes match `miden-node/crates/block-producer/src/errors.rs::AddTransactionError`.
+// Error codes match `miden-node/crates/block-producer/src/errors.rs::MempoolSubmissionError`.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum AddTransactionError {
     /// Internal server error (code 0)
     #[error("internal server error")]
     Internal,
-    /// One or more input notes have already been consumed
-    #[error("input notes already consumed")]
-    InputNotesAlreadyConsumed,
-    /// Unauthenticated notes were not found in the store
-    #[error("unauthenticated notes not found")]
-    UnauthenticatedNotesNotFound,
-    /// One or more output notes already exist in the store
-    #[error("output notes already exist")]
-    OutputNotesAlreadyExist,
-    /// Account's initial commitment doesn't match the current state
-    #[error("incorrect account initial commitment")]
-    IncorrectAccountInitialCommitment,
-    /// Transaction proof verification failed
-    #[error("invalid transaction proof")]
-    InvalidTransactionProof,
-    /// Failed to deserialize the transaction
-    #[error("failed to deserialize transaction")]
-    TransactionDeserializationFailed,
     /// Transaction has expired
     #[error("transaction expired")]
     Expired,
-    /// Block producer capacity exceeded
-    #[error("block producer capacity exceeded")]
+    /// Transaction conflicts with the current state
+    #[error("transaction conflicts with current state: {message}")]
+    StateConflict { message: String },
+    /// Mempool is at capacity
+    #[error("mempool at capacity")]
     CapacityExceeded,
     /// Error code not recognized by this client version. This can happen if the node
     /// is newer than the client and has added new error variants.
@@ -42,14 +27,9 @@ impl AddTransactionError {
     pub fn from_code(code: u8, message: &str) -> Self {
         match code {
             0 => Self::Internal,
-            1 => Self::InputNotesAlreadyConsumed,
-            2 => Self::UnauthenticatedNotesNotFound,
-            3 => Self::OutputNotesAlreadyExist,
-            4 => Self::IncorrectAccountInitialCommitment,
-            5 => Self::InvalidTransactionProof,
-            6 => Self::TransactionDeserializationFailed,
-            7 => Self::Expired,
-            8 => Self::CapacityExceeded,
+            1 => Self::Expired,
+            2 => Self::StateConflict { message: String::from(message) },
+            3 => Self::CapacityExceeded,
             _ => Self::Unknown { code, message: String::from(message) },
         }
     }

--- a/crates/rust-client/src/rpc/errors/node/transaction.rs
+++ b/crates/rust-client/src/rpc/errors/node/transaction.rs
@@ -15,7 +15,7 @@ pub enum AddTransactionError {
     #[error("transaction conflicts with current state: {message}")]
     StateConflict { message: String },
     /// Mempool is at capacity
-    #[error("mempool at capacity")]
+    #[error("the mempool is at capacity")]
     CapacityExceeded,
     /// Error code not recognized by this client version. This can happen if the node
     /// is newer than the client and has added new error variants.


### PR DESCRIPTION
Partly closes #2320. It solves the parsing mismatch of the error the node logs.