### PR TITLE
fix(rust-client): don't panic on consumed input note without metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.15.5 (TBD)
+## 0.15.5 (2026-08-03)
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 ## 0.15.5 (TBD)
 
+### Breaking Changes
+
+* [BREAKING][type][rust] `TransactionRequestError::InputNoteAlreadyConsumed` now carries a `NoteDetailsCommitment` instead of a `NoteId`, since a note record that was consumed externally may lack the metadata needed to derive its ID ([#2344](https://github.com/0xMiden/rust-sdk/issues/2344)).
+
 ### Fixes
 
 * [FIX][rust] An NTL delivery colliding with a note that a local transaction is consuming no longer wedges `sync_state()`: such deliveries are skipped (the store already holds their details) and the transport cursor advances past them ([#2353](https://github.com/0xMiden/rust-sdk/pull/2353)).
 * [FIX][rust] Transport deliveries are now validated on receipt — entries whose details don't match the header's details commitment or whose tag was never requested are dropped, with the cursor advancing past them ([#2353](https://github.com/0xMiden/rust-sdk/pull/2353)).
+* [FIX][rust] `Client::prepare_transaction` no longer panics when an input note is already consumed and its record carries no metadata; it returns `InputNoteAlreadyConsumed` instead ([#2344](https://github.com/0xMiden/rust-sdk/issues/2344)).
 
 ## 0.15.4 (2026-07-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### Breaking Changes
 
-* [BREAKING][type][rust] `TransactionRequestError::InputNoteAlreadyConsumed` now carries a `NoteDetailsCommitment` instead of a `NoteId`, since a note record that was consumed externally may lack the metadata needed to derive its ID ([#2344](https://github.com/0xMiden/rust-sdk/issues/2344)).
+* [BREAKING][type][rust] `TransactionRequestError::InputNoteAlreadyConsumed` now carries a `NoteDetailsCommitment` instead of a `NoteId`, since a note record that was consumed externally may lack the metadata needed to derive its ID ([#2344](https://github.com/0xMiden/rust-sdk/pull/2354)).
 
 ### Fixes
 
 * [FIX][rust] An NTL delivery colliding with a note that a local transaction is consuming no longer wedges `sync_state()`: such deliveries are skipped (the store already holds their details) and the transport cursor advances past them ([#2353](https://github.com/0xMiden/rust-sdk/pull/2353)).
 * [FIX][rust] Transport deliveries are now validated on receipt — entries whose details don't match the header's details commitment or whose tag was never requested are dropped, with the cursor advancing past them ([#2353](https://github.com/0xMiden/rust-sdk/pull/2353)).
-* [FIX][rust] `Client::prepare_transaction` no longer panics when an input note is already consumed and its record carries no metadata; it returns `InputNoteAlreadyConsumed` instead ([#2344](https://github.com/0xMiden/rust-sdk/issues/2344)).
+* [FIX][rust] `Client::prepare_transaction` no longer panics when an input note is already consumed and its record carries no metadata; it returns `InputNoteAlreadyConsumed` instead ([#2344](https://github.com/0xMiden/rust-sdk/pull/2354)).
 
 ## 0.15.4 (2026-07-16)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2077,7 +2077,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-bench"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2133,7 +2133,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-cli"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2160,7 +2160,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-integration-tests"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2183,7 +2183,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-sqlite-store"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2201,7 +2201,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-unit-tests"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "miden-client",
  "miden-client-sqlite-store",
@@ -4553,7 +4553,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-node-genesis"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anyhow",
  "miden-agglayer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ edition      = "2024"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/miden-client"
 rust-version = "1.93"
-version      = "0.15.4"
+version      = "0.15.5"
 
 [profile.dev]
 codegen-units = 16
@@ -30,8 +30,8 @@ opt-level = 1
 
 [workspace.dependencies]
 # Workspace crates
-miden-client              = { default-features = false, path = "crates/rust-client", version = "0.15.3" }
-miden-client-sqlite-store = { default-features = false, path = "crates/sqlite-store", version = "0.15.3" }
+miden-client              = { default-features = false, path = "crates/rust-client", version = "0.15.5" }
+miden-client-sqlite-store = { default-features = false, path = "crates/sqlite-store", version = "0.15.5" }
 
 # Miden protocol dependencies
 miden-agglayer        = { default-features = false, version = "0.15" }

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -373,14 +373,11 @@ where
             .get_input_notes(NoteFilter::List(transaction_request.input_note_ids().collect()))
             .await?;
 
-        // Verify that none of the authenticated input notes are already consumed.
+        // Verify that none of the stored input notes are already consumed.
         for note in &stored_note_records {
             if note.is_consumed() {
-                let id = note.id().expect(
-                    "stored note records reaching this check carry metadata so id() is Some",
-                );
                 return Err(ClientError::TransactionRequestError(
-                    TransactionRequestError::InputNoteAlreadyConsumed(id),
+                    TransactionRequestError::InputNoteAlreadyConsumed(note.details_commitment()),
                 ));
             }
         }

--- a/crates/rust-client/src/transaction/request/mod.rs
+++ b/crates/rust-client/src/transaction/request/mod.rs
@@ -264,7 +264,7 @@ impl TransactionRequest {
 
             if authenticated_note_record.is_consumed() {
                 return Err(TransactionRequestError::InputNoteAlreadyConsumed(
-                    authenticated_note_id,
+                    authenticated_note_record.details_commitment(),
                 ));
             }
 
@@ -501,8 +501,8 @@ pub enum TransactionRequestError {
         "note {0} cannot be used as an authenticated input: it does not have a valid inclusion proof"
     )]
     InputNoteNotAuthenticated(NoteId),
-    #[error("note {0} has already been consumed")]
-    InputNoteAlreadyConsumed(NoteId),
+    #[error("note with details commitment {} has already been consumed", .0.to_hex())]
+    InputNoteAlreadyConsumed(NoteDetailsCommitment),
     #[error(
         "output note declares sender {actual} but the transaction is executed by account {expected}"
     )]


### PR DESCRIPTION
Makes `prepare_transaction` use note details commitment instead of ID to handle `InputNoteAlreadyConsumed` errors. Note ID exists depending if the note has metadata but details commitment is always present.
This bugfix forces a breaking change because `InputNoteAlreadyConsumed` inner type changes.

Closes #2344.