### PR TITLE
chore: exclude submodule tomls from linting

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,6 +1,7 @@
 exclude = [
   "**/node_modules/**/*.toml",
-  "bin/miden-cli/templates/*.toml", # allcomponent templates
+  "bin/integration-tests/foundry-vectors/lib/**/*.toml", # git submodules, do not reformat
+  "bin/miden-cli/templates/*.toml",                      # allcomponent templates
 ]
 
 [formatting]

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,6 +1,6 @@
 exclude = [
   "**/node_modules/**/*.toml",
-  "bin/integration-tests/foundry-vectors/lib/**/*.toml", # git submodules, do not reformat
+  "bin/integration-tests/foundry-vectors/lib/**/*.toml", # git submodules
   "bin/miden-cli/templates/*.toml",                      # allcomponent templates
 ]
 


### PR DESCRIPTION
Add submodule tomls added after agglayer test PR to the taplo exclusion list.