### PR TITLE
Run state sync note and transaction RPCs concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Enhancements
 
+* [rust] State sync now fetches note and transaction data concurrently after discovering the chain tip, reducing sync latency while keeping both requests pinned to the same block range ([#2361](https://github.com/0xMiden/rust-sdk/issues/2361)).
 * [FEATURE][rust] A client that only watches a public account now recovers notes the account consumed authenticated, even when it never tracked them by tag. During sync it reads the note references the node attaches to the account's transactions, fetches each note body by id, and surfaces it through `InputNoteReader`. Requires node `0.15.1` ([#2300](https://github.com/0xMiden/rust-sdk/pull/2300)).
 * [FEATURE][cli] Added a `--payback-note-type` option to `swap` so the payback note can be created as public or private (defaults to private). Public payback works without any off-band advice now that SWAP derives the payback recipient deterministically ([#2190](https://github.com/0xMiden/rust-sdk/pull/2190)).
 * [FEATURE][rust] `Client::get_consumable_notes(Some(account_id))` now screens only that account instead of screening every tracked account and discarding the rest, so its cost no longer grows with the number of tracked accounts. Added `NoteScreener::get_batch_consumability_for_account` to screen notes against a single account ([#2338](https://github.com/0xMiden/rust-sdk/pull/2338)).

--- a/crates/rust-client/src/sync/state_sync.rs
+++ b/crates/rust-client/src/sync/state_sync.rs
@@ -459,10 +459,9 @@ impl StateSync {
 
     /// Fetches the sync data from the node by calling the following endpoints:
     /// 1. `sync_chain_mmr` — discovers the chain tip, gets the MMR delta and chain tip header.
-    /// 2. `sync_notes` — loops until the full range to the chain tip is covered (handles paginated
-    ///    responses).
-    /// 3. `get_notes_by_id` — fetches full metadata for notes with attachments.
-    /// 4. `sync_transactions` — gets transaction data for the full range.
+    /// 2. Concurrently fetches the remaining data for the discovered range:
+    ///    - `sync_notes`, followed by `get_notes_by_id` for notes whose content is required.
+    ///    - `sync_transactions` for tracked accounts.
     ///
     /// Returns `None` when the client is already at the chain tip (no progress).
     async fn fetch_sync_data(
@@ -493,22 +492,40 @@ impl StateSync {
             "Syncing state.",
         );
 
-        // Step 2: sync notes and fetch full note bodies for public notes (and attachment content
-        // for private notes that carry attachments), paginating with the same chain tip so MMR
-        // paths are opened at a consistent forest. With no tracked tags there's nothing the node
-        // could match, so skip the RPC entirely.
-        let note_blocks = if note_tags.is_empty() {
-            Vec::new()
-        } else {
-            self.rpc_api
-                .sync_notes_with_content(
-                    current_block_num + 1,
-                    chain_tip,
-                    note_tags.as_ref(),
-                    NoteContentFetch::PublicDetailsAndAttachments,
-                )
-                .await?
+        // Step 2: fetch notes and transactions concurrently. Both requests use the chain tip
+        // discovered above so their responses cover the same snapshot range.
+        let note_sync = async {
+            // Fetch full note bodies for public notes (and attachment content for private notes
+            // that carry attachments), paginating with the same chain tip so MMR paths are opened
+            // at a consistent forest. With no tracked tags there's nothing the node could match,
+            // so skip the RPC entirely.
+            if note_tags.is_empty() {
+                Ok(Vec::new())
+            } else {
+                self.rpc_api
+                    .sync_notes_with_content(
+                        current_block_num + 1,
+                        chain_tip,
+                        note_tags.as_ref(),
+                        NoteContentFetch::PublicDetailsAndAttachments,
+                    )
+                    .await
+            }
         };
+
+        let transaction_sync = async {
+            // With no tracked accounts there's nothing the node could match, so skip the RPC
+            // entirely.
+            if account_ids.is_empty() {
+                Ok(Vec::new())
+            } else {
+                self.rpc_api
+                    .sync_transactions(current_block_num + 1, chain_tip, account_ids.to_vec())
+                    .await
+            }
+        };
+
+        let (note_blocks, transaction_records) = futures::try_join!(note_sync, transaction_sync)?;
 
         // Validate every returned note block falls in (current_block_num, chain_tip].
         Self::validate_note_blocks_range(&note_blocks, current_block_num, chain_tip)?;
@@ -519,16 +536,6 @@ impl StateSync {
             notes = note_count,
             "Fetched note sync data.",
         );
-
-        // Step 3: sync transactions for tracked accounts over the full range. With no tracked
-        // accounts there's nothing the node could match, so skip the RPC entirely.
-        let transaction_records = if account_ids.is_empty() {
-            Vec::new()
-        } else {
-            self.rpc_api
-                .sync_transactions(current_block_num + 1, chain_tip, account_ids.to_vec())
-                .await?
-        };
 
         Self::validate_transaction_records_range(
             &transaction_records,
@@ -2173,6 +2180,41 @@ mod tests {
 
         assert_eq!(update.block_num(), chain_tip_2);
         assert_eq!(partial_mmr.forest(), forest_2);
+    }
+
+    /// Verifies that the independent note and transaction RPCs are started concurrently and are
+    /// pinned to the chain tip discovered by `sync_chain_mmr`.
+    #[tokio::test]
+    async fn fetch_sync_data_fetches_notes_and_transactions_concurrently() {
+        let mut builder = MockChainBuilder::new();
+        let account = builder.add_existing_mock_account(miden_testing::Auth::IncrNonce).unwrap();
+        let rpc_api = MockRpcApi::new(builder.build().unwrap());
+        rpc_api.advance_blocks(1);
+
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        let rpc_api = rpc_api.with_concurrent_sync_barrier(barrier);
+        let chain_tip = rpc_api.get_chain_tip_block_num();
+        let state_sync = StateSync::new(Arc::new(rpc_api.clone()), Arc::new(MockScreener), None);
+        let note_tags = Arc::new(BTreeSet::from([NoteTag::default()]));
+
+        let sync_result = tokio::time::timeout(
+            core::time::Duration::from_secs(1),
+            state_sync.fetch_sync_data(BlockNumber::GENESIS, &[account.id()], &note_tags),
+        )
+        .await
+        .expect("note and transaction RPCs should reach the concurrency barrier")
+        .unwrap()
+        .expect("the mock chain should have advanced past genesis");
+
+        assert_eq!(sync_result.chain_tip_header.block_num(), chain_tip);
+        assert_eq!(
+            rpc_api.concurrent_sync_ranges(),
+            BTreeMap::from([
+                ("notes", (BlockNumber::from(1u32), chain_tip)),
+                ("transactions", (BlockNumber::from(1u32), chain_tip)),
+            ]),
+            "both RPCs must be pinned to the MMR-discovered chain tip",
+        );
     }
 
     /// Builds a mock chain with a faucet that mints `num_blocks` notes, one per block.

--- a/crates/rust-client/src/test_utils/mock.rs
+++ b/crates/rust-client/src/test_utils/mock.rs
@@ -73,6 +73,12 @@ pub struct MockRpcApi {
     private_note_attachments: Arc<RwLock<BTreeMap<NoteId, NoteAttachments>>>,
     /// Test overrides for the MMR paths returned by `sync_notes`, keyed by block number.
     sync_notes_mmr_path_overrides: Arc<RwLock<BTreeMap<BlockNumber, MerklePath>>>,
+    /// Synchronizes note and transaction sync calls in state-sync concurrency tests.
+    #[cfg(test)]
+    concurrent_sync_barrier: Option<Arc<tokio::sync::Barrier>>,
+    /// Records the ranges used by note and transaction sync calls in concurrency tests.
+    #[cfg(test)]
+    concurrent_sync_ranges: Arc<RwLock<BTreeMap<&'static str, (BlockNumber, BlockNumber)>>>,
 }
 
 impl Default for MockRpcApi {
@@ -95,6 +101,42 @@ impl MockRpcApi {
             erased_notes: Arc::new(RwLock::new(Vec::new())),
             private_note_attachments: Arc::new(RwLock::new(BTreeMap::new())),
             sync_notes_mmr_path_overrides: Arc::new(RwLock::new(BTreeMap::new())),
+            #[cfg(test)]
+            concurrent_sync_barrier: None,
+            #[cfg(test)]
+            concurrent_sync_ranges: Arc::new(RwLock::new(BTreeMap::new())),
+        }
+    }
+
+    /// Configures a barrier that both note and transaction sync calls must reach.
+    #[cfg(test)]
+    pub(crate) fn with_concurrent_sync_barrier(
+        mut self,
+        barrier: Arc<tokio::sync::Barrier>,
+    ) -> Self {
+        self.concurrent_sync_barrier = Some(barrier);
+        self
+    }
+
+    /// Returns the ranges observed by note and transaction sync calls.
+    #[cfg(test)]
+    pub(crate) fn concurrent_sync_ranges(
+        &self,
+    ) -> BTreeMap<&'static str, (BlockNumber, BlockNumber)> {
+        self.concurrent_sync_ranges.read().clone()
+    }
+
+    /// Records a state-sync request and waits until its independent peer has started.
+    #[cfg(test)]
+    async fn wait_for_concurrent_sync_peer(
+        &self,
+        endpoint: &'static str,
+        block_from: BlockNumber,
+        block_to: BlockNumber,
+    ) {
+        self.concurrent_sync_ranges.write().insert(endpoint, (block_from, block_to));
+        if let Some(barrier) = &self.concurrent_sync_barrier {
+            barrier.wait().await;
         }
     }
 
@@ -341,6 +383,9 @@ impl NodeRpcClient for MockRpcApi {
         block_to: BlockNumber,
         note_tags: &BTreeSet<NoteTag>,
     ) -> Result<Vec<SyncNotesBlock>, RpcError> {
+        #[cfg(test)]
+        self.wait_for_concurrent_sync_peer("notes", block_from, block_to).await;
+
         let mut blocks_with_notes: BTreeMap<BlockNumber, BTreeMap<NoteId, CommittedNote>> =
             BTreeMap::new();
         for note in self.mock_chain.read().committed_notes().values() {
@@ -742,6 +787,9 @@ impl NodeRpcClient for MockRpcApi {
         block_to: BlockNumber,
         account_ids: Vec<AccountId>,
     ) -> Result<Vec<TransactionRecord>, RpcError> {
+        #[cfg(test)]
+        self.wait_for_concurrent_sync_peer("transactions", block_from, block_to).await;
+
         Ok(self.get_sync_transactions_request(block_from, block_to, &account_ids))
     }
 


### PR DESCRIPTION
## Summary

- keep `sync_chain_mmr` as the first request so it defines the sync range
- fetch note data and transaction records concurrently once the chain tip is known
- keep both requests pinned to the same MMR-discovered block range
- preserve the existing fast paths when no note tags or account IDs are tracked
- add a deterministic barrier-based regression test that proves both RPCs start concurrently

## Motivation

State sync currently waits for note synchronization, including note-content resolution, before it
starts fetching transaction records. These reads are independent after `sync_chain_mmr` determines
the target block, so running them concurrently removes an unnecessary sequence of network
round-trips without changing the snapshot semantics.

`sync_nullifiers` remains after note processing because its request depends on the notes discovered
during the sync. Account reconciliation also remains after transaction synchronization because the
transaction records determine which account commitments need to be checked.

## Testing

- added `fetch_sync_data_fetches_notes_and_transactions_concurrently`, which uses a two-party
  barrier and would time out with the previous sequential implementation
- verified that both requests use the same inclusive range ending at the discovered chain tip
- `cargo +nightly fmt` passes for the changed Rust files
- `git diff --check` and Cargo workspace metadata validation pass

The targeted test could not reach `miden-client` locally because upstream Miden dependency build
scripts fail while resolving MASM/protobuf paths on Windows. The draft PR CI will provide Linux
validation.

Addresses the state-sync portion of #2361.
