### PR TITLE
chore(cli): improve `miden-client init` output when a configuration already exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [FEATURE][rust,store] Added `NoteFilter::ScriptRoots` to query input notes by their note script root directly at the store level, without loading and screening unrelated notes. The filter doesn't apply to output notes: querying output notes with it returns an empty list ([#2335](https://github.com/0xMiden/rust-sdk/pull/2335)).
 * [rust] Added `PartialBlockchainUpdates::block_headers_to_store`, which narrows the staged headers to the ones a sync must persist: those marked as relevant, genesis, and the block at the sync height. `block_headers` still yields all staged headers ([#2297](https://github.com/0xMiden/rust-sdk/pull/2297)).
 * [rust] State sync now authenticates every relevant note block but only persists block headers and MMR authentication nodes for blocks containing notes that remain unspent or that a `NoteObserver` explicitly marks as relevant ([#2297](https://github.com/0xMiden/rust-sdk/pull/2297)).
+* Improved the output of the `miden-client init` command when a configuration already exists ([#](https://github.com/0xMiden/rust-sdk/pull/2357)).
 
 ## 0.16.0-alpha.1 (2026-07-17)
 

--- a/bin/miden-cli/src/commands/init.rs
+++ b/bin/miden-cli/src/commands/init.rs
@@ -8,7 +8,12 @@ use tracing::info;
 
 use crate::CLIENT_CONFIG_FILE_NAME;
 use crate::config::{
-    CliConfig, CliEndpoint, MIDEN_DIR, Network, NoteTransportConfig, get_global_miden_dir,
+    CliConfig,
+    CliEndpoint,
+    MIDEN_DIR,
+    Network,
+    NoteTransportConfig,
+    get_global_miden_dir,
     get_local_miden_dir,
 };
 use crate::errors::CliError;

--- a/bin/miden-cli/src/commands/init.rs
+++ b/bin/miden-cli/src/commands/init.rs
@@ -8,12 +8,7 @@ use tracing::info;
 
 use crate::CLIENT_CONFIG_FILE_NAME;
 use crate::config::{
-    CliConfig,
-    CliEndpoint,
-    MIDEN_DIR,
-    Network,
-    NoteTransportConfig,
-    get_global_miden_dir,
+    CliConfig, CliEndpoint, MIDEN_DIR, Network, NoteTransportConfig, get_global_miden_dir,
     get_local_miden_dir,
 };
 use crate::errors::CliError;
@@ -138,14 +133,17 @@ impl InitCmd {
 
         // Check if config already exists
         if config_file_path.exists() {
+            let config = CliConfig::from_dir(&target_miden_dir)?;
+
             return Err(CliError::Config(
                 "Error with the configuration file".to_string().into(),
                 format!(
-                    "The file \"{}\" already exists in the {} {} directory ({}). Please remove it first or use a different location.",
+                    "The file \"{}\" already exists in the {} {} directory ({}), configured with the network \"{}\".",
                     CLIENT_CONFIG_FILE_NAME,
                     config_type,
                     MIDEN_DIR,
-                    target_miden_dir.display()
+                    target_miden_dir.display(),
+                    config.rpc.endpoint
                 ),
             ));
         }

--- a/bin/miden-cli/src/errors.rs
+++ b/bin/miden-cli/src/errors.rs
@@ -6,12 +6,7 @@ use std::error::Error;
 use miden_client::account::{AccountId, AddressError};
 use miden_client::keystore::KeyStoreError;
 use miden_client::{
-    AccountError,
-    AccountIdError,
-    AssetError,
-    ClientError,
-    CodeBuilderError,
-    ErrorHint,
+    AccountError, AccountIdError, AssetError, ClientError, CodeBuilderError, ErrorHint,
     NetworkIdError,
 };
 use miette::Diagnostic;
@@ -49,9 +44,10 @@ pub enum CliError {
     #[diagnostic(
         code(cli::config_error),
         help(
-            "Check if the configuration file exists and is well-formed. If it does not exist, run `{} init` command to create it.",
+            "Check if the configuration file exists and is well-formed. If it does not exist, run `{} init` command to create it. \
+            If it already exists, run `{} clear-config` to remove it.",
+            client_binary_name().display(),
             client_binary_name().display()
-
         )
     )]
     Config(#[source] SourceError, String),

--- a/bin/miden-cli/src/errors.rs
+++ b/bin/miden-cli/src/errors.rs
@@ -6,7 +6,12 @@ use std::error::Error;
 use miden_client::account::{AccountId, AddressError};
 use miden_client::keystore::KeyStoreError;
 use miden_client::{
-    AccountError, AccountIdError, AssetError, ClientError, CodeBuilderError, ErrorHint,
+    AccountError,
+    AccountIdError,
+    AssetError,
+    ClientError,
+    CodeBuilderError,
+    ErrorHint,
     NetworkIdError,
 };
 use miette::Diagnostic;


### PR DESCRIPTION
Improves the output of the `miden-client init` command when a configuration already exists.

Now the output looks like this:

```
Error: cli::config_error

  × config error: The file "miden-client.toml" already exists in the global .miden directory (/Users/mateo/.miden), configured with the network
  │ "https://rpc.testnet.miden.io".
  ╰─▶ Error with the configuration file
  help: Check if the configuration file exists and is well-formed. If it does not exist, run `miden-client init` command to create it. If it
        already exists, run `miden-client clear-config` to remove it.
```

Closes #2339 