### PR TITLE
fix(cli): reject invalid remote prover endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
 * Improved the output of the `miden-client init` command when a configuration already exists ([#](https://github.com/0xMiden/rust-sdk/pull/2357)).
 * [FEATURE][cli] Added DAP-based transaction debugging with offline record/replay. `miden-client exec` and `consume-notes` accept `--start-debug-adapter <ADDR>` to run a transaction — script, kernel, note scripts, and account code — under a DAP client (e.g. the `miden-debug` TUI) instead of proving and submitting it (`consume-notes` is backed by a new `Client::execute_transaction_with_dap`). During the session the advice mutations produced by the transaction host's event handlers are recorded — readable via the handle from `DapConfig::record_event_mutations()`, and reported by the CLI — and `--record <FILE>` writes a self-contained replay snapshot (program, inputs, resolved code, and event log) that can be replayed offline with `miden-debug --replay <FILE>`, with no node, client, or account state. This uses the `miden-debug` 0.9.2 release ([#2306](https://github.com/0xMiden/rust-sdk/pull/2306)).
 
+### Fixes
+
+* [FIX][cli] `miden-client init` now reports invalid remote prover endpoints instead of silently writing a local-prover config ([#2376](https://github.com/0xMiden/rust-sdk/pull/2376)).
+
 ## 0.16.0-alpha.1 (2026-07-17)
 
 ### Breaking Changes

--- a/bin/miden-cli/src/commands/init.rs
+++ b/bin/miden-cli/src/commands/init.rs
@@ -178,7 +178,9 @@ impl InitCmd {
         }
 
         cli_config.remote_prover_endpoint = match &self.remote_prover_endpoint {
-            Some(rpc) => CliEndpoint::try_from(rpc.as_str()).ok(),
+            Some(rpc) => Some(CliEndpoint::try_from(rpc.as_str()).map_err(|err| {
+                CliError::Parse(err.into(), "Failed to parse remote prover endpoint".to_string())
+            })?),
             None => None,
         };
 

--- a/bin/miden-cli/tests/cli.rs
+++ b/bin/miden-cli/tests/cli.rs
@@ -92,6 +92,22 @@ fn init_with_params() {
 }
 
 #[test]
+fn init_rejects_invalid_remote_prover_endpoint() {
+    let temp_dir = temp_dir().join(format!("cli-test-{}", rand::rng().random::<u64>()));
+    std::fs::create_dir_all(&temp_dir).unwrap();
+
+    let mut init_cmd = cargo_bin_cmd!("miden-client");
+    init_cmd.args(["init", "--local", "--remote-prover-endpoint", "localhost:not-a-port"]);
+    init_cmd.current_dir(&temp_dir).assert().failure();
+
+    let config_path = temp_dir.join(MIDEN_DIR).join("miden-client.toml");
+    assert!(
+        !config_path.exists(),
+        "init should not write a config when the remote prover endpoint is invalid"
+    );
+}
+
+#[test]
 #[serial_test::file_serial]
 fn silent_initialization_uses_default_values() {
     let miden_home = set_isolated_miden_home();


### PR DESCRIPTION
## Summary

`miden-client init` was silently dropping invalid `--remote-prover-endpoint` values because the parse result was converted with `.ok()`. That could write a config without a remote prover even though the user explicitly passed one.

This returns the parse error instead, and adds a regression test for an invalid endpoint port.

## Testing

- `cargo test -p miden-client-cli --test integration init_rejects_invalid_remote_prover_endpoint -- --nocapture`
- `cargo +nightly-2026-04-30 fmt -p miden-client-cli --check`
- `cargo clippy -p miden-client-cli --test integration -- -D warnings`
- `git diff --check`