### PR TITLE
fix(sqlite-store): handle StorageValuePatch::Remove without zero-word fallback

### DIFF
--- a/crates/sqlite-store/src/account/storage.rs
+++ b/crates/sqlite-store/src/account/storage.rs
@@ -14,6 +14,7 @@ use miden_client::account::{
     StorageSlotContent,
     StorageSlotName,
     StorageSlotType,
+    StorageValuePatch,
 };
 use miden_client::store::{AccountSmtForest, StoreError};
 use miden_client::{Deserializable, EMPTY_WORD, Serializable, Word};
@@ -178,6 +179,18 @@ impl SqliteStore {
         let patch_maps: BTreeMap<&StorageSlotName, &StorageMapPatch> =
             storage_patch.maps().collect();
 
+        for (slot_name, value_patch) in storage_patch.values() {
+            if matches!(value_patch, StorageValuePatch::Remove) {
+                Self::write_value_slot_remove(
+                    tx,
+                    &mut hist_slot_stmt,
+                    &account_id_bytes,
+                    &nonce_val,
+                    slot_name,
+                )?;
+            }
+        }
+
         for (slot_name, (value, slot_type)) in updated_slots {
             let slot_name_str = slot_name.to_string();
             let slot_value_bytes = value.to_bytes();
@@ -340,6 +353,49 @@ impl SqliteStore {
         Ok(())
     }
 
+    /// Archives and deletes a value slot removed by [`StorageValuePatch::Remove`].
+    fn write_value_slot_remove(
+        tx: &Transaction<'_>,
+        hist_slot_stmt: &mut rusqlite::CachedStatement<'_>,
+        account_id_bytes: &[u8],
+        nonce_val: &rusqlite::types::Value,
+        slot_name: &StorageSlotName,
+    ) -> Result<(), StoreError> {
+        const READ_OLD_SLOT: &str =
+            "SELECT slot_value, slot_type FROM latest_account_storage WHERE account_id = ? AND slot_name = ?";
+        const DELETE_LATEST_SLOT: &str =
+            "DELETE FROM latest_account_storage WHERE account_id = ? AND slot_name = ?";
+
+        let slot_name_str = slot_name.to_string();
+
+        let (old_slot_value, slot_type_val): (Option<Vec<u8>>, u8) = tx
+            .query_row(READ_OLD_SLOT, params![account_id_bytes, &slot_name_str], |row| {
+                Ok((row.get(0)?, row.get(1)?))
+            })
+            .optional()
+            .into_store_error()?
+            .ok_or_else(|| {
+                StoreError::ParsingError(format!(
+                    "cannot remove storage value slot '{slot_name_str}': slot not found"
+                ))
+            })?;
+
+        hist_slot_stmt
+            .execute(params![
+                account_id_bytes,
+                nonce_val,
+                &slot_name_str,
+                old_slot_value,
+                slot_type_val,
+            ])
+            .into_store_error()?;
+
+        tx.execute(DELETE_LATEST_SLOT, params![account_id_bytes, &slot_name_str])
+            .into_store_error()?;
+
+        Ok(())
+    }
+
     /// Archives old map entry values to historical and updates latest for each changed entry.
     fn write_map_entry_delta(
         tx: &Transaction<'_>,
@@ -408,20 +464,15 @@ impl SqliteStore {
         old_map_roots: &BTreeMap<StorageSlotName, Word>,
         storage_patch: &AccountStoragePatch,
     ) -> Result<BTreeMap<StorageSlotName, (Word, StorageSlotType)>, StoreError> {
-        let mut updated_slots: BTreeMap<StorageSlotName, (Word, StorageSlotType)> = storage_patch
-            .values()
-            .map(|(slot_name, value_patch)| {
-                (
-                    slot_name.clone(),
-                    (
-                        value_patch
-                            .value()
-                            .expect("the protocol does not generate Remove value patches"),
-                        StorageSlotType::Value,
-                    ),
-                )
-            })
-            .collect();
+        let mut updated_slots: BTreeMap<StorageSlotName, (Word, StorageSlotType)> = BTreeMap::new();
+        for (slot_name, value_patch) in storage_patch.values() {
+            match value_patch {
+                StorageValuePatch::Create { value } | StorageValuePatch::Update { value } => {
+                    updated_slots.insert(slot_name.clone(), (*value, StorageSlotType::Value));
+                },
+                StorageValuePatch::Remove => {},
+            }
+        }
 
         let default_map_root = StorageMap::default().root();
 

--- a/crates/sqlite-store/src/account/tests.rs
+++ b/crates/sqlite-store/src/account/tests.rs
@@ -2498,3 +2498,70 @@ async fn remove_map_patch_clears_slot() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// A `Remove` patch deletes the value slot from latest storage and archives its prior value.
+#[tokio::test]
+async fn remove_value_patch_clears_slot() -> anyhow::Result<()> {
+    let store = create_test_store().await;
+    let value_slot_name = StorageSlotName::new("test::remove::value").expect("valid slot name");
+    let test_value = [Felt::from(42u32), ZERO, ZERO, ZERO].into();
+
+    let dummy_component = AccountComponent::new(
+        BasicWallet::code().as_library().clone(),
+        vec![StorageSlot::with_value(value_slot_name.clone(), test_value)],
+        AccountComponentMetadata::new("miden::testing::dummy_component"),
+    )?;
+
+    let account = AccountBuilder::new([0; 32])
+        .account_type(AccountType::Private)
+        .with_auth_component(AuthSingleSig::new(Approver::new(
+            PublicKeyCommitment::from(EMPTY_WORD),
+            AuthSchemeId::Falcon512Poseidon2,
+        )))
+        .with_component(dummy_component)
+        .build_existing()?;
+
+    let default_address = Address::new(account.id());
+    store
+        .insert_account(&account, default_address, ClientAccountType::Native)
+        .await?;
+
+    let account_id = account.id();
+    let m_before = get_storage_metrics(&store).await;
+    read_slot_value(&store, account_id, &value_slot_name).await?;
+
+    let storage_patch = AccountStoragePatch::from_entries([(
+        value_slot_name.clone(),
+        StorageSlotPatch::Value(StorageValuePatch::Remove),
+    )])?;
+
+    apply_storage_patch_directly(&store, account_id, 2, storage_patch).await?;
+
+    let slot_name = value_slot_name.to_string();
+    let account_id_bytes = account_id.to_bytes();
+    let latest_rows = store
+        .interact_with_connection(move |conn| {
+            conn.query_row(
+                "SELECT COUNT(*) FROM latest_account_storage WHERE account_id = ? AND slot_name = ?",
+                params![account_id_bytes, slot_name],
+                |row| row.get::<_, i64>(0),
+            )
+            .into_store_error()
+        })
+        .await?;
+    assert_eq!(latest_rows, 0, "removed value slot must have no latest row");
+
+    let m_after = get_storage_metrics(&store).await;
+    assert_eq!(
+        m_after.latest_account_storage,
+        m_before.latest_account_storage - 1,
+        "remove must drop exactly one latest storage row"
+    );
+    assert_eq!(
+        m_after.historical_account_storage,
+        m_before.historical_account_storage + 1,
+        "remove must archive exactly one prior value"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Handle `StorageValuePatch::Remove` by archiving the prior value and deleting the slot from `latest_account_storage`
- Stop treating removals as `Word::empty()` via `value().unwrap_or_default()` / `expect()`
- Add regression test `remove_value_patch_clears_slot`

Closes #2327

## Test plan
- [x] `cargo test -p miden-client-sqlite-store remove_value_patch_clears_slot`