### PR TITLE
docs: fix test genesis license link

### DIFF
--- a/crates/testing/test-node-genesis/README.md
+++ b/crates/testing/test-node-genesis/README.md
@@ -48,4 +48,4 @@ consumes, so this crate stays decoupled from the node's internal crates.
 
 ## License
 
-This project is [MIT licensed](../../LICENSE).
+This project is [MIT licensed](../../../LICENSE).


### PR DESCRIPTION
Fixed the license link in the `test-node-genesis` README. From that crate directory, `../../LICENSE` points at `crates/LICENSE`, which does not exist; the repository license is one level higher.

No changelog entry; this is only a docs link fix.

Testing:
- checked the old relative path does not exist and the new one resolves to the root `LICENSE`
- `git diff --check -- crates/testing/test-node-genesis/README.md`