### PR TITLE
fix(cli): show a dedicated error when `init` finds an existing config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 
 ### Fixes
 
+* [FIX][cli] `init` now reports a dedicated error when a configuration file already exists, hinting at `clear-config` instead of suggesting `init`, which the shared config-error hint did ([#2366](https://github.com/0xMiden/rust-sdk/pull/2366)).
 * [FIX][store] Opening a `SQLite` store now fingerprints the live database schema and compares it against the schema its migrations produce, rejecting a database whose schema has drifted (manual DDL, a partially applied migration, or corruption) instead of trusting a hash stored inside the database file ([#2304](https://github.com/0xMiden/rust-sdk/pull/2304)).
 * [FIX][rust] Notes received over the note transport layer now fetch attachments from the node via `get_notes_by_id`. Fetched attachment content is verified against the note metadata's attachments commitment; a note whose advertised attachment content the node cannot serve (or serves incorrectly) is skipped with a warning instead of failing the sync, and a note record is never stored with incomplete attachment content ([#2295](https://github.com/0xMiden/rust-sdk/pull/2295)).
 * [FIX][store] The SQLite store now honors `StorageMapPatch` create/remove semantics: a `Create` patch on an existing map slot clears the prior entries before writing (so its root reflects only the created entries) and a `Remove` patch drops the slot's entries and collapses its root to the empty-map root ([#2290](https://github.com/0xMiden/rust-sdk/pull/2290)).

--- a/bin/miden-cli/src/commands/init.rs
+++ b/bin/miden-cli/src/commands/init.rs
@@ -138,15 +138,21 @@ impl InitCmd {
 
         // Check if config already exists
         if config_file_path.exists() {
-            let config = CliConfig::from_dir(&target_miden_dir)?;
+            // An unparsable file must still hint at `clear-config`, not `init`.
+            let network_info = match CliConfig::from_dir(&target_miden_dir) {
+                Ok(config) => {
+                    format!(", configured with the network \"{}\"", config.rpc.endpoint)
+                },
+                Err(_) => ", but it could not be parsed".to_string(),
+            };
             let global_flag: String = if self.local { "" } else { " --global" }.into();
             let error_msg = format!(
-                "\"{}\" already exists in the {} {} directory ({}), configured with the network \"{}\".",
+                "\"{}\" already exists in the {} {} directory ({}){}.",
                 CLIENT_CONFIG_FILE_NAME,
                 config_type,
                 MIDEN_DIR,
                 target_miden_dir.display(),
-                config.rpc.endpoint
+                network_info
             );
             return Err(CliError::ConfigAlreadyExists(error_msg, global_flag));
         }

--- a/bin/miden-cli/src/commands/init.rs
+++ b/bin/miden-cli/src/commands/init.rs
@@ -139,18 +139,16 @@ impl InitCmd {
         // Check if config already exists
         if config_file_path.exists() {
             let config = CliConfig::from_dir(&target_miden_dir)?;
-
-            return Err(CliError::Config(
-                "Error with the configuration file".to_string().into(),
-                format!(
-                    "The file \"{}\" already exists in the {} {} directory ({}), configured with the network \"{}\".",
-                    CLIENT_CONFIG_FILE_NAME,
-                    config_type,
-                    MIDEN_DIR,
-                    target_miden_dir.display(),
-                    config.rpc.endpoint
-                ),
-            ));
+            let global_flag: String = if self.local { "" } else { " --global" }.into();
+            let error_msg = format!(
+                "\"{}\" already exists in the {} {} directory ({}), configured with the network \"{}\".",
+                CLIENT_CONFIG_FILE_NAME,
+                config_type,
+                MIDEN_DIR,
+                target_miden_dir.display(),
+                config.rpc.endpoint
+            );
+            return Err(CliError::ConfigAlreadyExists(error_msg, global_flag));
         }
 
         // Create the miden directory if not existent

--- a/bin/miden-cli/src/errors.rs
+++ b/bin/miden-cli/src/errors.rs
@@ -49,9 +49,7 @@ pub enum CliError {
     #[diagnostic(
         code(cli::config_error),
         help(
-            "Check if the configuration file exists and is well-formed. If it does not exist, run `{} init` command to create it. \
-            If it already exists, run `{} clear-config` to remove it.",
-            client_binary_name().display(),
+            "Check if the configuration file exists and is well-formed. If it does not exist, run `{} init` command to create it.",
             client_binary_name().display()
         )
     )]
@@ -65,6 +63,16 @@ pub enum CliError {
         )
     )]
     ConfigNotFound(String),
+    #[error("configuration file already exists: {0}")]
+    #[diagnostic(
+        code(cli::config_already_exists),
+        help(
+            "Edit the configuration file, or remove it with `{} clear-config{1}` \
+            (this deletes the whole .miden directory, including the store and keystore).",
+            client_binary_name().display(),
+        )
+    )]
+    ConfigAlreadyExists(String, String),
     #[error("execute program error: {1}")]
     #[diagnostic(code(cli::execute_program_error))]
     Exec(#[source] SourceError, String),


### PR DESCRIPTION
**Motivation**

PR #2357 changed the output of the `miden-client init` command when a configuration file already exists.
However, that fix reused the generic `CliError::Config` error, which isn't the most appropriate variant and doesn't show a useful suggestion to the user, as pointed out in [this comment](https://github.com/0xMiden/rust-sdk/issues/2339#issuecomment-5205468349) from the corresponding issue. The help message also omitted the `--global` flag for the `clear-config` command.

**Changes**

This PR introduces the `CliError::ConfigAlreadyExists` error, with a more actionable message, and updates the `init` command to return it when a configuration file already exists.

Now the output looks like this

```
Error: cli::config_already_exists

  × configuration file already exists: "miden-client.toml" already exists in the global .miden directory (/Users/mateo/.miden), configured with the
  │ network "http://localhost:57291".
  help: Edit the configuration file, or remove it with `miden-client clear-config --global` (this deletes the whole .miden directory, including the
        store and keystore).
```
 