### PR TITLE
fix(rpc): validate account IDs in VerifyingRpcClient::sync_transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 ### Fixes
 
 * [FIX][cli] `miden-client init` now reports invalid remote prover endpoints instead of silently writing a local-prover config ([#2376](https://github.com/0xMiden/rust-sdk/pull/2376)).
+* [FIX][rust] `VerifyingRpcClient::sync_transactions` now validates that every returned transaction record's account ID was actually requested, rejecting mismatches with `RpcError::InvalidResponse` ([#2372](https://github.com/0xMiden/rust-sdk/issues/2372)).
 
 ## 0.16.0-alpha.1 (2026-07-17)
 

--- a/crates/rust-client/src/rpc/verifying_client/mod.rs
+++ b/crates/rust-client/src/rpc/verifying_client/mod.rs
@@ -98,6 +98,25 @@ fn verify_nullifier_prefixes(
     Ok(())
 }
 
+
+/// Returns [`RpcError::InvalidResponse`] if any returned transaction record carries an account ID
+/// that was not in `requested`.
+fn verify_account_ids(
+    requested: &BTreeSet<AccountId>,
+    records: &[TransactionRecord],
+) -> Result<(), RpcError> {
+    for record in records {
+        let id = record.transaction_header.account_id();
+        if !requested.contains(&id) {
+            let list = requested.iter().map(ToString::to_string).collect::<Vec<_>>().join(", ");
+            return Err(RpcError::InvalidResponse(format!(
+                "node returned transaction for account {id} but [{list}] were requested"
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Returns [`RpcError::InvalidResponse`] if `script`'s root does not equal the `requested` root.
 fn verify_note_script_root(requested: Word, script: &NoteScript) -> Result<(), RpcError> {
     let fetched_root = script.root();
@@ -127,6 +146,8 @@ fn verify_note_script_root(requested: Word, script: &NoteScript) -> Result<(), R
 ///   the response must be for that block.
 /// - [`get_note_script_by_root`](NodeRpcClient::get_note_script_by_root): a returned script's root
 ///   must match the requested one.
+/// - [`sync_transactions`](NodeRpcClient::sync_transactions): every returned transaction record's
+///   account ID must have been requested.
 ///
 /// All other methods delegate to the wrapped client unchanged.
 pub struct VerifyingRpcClient<T>(T);
@@ -287,7 +308,10 @@ impl<T: NodeRpcClient> NodeRpcClient for VerifyingRpcClient<T> {
         block_to: BlockNumber,
         account_ids: Vec<AccountId>,
     ) -> Result<Vec<TransactionRecord>, RpcError> {
-        self.0.sync_transactions(block_from, block_to, account_ids).await
+        let requested: BTreeSet<AccountId> = account_ids.iter().copied().collect();
+        let records = self.0.sync_transactions(block_from, block_to, account_ids).await?;
+        verify_account_ids(&requested, &records)?;
+        Ok(records)
     }
 
     async fn get_network_id(&self) -> Result<NetworkId, RpcError> {

--- a/crates/rust-client/src/rpc/verifying_client/mod.rs
+++ b/crates/rust-client/src/rpc/verifying_client/mod.rs
@@ -98,7 +98,6 @@ fn verify_nullifier_prefixes(
     Ok(())
 }
 
-
 /// Returns [`RpcError::InvalidResponse`] if any returned transaction record carries an account ID
 /// that was not in `requested`.
 fn verify_account_ids(

--- a/crates/rust-client/src/rpc/verifying_client/tests.rs
+++ b/crates/rust-client/src/rpc/verifying_client/tests.rs
@@ -28,10 +28,14 @@ use miden_protocol::note::{
     Nullifier,
     PartialNoteMetadata,
 };
-use miden_protocol::testing::account_id::ACCOUNT_ID_SENDER;
+use miden_protocol::testing::account_id::{
+    ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE, ACCOUNT_ID_SENDER,
+};
 use miden_protocol::transaction::{
+    InputNotes,
     OrderedTransactionHeaders,
     ProvenTransaction,
+    TransactionHeader,
     TransactionKernel,
 };
 use miden_protocol::{Felt, Word};
@@ -141,6 +145,22 @@ fn sync_notes_block(block_num: u32, tags: &[NoteTag]) -> SyncNotesBlock {
     }
 }
 
+fn transaction_record(account_id: AccountId) -> TransactionRecord {
+    TransactionRecord {
+        block_num: BlockNumber::GENESIS,
+        transaction_header: TransactionHeader::new(
+            account_id,
+            Word::default(),
+            Word::default(),
+            InputNotes::new_unchecked(vec![]),
+            vec![],
+        ),
+        output_notes: vec![],
+        erased_output_notes: vec![],
+        consumed_note_refs: vec![],
+    }
+}
+
 fn account_proof() -> AccountProof {
     let path = SparseMerklePath::from_parts(u64::MAX, Vec::new())
         .expect("an all-empty path spans the full account tree depth");
@@ -180,6 +200,7 @@ struct CannedTransport {
     nullifiers: Option<Vec<NullifierUpdate>>,
     account: Option<(BlockNumber, AccountProof)>,
     note_script: CannedScript,
+    transactions: Option<Vec<TransactionRecord>>,
     /// When set, every canned method fails instead of answering.
     fail_with: Option<String>,
 }
@@ -330,7 +351,10 @@ impl NodeRpcClient for CannedTransport {
         _block_to: BlockNumber,
         _account_ids: Vec<AccountId>,
     ) -> Result<Vec<TransactionRecord>, RpcError> {
-        unimplemented!("not used in these tests")
+        self.canned(
+            self.transactions.as_ref(),
+            "test must set a canned sync_transactions response",
+        )
     }
 
     async fn get_network_id(&self) -> Result<NetworkId, RpcError> {
@@ -585,6 +609,58 @@ async fn get_note_script_by_root_verifies_script_root() {
         .await
         .expect_err("a script with another root must be rejected");
     assert!(matches!(err, RpcError::InvalidResponse(_)));
+}
+
+#[tokio::test]
+async fn sync_transactions_verifies_account_ids() {
+    let requested = test_account_id();
+    let other = AccountId::try_from(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE)
+        .expect("test public account ID is well formed");
+
+    let client = VerifyingRpcClient::new(CannedTransport {
+        transactions: Some(vec![transaction_record(requested)]),
+        ..Default::default()
+    });
+    let records = client
+        .sync_transactions(BlockNumber::GENESIS, BlockNumber::from(1u32), vec![requested])
+        .await
+        .expect("the requested account must be accepted");
+    assert_eq!(records.len(), 1);
+
+    // A superset request that includes the returned account is fine.
+    client
+        .sync_transactions(BlockNumber::GENESIS, BlockNumber::from(1u32), vec![requested, other])
+        .await
+        .expect("a superset of accounts must be accepted");
+
+    let err = client
+        .sync_transactions(BlockNumber::GENESIS, BlockNumber::from(1u32), vec![other])
+        .await
+        .expect_err("a transaction for an unrequested account must be rejected");
+    assert!(matches!(err, RpcError::InvalidResponse(_)));
+
+    let err = client
+        .sync_transactions(BlockNumber::GENESIS, BlockNumber::from(1u32), vec![])
+        .await
+        .expect_err("no transaction may come back when no account was requested");
+    assert!(matches!(err, RpcError::InvalidResponse(_)));
+}
+
+#[tokio::test]
+async fn sync_transactions_accepts_empty_response() {
+    let client = VerifyingRpcClient::new(CannedTransport {
+        transactions: Some(Vec::new()),
+        ..Default::default()
+    });
+    let records = client
+        .sync_transactions(
+            BlockNumber::GENESIS,
+            BlockNumber::from(1u32),
+            vec![test_account_id()],
+        )
+        .await
+        .expect("an empty response must be accepted");
+    assert!(records.is_empty());
 }
 
 #[tokio::test]

--- a/crates/rust-client/src/rpc/verifying_client/tests.rs
+++ b/crates/rust-client/src/rpc/verifying_client/tests.rs
@@ -29,7 +29,8 @@ use miden_protocol::note::{
     PartialNoteMetadata,
 };
 use miden_protocol::testing::account_id::{
-    ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE, ACCOUNT_ID_SENDER,
+    ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE,
+    ACCOUNT_ID_SENDER,
 };
 use miden_protocol::transaction::{
     InputNotes,
@@ -351,10 +352,7 @@ impl NodeRpcClient for CannedTransport {
         _block_to: BlockNumber,
         _account_ids: Vec<AccountId>,
     ) -> Result<Vec<TransactionRecord>, RpcError> {
-        self.canned(
-            self.transactions.as_ref(),
-            "test must set a canned sync_transactions response",
-        )
+        self.canned(self.transactions.as_ref(), "test must set a canned sync_transactions response")
     }
 
     async fn get_network_id(&self) -> Result<NetworkId, RpcError> {
@@ -653,11 +651,7 @@ async fn sync_transactions_accepts_empty_response() {
         ..Default::default()
     });
     let records = client
-        .sync_transactions(
-            BlockNumber::GENESIS,
-            BlockNumber::from(1u32),
-            vec![test_account_id()],
-        )
+        .sync_transactions(BlockNumber::GENESIS, BlockNumber::from(1u32), vec![test_account_id()])
         .await
         .expect("an empty response must be accepted");
     assert!(records.is_empty());


### PR DESCRIPTION
## Summary

- Add `verify_account_ids` helper that rejects transaction records whose account ID was not in the request, matching the existing `verify_note_ids` / `verify_nullifier_prefixes` pattern.
- Wire the check into `VerifyingRpcClient::sync_transactions` so a misbehaving node cannot slip in unrequested transaction data.
- Update the struct-level doc comment to document the new invariant.
- Add CHANGELOG entry under Fixes.

## Test plan

- `sync_transactions_verifies_account_ids`: exact match accepted, superset accepted, unrequested account rejected, empty request with non-empty response rejected.
- `sync_transactions_accepts_empty_response`: empty response always passes.
- All existing `verifying_client` tests still pass (11/11).

Closes #2372