### PR TITLE
fix: fallible NTL resolutions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,8 @@ jobs:
         uses: ./.github/actions/cleanup-runner
       - name: Resolve note-transport revision
         id: note-transport-rev
-        run: echo "rev=$(git ls-remote https://github.com/0xMiden/miden-note-transport HEAD | cut -f1)" >> "$GITHUB_OUTPUT"
+        # v0.4.1; bump deliberately together with the toolchain (newer revs require rustc >= 1.96).
+        run: echo "rev=91ca4de34a8b88435e452dda0ed185b90f0bcda0" >> "$GITHUB_OUTPUT"
       - name: Restore note-transport binary
         id: cache-note-transport
         uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Fixes
 
-* [FIX][rust] An NTL delivery colliding with a note that a local transaction is consuming no longer wedges `sync_state()`: such deliveries are skipped (the store already holds their details) and the transport cursor advances past them ([#2345](https://github.com/0xMiden/rust-sdk/issues/2345)).
-* [FIX][rust] Transport deliveries are now validated on receipt — entries whose details don't match the header's details commitment or whose tag was never requested are dropped, with the cursor advancing past them ([#2345](https://github.com/0xMiden/rust-sdk/issues/2345)).
+* [FIX][rust] An NTL delivery colliding with a note that a local transaction is consuming no longer wedges `sync_state()`: such deliveries are skipped (the store already holds their details) and the transport cursor advances past them ([#2353](https://github.com/0xMiden/rust-sdk/pull/2353)).
+* [FIX][rust] Transport deliveries are now validated on receipt — entries whose details don't match the header's details commitment or whose tag was never requested are dropped, with the cursor advancing past them ([#2353](https://github.com/0xMiden/rust-sdk/pull/2353)).
 
 ## 0.15.4 (2026-07-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.15.5 (TBD)
+
+### Fixes
+
+* [FIX][rust] An NTL delivery colliding with a note that a local transaction is consuming no longer wedges `sync_state()` permanently. Transport deliveries whose note is currently being processed are skipped as redundant (consuming requires the full note details, so the store already holds them) and the transport cursor advances past them; a transport fetch/import failure is now logged instead of aborting the sync, so the chain sync — the only way to observe the consume committing — always runs, mirroring the existing relay-outbox handling ([#2345](https://github.com/0xMiden/rust-sdk/issues/2345)).
+
 ## 0.15.4 (2026-07-16)
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-* [FIX][rust] An NTL delivery colliding with a note that a local transaction is consuming no longer wedges `sync_state()` permanently. Transport deliveries whose note is currently being processed are skipped as redundant (consuming requires the full note details, so the store already holds them) and the transport cursor advances past them; a transport fetch/import failure is now logged instead of aborting the sync, so the chain sync — the only way to observe the consume committing — always runs, mirroring the existing relay-outbox handling ([#2345](https://github.com/0xMiden/rust-sdk/issues/2345)).
+* [FIX][rust] An NTL delivery colliding with a note that a local transaction is consuming no longer wedges `sync_state()`: such deliveries are skipped (the store already holds their details) and the transport cursor advances past them ([#2345](https://github.com/0xMiden/rust-sdk/issues/2345)).
 * [FIX][rust] Transport deliveries are now validated on receipt — entries whose details don't match the header's details commitment or whose tag was never requested are dropped, with the cursor advancing past them ([#2345](https://github.com/0xMiden/rust-sdk/issues/2345)).
 
 ## 0.15.4 (2026-07-16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 * [FIX][rust] An NTL delivery colliding with a note that a local transaction is consuming no longer wedges `sync_state()` permanently. Transport deliveries whose note is currently being processed are skipped as redundant (consuming requires the full note details, so the store already holds them) and the transport cursor advances past them; a transport fetch/import failure is now logged instead of aborting the sync, so the chain sync — the only way to observe the consume committing — always runs, mirroring the existing relay-outbox handling ([#2345](https://github.com/0xMiden/rust-sdk/issues/2345)).
+* [FIX][rust] Transport deliveries are now validated on receipt — entries whose details don't match the header's details commitment or whose tag was never requested are dropped, with the cursor advancing past them ([#2345](https://github.com/0xMiden/rust-sdk/issues/2345)).
 
 ## 0.15.4 (2026-07-16)
 

--- a/crates/rust-client/src/note_transport/mod.rs
+++ b/crates/rust-client/src/note_transport/mod.rs
@@ -32,7 +32,7 @@ use miden_tx::utils::serde::{
 };
 
 pub use self::errors::NoteTransportError;
-use crate::store::NoteFilter;
+use crate::store::{InputNoteRecord, NoteFilter};
 use crate::{Client, ClientError};
 
 pub const NOTE_TRANSPORT_TESTNET_ENDPOINT: &str = "https://transport.miden.io";
@@ -369,39 +369,27 @@ where
             // e2ee impl hint:
             // for key in self.store.decryption_keys() try
             // key.decrypt(details_bytes_encrypted)
-            let note = rejoin_note(&note_info.header, &note_info.details_bytes)?;
+            //
+            // Invalid entries are dropped (the cursor advances past them) rather than errored,
+            // since failing the batch would re-fetch the same poison entry on every sync.
+            let note = match rejoin_note(&note_info.header, &note_info.details_bytes) {
+                Ok(note) => note,
+                Err(err) => {
+                    tracing::warn!(?err, "dropping malformed transport delivery");
+                    continue;
+                },
+            };
+            if !tags.contains(&note.metadata().tag()) {
+                tracing::warn!(
+                    tag = ?note.metadata().tag(),
+                    "dropping transport delivery for a tag that was not requested"
+                );
+                continue;
+            }
             notes.push((note, note_info.block_hint));
         }
 
-        // A delivery that collides with a note a local transaction is currently consuming is
-        // redundant: consuming requires the full note details, so the store already holds
-        // everything the delivery carries. Importing it would hit the
-        // can't-overwrite-a-processing-note guard and fail the whole batch — and with it the
-        // cursor, re-fetching the same delivery and failing identically on every subsequent
-        // sync until the consume commits, which only a successful chain sync can observe
-        // (#2345). Skip such notes and let the cursor advance past them.
-        if !notes.is_empty() {
-            let commitments: Vec<NoteDetailsCommitment> =
-                notes.iter().map(|(note, _)| note.details_commitment()).collect();
-            let processing: BTreeSet<NoteDetailsCommitment> = self
-                .get_input_notes(NoteFilter::DetailsCommitments(commitments))
-                .await?
-                .into_iter()
-                .filter(|record| record.is_processing())
-                .map(|record| record.details_commitment())
-                .collect();
-            notes.retain(|(note, _)| {
-                let is_processing_locally = processing.contains(&note.details_commitment());
-                if is_processing_locally {
-                    tracing::warn!(
-                        details_commitment = %note.details_commitment().to_hex(),
-                        "skipping redundant transport delivery of a note currently being \
-                         consumed by a local transaction"
-                    );
-                }
-                !is_processing_locally
-            });
-        }
+        self.drop_notes_processed_locally(&mut notes).await?;
 
         let sync_height = self.get_sync_height().await?;
         let fallback_after_block_num =
@@ -429,6 +417,34 @@ where
             .collect();
 
         Ok((imported_ids, rcursor))
+    }
+
+    /// Drops deliveries of notes that a local transaction is currently consuming: the store
+    /// already holds their full details, and importing them would fail the batch on the
+    /// no-overwrite-while-processing guard — pinning the cursor to the same entry on every
+    /// sync until the consume commits (#2345).
+    async fn drop_notes_processed_locally(
+        &self,
+        notes: &mut Vec<(Note, Option<BlockNumber>)>,
+    ) -> Result<(), ClientError> {
+        if notes.is_empty() {
+            return Ok(());
+        }
+
+        let commitments = notes.iter().map(|(note, _)| note.details_commitment()).collect();
+        let processing: BTreeSet<NoteDetailsCommitment> = self
+            .get_input_notes(NoteFilter::DetailsCommitments(commitments))
+            .await?
+            .into_iter()
+            .filter(InputNoteRecord::is_processing)
+            .map(|record| record.details_commitment())
+            .collect();
+
+        if !processing.is_empty() {
+            tracing::warn!(?processing, "skipping deliveries of notes being consumed locally");
+            notes.retain(|(note, _)| !processing.contains(&note.details_commitment()));
+        }
+        Ok(())
     }
 }
 
@@ -591,6 +607,15 @@ impl Deserializable for NoteTransportCursor {
 fn rejoin_note(header: &NoteHeader, details_bytes: &[u8]) -> Result<Note, DeserializationError> {
     let mut reader = SliceReader::new(details_bytes);
     let details = NoteDetails::read_from(&mut reader)?;
+    // The delivered details must be the ones the header commits to (and thus the ones its
+    // note ID is derived from); a mismatch means a malformed or forged delivery.
+    if details.commitment() != header.details_commitment() {
+        return Err(DeserializationError::InvalidValue(format!(
+            "delivered note details (commitment {}) do not match the header's details commitment {}",
+            details.commitment().to_hex(),
+            header.details_commitment().to_hex(),
+        )));
+    }
     // The transport wire format only carries `NoteHeader` + serialized `NoteDetails`, not the
     // attachments collection. We rejoin with empty attachments; this matches the original note
     // only when it had no attachments in the first place.

--- a/crates/rust-client/src/note_transport/mod.rs
+++ b/crates/rust-client/src/note_transport/mod.rs
@@ -4,7 +4,7 @@ pub mod generated;
 pub mod grpc;
 
 use alloc::boxed::Box;
-use alloc::collections::BTreeMap;
+use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::string::String;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
@@ -32,6 +32,7 @@ use miden_tx::utils::serde::{
 };
 
 pub use self::errors::NoteTransportError;
+use crate::store::NoteFilter;
 use crate::{Client, ClientError};
 
 pub const NOTE_TRANSPORT_TESTNET_ENDPOINT: &str = "https://transport.miden.io";
@@ -370,6 +371,36 @@ where
             // key.decrypt(details_bytes_encrypted)
             let note = rejoin_note(&note_info.header, &note_info.details_bytes)?;
             notes.push((note, note_info.block_hint));
+        }
+
+        // A delivery that collides with a note a local transaction is currently consuming is
+        // redundant: consuming requires the full note details, so the store already holds
+        // everything the delivery carries. Importing it would hit the
+        // can't-overwrite-a-processing-note guard and fail the whole batch — and with it the
+        // cursor, re-fetching the same delivery and failing identically on every subsequent
+        // sync until the consume commits, which only a successful chain sync can observe
+        // (#2345). Skip such notes and let the cursor advance past them.
+        if !notes.is_empty() {
+            let commitments: Vec<NoteDetailsCommitment> =
+                notes.iter().map(|(note, _)| note.details_commitment()).collect();
+            let processing: BTreeSet<NoteDetailsCommitment> = self
+                .get_input_notes(NoteFilter::DetailsCommitments(commitments))
+                .await?
+                .into_iter()
+                .filter(|record| record.is_processing())
+                .map(|record| record.details_commitment())
+                .collect();
+            notes.retain(|(note, _)| {
+                let is_processing_locally = processing.contains(&note.details_commitment());
+                if is_processing_locally {
+                    tracing::warn!(
+                        details_commitment = %note.details_commitment().to_hex(),
+                        "skipping redundant transport delivery of a note currently being \
+                         consumed by a local transaction"
+                    );
+                }
+                !is_processing_locally
+            });
         }
 
         let sync_height = self.get_sync_height().await?;

--- a/crates/rust-client/src/note_transport/mod.rs
+++ b/crates/rust-client/src/note_transport/mod.rs
@@ -370,8 +370,7 @@ where
             // for key in self.store.decryption_keys() try
             // key.decrypt(details_bytes_encrypted)
             //
-            // Invalid entries are dropped (the cursor advances past them) rather than errored,
-            // since failing the batch would re-fetch the same poison entry on every sync.
+            // Drop invalid entries so the cursor can advance past them.
             let note = match rejoin_note(&note_info.header, &note_info.details_bytes) {
                 Ok(note) => note,
                 Err(err) => {
@@ -419,10 +418,8 @@ where
         Ok((imported_ids, rcursor))
     }
 
-    /// Drops deliveries of notes that a local transaction is currently consuming: the store
-    /// already holds their full details, and importing them would fail the batch on the
-    /// no-overwrite-while-processing guard — pinning the cursor to the same entry on every
-    /// sync until the consume commits (#2345).
+    /// Drops deliveries of notes a local transaction is consuming; importing them would fail
+    /// on the no-overwrite-while-processing guard.
     async fn drop_notes_processed_locally(
         &self,
         notes: &mut Vec<(Note, Option<BlockNumber>)>,
@@ -607,8 +604,7 @@ impl Deserializable for NoteTransportCursor {
 fn rejoin_note(header: &NoteHeader, details_bytes: &[u8]) -> Result<Note, DeserializationError> {
     let mut reader = SliceReader::new(details_bytes);
     let details = NoteDetails::read_from(&mut reader)?;
-    // The delivered details must be the ones the header commits to (and thus the ones its
-    // note ID is derived from); a mismatch means a malformed or forged delivery.
+    // The header must commit to the delivered details.
     if details.commitment() != header.details_commitment() {
         return Err(DeserializationError::InvalidValue(format!(
             "delivered note details (commitment {}) do not match the header's details commitment {}",

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -67,7 +67,7 @@ use miden_protocol::note::NoteId;
 use miden_protocol::transaction::TransactionId;
 use miden_tx::auth::TransactionAuthenticator;
 use miden_tx::utils::serde::{Deserializable, DeserializationError, Serializable};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::pswap::PswapChainObserver;
 use crate::store::{NoteFilter, TransactionFilter};
@@ -185,10 +185,24 @@ where
     /// node (see [`Client::sync_chain`]). If note transport is disabled, this is equivalent to
     /// [`Client::sync_chain`].
     ///
-    /// Fails fast on the first error. Private notes delivered via NTL are imported before the
-    /// chain sync reads its input set, so their nullifiers are checked in the same call.
+    /// A note-transport failure does not abort the sync: the error is logged, the chain sync
+    /// still runs, and the un-advanced transport cursor means the fetch is retried on the next
+    /// call. This mirrors how [`Client::sync_note_transport`] treats relay-outbox failures. The
+    /// chain sync is what observes a local consume committing — the transition that releases a
+    /// note from its processing state — so failing fast on the transport half could permanently
+    /// starve the chain half (#2345). Callers that need to inspect transport failures can call
+    /// [`Client::sync_note_transport`] directly.
+    ///
+    /// Private notes delivered via NTL are imported before the chain sync reads its input set,
+    /// so their nullifiers are checked in the same call.
     pub async fn sync_state(&mut self) -> Result<SyncSummary, ClientError> {
-        let new_private_notes = self.sync_note_transport().await?;
+        let new_private_notes = match self.sync_note_transport().await {
+            Ok(note_ids) => note_ids,
+            Err(err) => {
+                warn!(?err, "note transport sync failed; continuing with chain sync");
+                Vec::new()
+            },
+        };
         let mut summary = self.sync_chain().await?;
         summary.new_private_notes = new_private_notes;
         Ok(summary)

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -67,7 +67,7 @@ use miden_protocol::note::NoteId;
 use miden_protocol::transaction::TransactionId;
 use miden_tx::auth::TransactionAuthenticator;
 use miden_tx::utils::serde::{Deserializable, DeserializationError, Serializable};
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 use crate::pswap::PswapChainObserver;
 use crate::store::{NoteFilter, TransactionFilter};
@@ -185,24 +185,10 @@ where
     /// node (see [`Client::sync_chain`]). If note transport is disabled, this is equivalent to
     /// [`Client::sync_chain`].
     ///
-    /// A note-transport failure does not abort the sync: the error is logged, the chain sync
-    /// still runs, and the un-advanced transport cursor means the fetch is retried on the next
-    /// call. This mirrors how [`Client::sync_note_transport`] treats relay-outbox failures. The
-    /// chain sync is what observes a local consume committing — the transition that releases a
-    /// note from its processing state — so failing fast on the transport half could permanently
-    /// starve the chain half (#2345). Callers that need to inspect transport failures can call
-    /// [`Client::sync_note_transport`] directly.
-    ///
-    /// Private notes delivered via NTL are imported before the chain sync reads its input set,
-    /// so their nullifiers are checked in the same call.
+    /// Fails fast on the first error. Private notes delivered via NTL are imported before the
+    /// chain sync reads its input set, so their nullifiers are checked in the same call.
     pub async fn sync_state(&mut self) -> Result<SyncSummary, ClientError> {
-        let new_private_notes = match self.sync_note_transport().await {
-            Ok(note_ids) => note_ids,
-            Err(err) => {
-                warn!(?err, "note transport sync failed; continuing with chain sync");
-                Vec::new()
-            },
-        };
+        let new_private_notes = self.sync_note_transport().await?;
         let mut summary = self.sync_chain().await?;
         summary.new_private_notes = new_private_notes;
         Ok(summary)

--- a/crates/rust-client/src/test_utils/note_transport.rs
+++ b/crates/rust-client/src/test_utils/note_transport.rs
@@ -223,12 +223,15 @@ impl NoteTransportClient for MockNoteTransportApi {
 ///
 /// The decorator counts attempts (`send_attempts`) and lets a test specify how
 /// many of the next `send_note` calls should fail (`fail_next`); successful
-/// calls delegate to an inner [`MockNoteTransportApi`]. `fetch_notes` and
-/// `stream_notes` always delegate to the inner mock.
+/// calls delegate to an inner [`MockNoteTransportApi`]. `fetch_notes` failures
+/// can be injected separately via [`FaultyNoteTransportApi::fail_next_n_fetches`];
+/// `stream_notes` always delegates to the inner mock.
 pub struct FaultyNoteTransportApi {
     inner: MockNoteTransportApi,
     fail_next: AtomicUsize,
     send_attempts: AtomicUsize,
+    fail_next_fetches: AtomicUsize,
+    fetch_attempts: AtomicUsize,
 }
 
 impl FaultyNoteTransportApi {
@@ -239,6 +242,8 @@ impl FaultyNoteTransportApi {
             inner: MockNoteTransportApi::new(mock_node),
             fail_next: AtomicUsize::new(fail_next),
             send_attempts: AtomicUsize::new(0),
+            fail_next_fetches: AtomicUsize::new(0),
+            fetch_attempts: AtomicUsize::new(0),
         }
     }
 
@@ -251,6 +256,17 @@ impl FaultyNoteTransportApi {
     /// Total `send_note` calls observed (success + failure).
     pub fn send_attempts(&self) -> usize {
         self.send_attempts.load(Ordering::SeqCst)
+    }
+
+    /// Fail the next `n` `fetch_notes` calls before delegating to the inner
+    /// mock again.
+    pub fn fail_next_n_fetches(&self, n: usize) {
+        self.fail_next_fetches.store(n, Ordering::SeqCst);
+    }
+
+    /// Total `fetch_notes` calls observed (success + failure).
+    pub fn fetch_attempts(&self) -> usize {
+        self.fetch_attempts.load(Ordering::SeqCst)
     }
 }
 
@@ -301,6 +317,16 @@ impl NoteTransportClient for FaultyNoteTransportApi {
         tags: &[NoteTag],
         cursor: NoteTransportCursor,
     ) -> Result<(Vec<NoteInfo>, NoteTransportCursor), NoteTransportError> {
+        self.fetch_attempts.fetch_add(1, Ordering::SeqCst);
+        let should_fail = self
+            .fail_next_fetches
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| n.checked_sub(1))
+            .is_ok();
+        if should_fail {
+            return Err(NoteTransportError::Network(
+                "FaultyNoteTransportApi: simulated fetch_notes failure".to_string(),
+            ));
+        }
         Ok(self.inner.fetch_notes(tags, cursor))
     }
 

--- a/crates/rust-client/src/test_utils/note_transport.rs
+++ b/crates/rust-client/src/test_utils/note_transport.rs
@@ -74,6 +74,19 @@ impl MockNoteTransportNode {
         self.notes.entry(tag).or_default().push((info, cursor.into()));
     }
 
+    /// Seed a note under an arbitrary transport tag key, regardless of the note's own tag —
+    /// simulates a misbehaving server returning entries for tags the client did not request.
+    pub fn add_note_with_tag_key(
+        &mut self,
+        tag: NoteTag,
+        header: NoteHeader,
+        details_bytes: Vec<u8>,
+    ) {
+        let info = NoteInfo { header, details_bytes, block_hint: None };
+        let cursor = u64::try_from(Utc::now().timestamp_micros()).unwrap();
+        self.notes.entry(tag).or_default().push((info, cursor.into()));
+    }
+
     pub fn get_notes(
         &self,
         tags: &[NoteTag],

--- a/crates/rust-client/src/test_utils/note_transport.rs
+++ b/crates/rust-client/src/test_utils/note_transport.rs
@@ -74,8 +74,7 @@ impl MockNoteTransportNode {
         self.notes.entry(tag).or_default().push((info, cursor.into()));
     }
 
-    /// Seed a note under an arbitrary transport tag key, regardless of the note's own tag —
-    /// simulates a misbehaving server returning entries for tags the client did not request.
+    /// Seed a note under an arbitrary transport tag key, regardless of the note's own tag.
     pub fn add_note_with_tag_key(
         &mut self,
         tag: NoteTag,

--- a/crates/testing/miden-client-tests/src/tests/transport.rs
+++ b/crates/testing/miden-client-tests/src/tests/transport.rs
@@ -751,6 +751,89 @@ async fn transport_fetch_failure_does_not_block_chain_sync() {
     assert_eq!(summary.new_private_notes.len(), 1, "note seeded during the outage must arrive");
 }
 
+/// A delivery whose details don't match the header's details commitment is forged or corrupt;
+/// it must be dropped (with the cursor advancing past it) rather than failing the batch, so a
+/// single poison entry can't block the transport inbox forever.
+#[tokio::test]
+async fn transport_delivery_with_mismatched_details_is_dropped() {
+    let mock_node = Arc::new(RwLock::new(MockNoteTransportNode::new()));
+    let (mut sender, sender_account) = create_test_user_transport(mock_node.clone()).await;
+    let (mut recipient, recipient_account) = create_test_user_transport(mock_node.clone()).await;
+
+    let note_a = P2idNote::create(
+        sender_account.id(),
+        recipient_account.id(),
+        vec![],
+        NoteType::Private,
+        NoteAttachments::empty(),
+        sender.rng(),
+    )
+    .unwrap();
+    let note_b = P2idNote::create(
+        sender_account.id(),
+        recipient_account.id(),
+        vec![],
+        NoteType::Private,
+        NoteAttachments::empty(),
+        sender.rng(),
+    )
+    .unwrap();
+
+    // Forged delivery: note B's header paired with note A's details.
+    let cursor_before = recipient.test_store().get_note_transport_cursor().await.unwrap();
+    mock_node
+        .write()
+        .add_note(*note_b.header(), NoteDetails::from(note_a.clone()).to_bytes());
+
+    let summary = recipient.sync_state().await.unwrap();
+    assert!(summary.new_private_notes.is_empty(), "forged delivery must not import");
+    assert_eq!(recipient.get_input_notes(NoteFilter::All).await.unwrap().len(), 0);
+    let cursor_after = recipient.test_store().get_note_transport_cursor().await.unwrap();
+    assert!(cursor_after > cursor_before, "cursor must advance past the forged delivery");
+
+    // A legitimate delivery of note B still arrives on the next sync.
+    mock_node
+        .write()
+        .add_note(*note_b.header(), NoteDetails::from(note_b.clone()).to_bytes());
+    let summary = recipient.sync_state().await.unwrap();
+    assert_eq!(summary.new_private_notes.len(), 1);
+    let notes = recipient.get_input_notes(NoteFilter::All).await.unwrap();
+    assert_eq!(notes.len(), 1);
+    assert_eq!(notes[0].details_commitment(), note_b.details_commitment());
+}
+
+/// A delivery returned for a tag the client never requested (a misbehaving or malicious
+/// server) must be dropped instead of creating a phantom record and tracking a foreign tag.
+#[tokio::test]
+async fn transport_delivery_for_unrequested_tag_is_dropped() {
+    let mock_node = Arc::new(RwLock::new(MockNoteTransportNode::new()));
+    let (mut sender, sender_account) = create_test_user_transport(mock_node.clone()).await;
+    let (mut recipient, _recipient_account) = create_test_user_transport(mock_node.clone()).await;
+
+    // The recipient explicitly tracks one tag; the server returns, under that tag key, a note
+    // whose own tag is a different one (it targets the sender's account, not the recipient's).
+    let tracked_tag = NoteTag::new(777);
+    recipient.add_note_tag(tracked_tag).await.unwrap();
+    let foreign_note = P2idNote::create(
+        sender_account.id(),
+        sender_account.id(),
+        vec![],
+        NoteType::Private,
+        NoteAttachments::empty(),
+        sender.rng(),
+    )
+    .unwrap();
+    mock_node.write().add_note_with_tag_key(
+        tracked_tag,
+        *foreign_note.header(),
+        NoteDetails::from(foreign_note).to_bytes(),
+    );
+
+    let summary = recipient.sync_state().await.unwrap();
+    assert!(summary.new_private_notes.is_empty(), "foreign-tag delivery must not import");
+    assert_eq!(recipient.get_input_notes(NoteFilter::All).await.unwrap().len(), 0);
+}
+
 // HELPERS
 // ================================================================================================
 

--- a/crates/testing/miden-client-tests/src/tests/transport.rs
+++ b/crates/testing/miden-client-tests/src/tests/transport.rs
@@ -16,9 +16,11 @@ use miden_client::testing::note_transport::{
     MockNoteTransportApi,
     MockNoteTransportNode,
 };
+use miden_client::transaction::TransactionRequestBuilder;
 use miden_client::utils::RwLock;
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use miden_protocol::Felt;
+use miden_protocol::asset::FungibleAsset;
 use miden_protocol::block::BlockNumber;
 use miden_protocol::crypto::rand::RandomCoin;
 use miden_protocol::note::NoteType as ProtocolNoteType;
@@ -29,7 +31,7 @@ use miden_standards::testing::note::NoteBuilder;
 use miden_testing::{MockChainBuilder, TxContextInput};
 use rand::Rng;
 
-use crate::tests::{create_test_client_builder, insert_new_wallet};
+use crate::tests::{create_test_client_builder, insert_new_fungible_faucet, insert_new_wallet};
 
 #[tokio::test]
 async fn transport_basic() {
@@ -635,6 +637,118 @@ async fn fetch_private_notes_without_floor_falls_back_to_lookback_window() {
         !committed_notes.iter().any(|n| n.id() == Some(private_note.id())),
         "without a floor the lookback window misses a note committed before sync_height - 20"
     );
+}
+
+/// Reproduces 0xMiden/rust-sdk#2345: an NTL delivery of a note that a local transaction is
+/// currently consuming must not wedge `sync_state()`.
+///
+/// A note observed on-chain is being consumed (its input-note record is `Processing*`) when the
+/// same note's transport delivery arrives late. The transport import used to hit the
+/// can't-overwrite-a-processing-note guard, failing the whole sync — and since the transport
+/// cursor only advances on success, every subsequent `sync_state()` refetched the same delivery
+/// and failed identically, permanently, because only a successful chain sync can observe the
+/// consume committing. The delivery is redundant (consuming requires the full note details, so
+/// the store already holds them): it must be skipped and the cursor must advance past it.
+#[tokio::test]
+async fn transport_delivery_of_processing_note_does_not_wedge_sync_state() {
+    let mock_node = Arc::new(RwLock::new(MockNoteTransportNode::new()));
+    let (mut client, keystore) = Box::pin(create_test_client_transport(mock_node.clone())).await;
+    client.sync_state().await.unwrap();
+
+    let account = insert_new_wallet(&mut client, AccountType::Private, &keystore).await.unwrap();
+    let faucet = insert_new_fungible_faucet(&mut client, AccountType::Private, &keystore)
+        .await
+        .unwrap();
+
+    // Mint a note to the wallet and start consuming it, leaving its record in a processing state.
+    let mint_request = TransactionRequestBuilder::new()
+        .build_mint_fungible_asset(
+            FungibleAsset::new(faucet.id(), 5u64).unwrap(),
+            account.id(),
+            ProtocolNoteType::Public,
+            client.rng(),
+        )
+        .unwrap();
+    Box::pin(client.submit_new_transaction(faucet.id(), mint_request.clone()))
+        .await
+        .unwrap();
+
+    let minted_note = mint_request.expected_output_own_notes().pop().unwrap();
+    let note_record = client.get_input_note(minted_note.id()).await.unwrap().unwrap();
+    let consume_request = TransactionRequestBuilder::new()
+        .input_notes([(note_record.try_into().unwrap(), None)])
+        .build()
+        .unwrap();
+    Box::pin(client.submit_new_transaction(account.id(), consume_request))
+        .await
+        .unwrap();
+    assert!(
+        !client.get_input_notes(NoteFilter::Processing).await.unwrap().is_empty(),
+        "the consumed note should be in a processing state"
+    );
+
+    // The transport delivery of the very same note arrives while the consume is in flight.
+    let cursor_before = client.test_store().get_note_transport_cursor().await.unwrap();
+    mock_node
+        .write()
+        .add_note(*minted_note.header(), NoteDetails::from(minted_note.clone()).to_bytes());
+
+    // The delivery collides with the processing record; sync must skip it, not fail.
+    let summary = client.sync_state().await.unwrap();
+    assert!(
+        summary.new_private_notes.is_empty(),
+        "the redundant delivery must not be re-imported"
+    );
+
+    // The cursor advanced past the skipped delivery, so the next sync doesn't refetch it.
+    let cursor_after = client.test_store().get_note_transport_cursor().await.unwrap();
+    assert!(cursor_after > cursor_before, "cursor must advance past the skipped delivery");
+    client.sync_state().await.unwrap();
+
+    // The store still holds exactly one record for the note, untouched by the delivery.
+    let records = client.get_input_notes(NoteFilter::All).await.unwrap();
+    let matching = records
+        .iter()
+        .filter(|record| record.details_commitment() == minted_note.details_commitment())
+        .count();
+    assert_eq!(matching, 1, "the skipped delivery must not create or overwrite a record");
+}
+
+/// A transport fetch failure must not abort `sync_state()`: the chain sync still runs (it is the
+/// only way to observe a local consume committing), and the un-advanced cursor means the fetch is
+/// simply retried — notes seeded while the transport was down are delivered once it heals.
+#[tokio::test]
+async fn transport_fetch_failure_does_not_block_chain_sync() {
+    let mock_node = Arc::new(RwLock::new(MockNoteTransportNode::new()));
+    let faulty = Arc::new(FaultyNoteTransportApi::new(mock_node.clone(), 0));
+    let (mut recipient, recipient_account) =
+        Box::pin(create_test_user_with_transport(faulty.clone())).await;
+
+    // The NTL is unreachable: sync_state must still complete the chain sync.
+    faulty.fail_next_n_fetches(2);
+    let summary = recipient.sync_state().await.unwrap();
+    assert!(summary.new_private_notes.is_empty());
+    recipient.sync_state().await.unwrap();
+    assert_eq!(faulty.fetch_attempts(), 2);
+
+    // A note is relayed while the transport is down for fetches...
+    let note = P2idNote::create(
+        recipient_account.id(),
+        recipient_account.id(),
+        vec![],
+        NoteType::Private,
+        NoteAttachments::empty(),
+        recipient.rng(),
+    )
+    .unwrap();
+    mock_node
+        .write()
+        .add_note(*note.header(), NoteDetails::from(note.clone()).to_bytes());
+
+    // ...and is delivered on the first sync after it heals: the failed fetches never advanced
+    // the cursor.
+    let summary = recipient.sync_state().await.unwrap();
+    assert_eq!(summary.new_private_notes.len(), 1, "note seeded during the outage must arrive");
 }
 
 // HELPERS

--- a/crates/testing/miden-client-tests/src/tests/transport.rs
+++ b/crates/testing/miden-client-tests/src/tests/transport.rs
@@ -639,16 +639,7 @@ async fn fetch_private_notes_without_floor_falls_back_to_lookback_window() {
     );
 }
 
-/// Reproduces 0xMiden/rust-sdk#2345: an NTL delivery of a note that a local transaction is
-/// currently consuming must not wedge `sync_state()`.
-///
-/// A note observed on-chain is being consumed (its input-note record is `Processing*`) when the
-/// same note's transport delivery arrives late. The transport import used to hit the
-/// can't-overwrite-a-processing-note guard, failing the whole sync — and since the transport
-/// cursor only advances on success, every subsequent `sync_state()` refetched the same delivery
-/// and failed identically, permanently, because only a successful chain sync can observe the
-/// consume committing. The delivery is redundant (consuming requires the full note details, so
-/// the store already holds them): it must be skipped and the cursor must advance past it.
+/// A delivery of a note being consumed locally is skipped and the cursor advances (#2345).
 #[tokio::test]
 async fn transport_delivery_of_processing_note_does_not_wedge_sync_state() {
     let mock_node = Arc::new(RwLock::new(MockNoteTransportNode::new()));
@@ -660,7 +651,6 @@ async fn transport_delivery_of_processing_note_does_not_wedge_sync_state() {
         .await
         .unwrap();
 
-    // Mint a note to the wallet and start consuming it, leaving its record in a processing state.
     let mint_request = TransactionRequestBuilder::new()
         .build_mint_fungible_asset(
             FungibleAsset::new(faucet.id(), 5u64).unwrap(),
@@ -687,25 +677,22 @@ async fn transport_delivery_of_processing_note_does_not_wedge_sync_state() {
         "the consumed note should be in a processing state"
     );
 
-    // The transport delivery of the very same note arrives while the consume is in flight.
     let cursor_before = client.test_store().get_note_transport_cursor().await.unwrap();
+    // The same note arrives via transport while the consume is in flight.
     mock_node
         .write()
         .add_note(*minted_note.header(), NoteDetails::from(minted_note.clone()).to_bytes());
 
-    // The delivery collides with the processing record; sync must skip it, not fail.
     let summary = client.sync_state().await.unwrap();
     assert!(
         summary.new_private_notes.is_empty(),
         "the redundant delivery must not be re-imported"
     );
 
-    // The cursor advanced past the skipped delivery, so the next sync doesn't refetch it.
     let cursor_after = client.test_store().get_note_transport_cursor().await.unwrap();
     assert!(cursor_after > cursor_before, "cursor must advance past the skipped delivery");
     client.sync_state().await.unwrap();
 
-    // The store still holds exactly one record for the note, untouched by the delivery.
     let records = client.get_input_notes(NoteFilter::All).await.unwrap();
     let matching = records
         .iter()
@@ -714,24 +701,14 @@ async fn transport_delivery_of_processing_note_does_not_wedge_sync_state() {
     assert_eq!(matching, 1, "the skipped delivery must not create or overwrite a record");
 }
 
-/// A transport fetch failure must not abort `sync_state()`: the chain sync still runs (it is the
-/// only way to observe a local consume committing), and the un-advanced cursor means the fetch is
-/// simply retried — notes seeded while the transport was down are delivered once it heals.
+/// A failed fetch propagates and leaves the cursor unchanged for retry.
 #[tokio::test]
-async fn transport_fetch_failure_does_not_block_chain_sync() {
+async fn transport_fetch_failure_leaves_cursor_for_retry() {
     let mock_node = Arc::new(RwLock::new(MockNoteTransportNode::new()));
     let faulty = Arc::new(FaultyNoteTransportApi::new(mock_node.clone(), 0));
     let (mut recipient, recipient_account) =
         Box::pin(create_test_user_with_transport(faulty.clone())).await;
 
-    // The NTL is unreachable: sync_state must still complete the chain sync.
-    faulty.fail_next_n_fetches(2);
-    let summary = recipient.sync_state().await.unwrap();
-    assert!(summary.new_private_notes.is_empty());
-    recipient.sync_state().await.unwrap();
-    assert_eq!(faulty.fetch_attempts(), 2);
-
-    // A note is relayed while the transport is down for fetches...
     let note = P2idNote::create(
         recipient_account.id(),
         recipient_account.id(),
@@ -745,15 +722,17 @@ async fn transport_fetch_failure_does_not_block_chain_sync() {
         .write()
         .add_note(*note.header(), NoteDetails::from(note.clone()).to_bytes());
 
-    // ...and is delivered on the first sync after it heals: the failed fetches never advanced
-    // the cursor.
+    faulty.fail_next_n_fetches(2);
+    recipient.sync_state().await.unwrap_err();
+    recipient.sync_state().await.unwrap_err();
+    assert_eq!(faulty.fetch_attempts(), 2);
+    assert_eq!(recipient.get_input_notes(NoteFilter::All).await.unwrap().len(), 0);
+
     let summary = recipient.sync_state().await.unwrap();
     assert_eq!(summary.new_private_notes.len(), 1, "note seeded during the outage must arrive");
 }
 
-/// A delivery whose details don't match the header's details commitment is forged or corrupt;
-/// it must be dropped (with the cursor advancing past it) rather than failing the batch, so a
-/// single poison entry can't block the transport inbox forever.
+/// A delivery whose details don't match the header's commitment is dropped.
 #[tokio::test]
 async fn transport_delivery_with_mismatched_details_is_dropped() {
     let mock_node = Arc::new(RwLock::new(MockNoteTransportNode::new()));
@@ -779,8 +758,8 @@ async fn transport_delivery_with_mismatched_details_is_dropped() {
     )
     .unwrap();
 
-    // Forged delivery: note B's header paired with note A's details.
     let cursor_before = recipient.test_store().get_note_transport_cursor().await.unwrap();
+    // Note B's header paired with note A's details.
     mock_node
         .write()
         .add_note(*note_b.header(), NoteDetails::from(note_a.clone()).to_bytes());
@@ -791,7 +770,6 @@ async fn transport_delivery_with_mismatched_details_is_dropped() {
     let cursor_after = recipient.test_store().get_note_transport_cursor().await.unwrap();
     assert!(cursor_after > cursor_before, "cursor must advance past the forged delivery");
 
-    // A legitimate delivery of note B still arrives on the next sync.
     mock_node
         .write()
         .add_note(*note_b.header(), NoteDetails::from(note_b.clone()).to_bytes());
@@ -802,16 +780,13 @@ async fn transport_delivery_with_mismatched_details_is_dropped() {
     assert_eq!(notes[0].details_commitment(), note_b.details_commitment());
 }
 
-/// A delivery returned for a tag the client never requested (a misbehaving or malicious
-/// server) must be dropped instead of creating a phantom record and tracking a foreign tag.
+/// A delivery for a tag that wasn't requested is dropped.
 #[tokio::test]
 async fn transport_delivery_for_unrequested_tag_is_dropped() {
     let mock_node = Arc::new(RwLock::new(MockNoteTransportNode::new()));
     let (mut sender, sender_account) = create_test_user_transport(mock_node.clone()).await;
     let (mut recipient, _recipient_account) = create_test_user_transport(mock_node.clone()).await;
 
-    // The recipient explicitly tracks one tag; the server returns, under that tag key, a note
-    // whose own tag is a different one (it targets the sender's account, not the recipient's).
     let tracked_tag = NoteTag::new(777);
     recipient.add_note_tag(tracked_tag).await.unwrap();
     let foreign_note = P2idNote::create(
@@ -823,6 +798,7 @@ async fn transport_delivery_for_unrequested_tag_is_dropped() {
         sender.rng(),
     )
     .unwrap();
+    // A note tagged for the sender, served under the recipient's tracked tag.
     mock_node.write().add_note_with_tag_key(
         tracked_tag,
         *foreign_note.header(),


### PR DESCRIPTION
Closes #2345

Validates the incoming data from NTL more, but skips over invalid data.
The main reasoning behind the fix is that NTL currently allows malformed and non-existant data to be passed, and so we need to make it so that an invalid note does not fail the whole syncing process.